### PR TITLE
Add support for method based injection.

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -125,7 +125,7 @@ class MethodReader {
       if (i > 0) {
         sb.append(",");
       }
-      sb.append(params.get(i).builderGetDependency());
+      sb.append(params.get(i).builderGetDependency("builder"));
     }
     sb.append(");");
     return sb.toString();
@@ -268,13 +268,13 @@ class MethodReader {
       this.genericType = GenericType.maybe(paramType);
     }
 
-    String builderGetDependency() {
+    String builderGetDependency(String builderName) {
       StringBuilder sb = new StringBuilder();
       if (genericType != null) {
         // passed as provider to build method
         sb.append("prov").append(providerIndex).append(".get(");
       } else {
-        sb.append("builder.").append(utilType.getMethod());
+        sb.append(builderName).append(".").append(utilType.getMethod());
       }
       if (genericType == null) {
         sb.append(Util.shortName(paramType)).append(".class");

--- a/inject-test/src/test/java/org/example/coffee/fruit/AppleService.java
+++ b/inject-test/src/test/java/org/example/coffee/fruit/AppleService.java
@@ -9,13 +9,16 @@ class AppleService {
   @Inject
   BananaService bananaService;
 
-  @Inject
   PeachService peachService;
+
+  @Inject
+  void setPeachService(PeachService peachService) {
+    this.peachService = peachService;
+  }
 
   String ban() {
     return bananaService.ban("hello");
   }
-
 
   void apple(String a, String b, String c) {
     System.out.println("apple> a: " + a + " b:" + b + " c:" + c);

--- a/inject-test/src/test/java/org/example/request/AController.java
+++ b/inject-test/src/test/java/org/example/request/AController.java
@@ -12,8 +12,13 @@ public class AController {
   @Inject
   AService service;
 
-  @Inject
   Context context;
+
+  @Inject
+  AController withContext(Context context) {
+    this.context = context;
+    return this;
+  }
 
   public String get() {
     return "hi " + context.toString() + service.hi();

--- a/inject-test/src/test/java/org/example/request/JexController.java
+++ b/inject-test/src/test/java/org/example/request/JexController.java
@@ -12,8 +12,13 @@ public class JexController {
   @Inject
   AService service;
 
-  @Inject
   Context context;
+
+  @Inject
+  JexController withContext(Context context) {
+    this.context = context;
+    return this;
+  }
 
   public String get() {
     return "hi " + context.toString() + service.hi();


### PR DESCRIPTION
This is a missing feature I stumbled across when attempting to convert a project from Guice, which supports `@Inject` on methods.
I tweaked a few classes in the inject-test module to use method injection instead of field injection and the unit tests all still passed.
I also examined the generated code and it seemed correct to me, so hopefully I didn't miss anything.