### PR TITLE
More annotation-api tweaks

### DIFF
--- a/inject/src/main/java/io/avaje/inject/spi/DBeanContext.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanContext.java
@@ -106,10 +106,6 @@ class DBeanContext implements BeanContext {
 
   @Override
   public <T> List<T> sortByPriority(List<T> list, final Class<? extends Annotation> priorityAnnotation) {
-    if (priorityAnnotation == null) {
-      // priority annotation not on the classpath
-      return list;
-    }
     boolean priorityUsed = false;
     List<SortBean<T>> tempList = new ArrayList<>(list.size());
     for (T bean : list) {

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanContext.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanContext.java
@@ -246,7 +246,7 @@ class DBeanContext implements BeanContext {
     int initPriority(Class<? extends Annotation> priorityAnnotation) {
       // Avoid adding hard dependency on javax.annotation-api by using reflection
       try {
-        Annotation ann = bean.getClass().getAnnotation(priorityAnnotation);
+        Annotation ann = bean.getClass().getDeclaredAnnotation(priorityAnnotation);
         if (ann != null) {
           int priority = (Integer) priorityAnnotation.getMethod("value").invoke(ann);
           priorityDefined = true;


### PR DESCRIPTION
1. Don't allow null priorityAnnotation since consumers now pass it in instead of allowing it to be reflectively discovered.
2. Only used directly declared instances of Priority annotations and not those of any superclasses.