### PR TITLE
Make javax.annotation-api dependency optional

### DIFF
--- a/inject/pom.xml
+++ b/inject/pom.xml
@@ -30,12 +30,6 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.3.2</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.25</version>


### PR DESCRIPTION
Use reflection to find javax.annotation.Priority, thus making the javax.annotation-api dependency optional.