### PR TITLE
Tweaks for PostConstruct/PreDestory changes

### DIFF
--- a/inject-generator/pom.xml
+++ b/inject-generator/pom.xml
@@ -19,12 +19,6 @@
       <version>2.1-SNAPSHOT</version>
     </dependency>
 
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.3.2</version>
-    </dependency>
-
     <!-- test dependencies -->
     <dependency>
       <groupId>org.avaje.composite</groupId>

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -264,14 +264,12 @@ class BeanReader {
       }
     }
 
-    if (context.isPostConstructAvailable()) {
-      if (hasAnnotationWithName(element, "PostConstruct")) {
-        postConstructMethod = element;
-      }
+    if (hasAnnotationWithName(element, "PostConstruct")) {
+      postConstructMethod = element;
+    }
 
-      if (hasAnnotationWithName(element, "PreDestroy")) {
-        preDestroyMethod = element;
-      }
+    if (hasAnnotationWithName(element, "PreDestroy")) {
+      preDestroyMethod = element;
     }
   }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
@@ -5,7 +5,6 @@ class Constants {
   static final String KOTLIN_METADATA = "kotlin.Metadata";
   static final String GENERATED_9 = "javax.annotation.processing.Generated";
 
-  static final String POSTCONSTRUCT = "javax.annotation.PostConstruct";
   static final String PROVIDER = "javax.inject.Provider";
 
   static final String PATH = "io.avaje.http.api.Path";

--- a/inject-generator/src/main/java/io/avaje/inject/generator/IncludeAnnotations.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/IncludeAnnotations.java
@@ -5,7 +5,8 @@ import java.util.Set;
 
 class IncludeAnnotations {
 
-  private static final String[] EXCLUDED_PREFIX = {"javax.annotation.", "javax.inject.", "io.avaje.inject.", "lombok."};
+  private static final String[] EXCLUDED_PREFIX = {"javax.annotation.", "javax.inject.", "jakarta.annotation.", "jakarta.inject.", "io.avaje.inject.", "lombok."};
+  private static final String[] EXCLUDED_SUFFIX = {".PostConstruct", ".PreDestory"};
 
   /**
    * Annotations that we don't bother registering lists for.
@@ -23,6 +24,11 @@ class IncludeAnnotations {
   static boolean include(String annotationType) {
     for (String prefix : EXCLUDED_PREFIX) {
       if (annotationType.startsWith(prefix)) {
+        return false;
+      }
+    }
+    for (String suffix : EXCLUDED_SUFFIX) {
+      if (annotationType.endsWith(suffix)) {
         return false;
       }
     }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -60,10 +60,6 @@ class ProcessingContext {
     return null != elementUtils.getTypeElement(canonicalName);
   }
 
-  boolean isPostConstructAvailable() {
-    return isTypeAvailable(Constants.POSTCONSTRUCT);
-  }
-
   boolean isGeneratedAvailable() {
     return generatedAnnotation != null;
   }

--- a/inject-test/pom.xml
+++ b/inject-test/pom.xml
@@ -26,6 +26,12 @@
 
     <!-- test dependencies -->
     <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+    </dependency>
+
+    <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-api</artifactId>
       <version>0.1</version>


### PR DESCRIPTION
1. Allow PostConstruct/PreDestory annotations from other packages.
2. Remove javax.annotation-api dependency since it is no longer strictly required.