### PR TITLE
Add io.avaje.inject @PostConstruct/@PreDestroy annotations

### DIFF
--- a/inject-test/src/test/java/org/example/coffee/factory/Configuration.java
+++ b/inject-test/src/test/java/org/example/coffee/factory/Configuration.java
@@ -2,10 +2,10 @@ package org.example.coffee.factory;
 
 import io.avaje.inject.Bean;
 import io.avaje.inject.Factory;
+import io.avaje.inject.PostConstruct;
+import io.avaje.inject.PreDestroy;
 import org.example.coffee.CoffeeMaker;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
 /**
@@ -40,7 +40,6 @@ class Configuration {
   BFact buildB(AFact afact, CoffeeMaker maker) {
     return new BFact(afact, maker);
   }
-
 
   @PostConstruct
   void initFactory() {

--- a/inject/src/main/java/io/avaje/inject/PostConstruct.java
+++ b/inject/src/main/java/io/avaje/inject/PostConstruct.java
@@ -1,0 +1,32 @@
+package io.avaje.inject;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The <code>PostConstruct</code> annotation is used on a method that needs to be executed
+ * after dependency injection is done to perform any initialization.
+ * <p>
+ * Note that we can equally use any <code>PostConstruct</code> annotation - so we can use
+ * the one from <code>javax.annotation</code>, <code>jakarta.annotation</code> or this one.
+ * </p>
+ * <p>
+ * Only one method in a given class can be annotated with this annotation.
+ * <p>
+ * The method on which the <code>PostConstruct</code> annotation is applied must fulfill
+ * the following criteria:
+ * <ul>
+ * <li>The method must not have any parameters.</li>
+ * <li>The method may be public, protected or package private.</li>
+ * <li>The method must not be static.</li>
+ * </ul>
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface PostConstruct {
+}

--- a/inject/src/main/java/io/avaje/inject/PreDestroy.java
+++ b/inject/src/main/java/io/avaje/inject/PreDestroy.java
@@ -1,0 +1,32 @@
+package io.avaje.inject;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The <code>PreDestroy</code> annotation is used on a method as a callback notification
+ * to signal that the instance is in the process of being removed by the container.
+ * <p>
+ * Note that we can equally use any <code>PreDestroy</code> annotation - so we can use
+ * the one from <code>javax.annotation</code>, <code>jakarta.annotation</code> or this one.
+ * <p>
+ * The method annotated with <code>PreDestroy</code> is typically used to release resources
+ * that it has been holding.
+ * <p>
+ * The method on which the <code>PreDestroy</code> annotation is applied must fulfill the
+ * following criteria:
+ * <ul>
+ * <li>The method must not have any parameters.</li>
+ * <li>The method may be public, protected or package private.</li>
+ * <li>The method must not be static.</li>
+ * </ul>
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface PreDestroy {
+}


### PR DESCRIPTION
We can use any `@PostConstruct` or `@PreDestory` annotation.  Adding these as avaje inject annotations means that people don't need to depend on the JEE javax.annotation or jakarta.annotation for these annotations.

That is, we consider them important enough to have our own (and dependency on jakarta.annotation for these is not ideal). 