### PR TITLE
Refactor rename BeanContext to BeanScope (to better align with ApplicationScope and RequestScope)

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
@@ -20,7 +20,7 @@ class Constants {
   static final String META_INF_FACTORY = "META-INF/services/io.avaje.inject.spi.BeanContextFactory";
 
   static final String REQUESTSCOPE = "io.avaje.inject.RequestScope";
-  static final String BEANCONTEXT = "io.avaje.inject.BeanContext";
+  static final String BEANCONTEXT = "io.avaje.inject.BeanScope";
   static final String CONTEXTMODULE = "io.avaje.inject.ContextModule";
 
   static final String GENERATED = "io.avaje.inject.spi.Generated";

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleFactoryWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleFactoryWriter.java
@@ -14,7 +14,7 @@ class SimpleFactoryWriter {
 
   private static final String CODE_COMMENT_FACTORY =
     "/**\n" +
-      " * Generated source - Creates the BeanContext for the %s module.\n" +
+      " * Generated source - Creates the BeanScope for the %s module.\n" +
       " * \n" +
       " * With JPMS Java module system this generated class should be explicitly\n" +
       " * registered in module-info via a <code>provides</code> clause like:\n" +
@@ -33,16 +33,12 @@ class SimpleFactoryWriter {
 
   private static final String CODE_COMMENT_CREATE_CONTEXT =
     "  /**\n" +
-      "   * Create and return the BeanContext.\n" +
+      "   * Create the beans.\n" +
       "   * <p>\n" +
       "   * Creates all the beans in order based on constuctor dependencies.\n" +
       "   * The beans are registered into the builder along with callbacks for\n" +
       "   * field injection, method injection and lifecycle support.\n" +
       "   * <p>\n" +
-      "   * Ultimately the builder returns the BeanContext containing the beans.\n" +
-      "   *\n" +
-      "   * @param parent The parent context for multi-module wiring\n" +
-      "   * @return The BeanContext containing the beans\n" +
       "   */";
 
   private final MetaDataOrdering ordering;

--- a/inject-test/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
+++ b/inject-test/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
@@ -10,12 +10,12 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BeanContextBuilderTest {
+public class BeanScopeBuilderTest {
 
   @Test
   public void noDepends() {
 
-    DBeanContextBuilder.FactoryOrder factoryOrder = new DBeanContextBuilder.FactoryOrder(Collections.emptySet(), true, true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(Collections.emptySet(), true, true);
     factoryOrder.add(bc("1", null, null));
     factoryOrder.add(bc("2", null, null));
     factoryOrder.add(bc("3", null, null));
@@ -27,7 +27,7 @@ public class BeanContextBuilderTest {
   @Test
   public void name_depends() {
 
-    DBeanContextBuilder.FactoryOrder factoryOrder = new DBeanContextBuilder.FactoryOrder(Collections.emptySet(), true, true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(Collections.emptySet(), true, true);
     factoryOrder.add(bc("two", null, "one"));
     factoryOrder.add(bc("one", null, null));
     factoryOrder.orderFactories();
@@ -38,7 +38,7 @@ public class BeanContextBuilderTest {
   @Test
   public void name_depends4() {
 
-    DBeanContextBuilder.FactoryOrder factoryOrder = new DBeanContextBuilder.FactoryOrder(Collections.emptySet(), true, true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(Collections.emptySet(), true, true);
     factoryOrder.add(bc("1", null, "3"));
     factoryOrder.add(bc("2", null, "4"));
     factoryOrder.add(bc("3", null, "4"));
@@ -52,7 +52,7 @@ public class BeanContextBuilderTest {
   @Test
   public void nameFeature_depends() {
 
-    DBeanContextBuilder.FactoryOrder factoryOrder = new DBeanContextBuilder.FactoryOrder(Collections.emptySet(), true, true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(Collections.emptySet(), true, true);
     factoryOrder.add(bc("1", "a", "3"));
     factoryOrder.add(bc("2", null, "4,a"));
     factoryOrder.add(bc("3", null, "4"));
@@ -66,7 +66,7 @@ public class BeanContextBuilderTest {
   @Test
   public void feature_depends() {
 
-    DBeanContextBuilder.FactoryOrder factoryOrder = new DBeanContextBuilder.FactoryOrder(Collections.emptySet(), true, true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(Collections.emptySet(), true, true);
     factoryOrder.add(bc("two", null, "myfeature"));
     factoryOrder.add(bc("one", "myfeature", null));
     factoryOrder.orderFactories();
@@ -77,7 +77,7 @@ public class BeanContextBuilderTest {
   @Test
   public void feature_depends2() {
 
-    DBeanContextBuilder.FactoryOrder factoryOrder = new DBeanContextBuilder.FactoryOrder(Collections.emptySet(), true, true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(Collections.emptySet(), true, true);
     factoryOrder.add(bc("two", null, "myfeature"));
     factoryOrder.add(bc("one", "myfeature", null));
     factoryOrder.add(bc("three", "myfeature", null));

--- a/inject-test/src/test/java/io/avaje/inject/spi/DContextEntryTest.java
+++ b/inject-test/src/test/java/io/avaje/inject/spi/DContextEntryTest.java
@@ -16,7 +16,7 @@ public class DContextEntryTest {
     entry.add(DContextEntryBean.of("N", null, BeanEntry.NORMAL));
     entry.add(DContextEntryBean.of("S", null, BeanEntry.SECONDARY));
 
-    assertEquals(entry.candidate(null).getBean(), "P");
+    assertEquals(entry.get(null), "P");
   }
 
   @Test
@@ -27,7 +27,7 @@ public class DContextEntryTest {
       entry.add(DContextEntryBean.of("N", null, BeanEntry.NORMAL));
       entry.add(DContextEntryBean.of("S", null, BeanEntry.PRIMARY));
 
-      entry.candidate(null);
+      entry.get(null);
     });
   }
 
@@ -38,7 +38,7 @@ public class DContextEntryTest {
     entry.add(DContextEntryBean.of("N", null, BeanEntry.NORMAL));
     entry.add(DContextEntryBean.of("S", null, BeanEntry.SECONDARY));
 
-    assertEquals(entry.candidate(null).getBean(), "N");
+    assertEquals(entry.get(null), "N");
   }
 
 
@@ -50,7 +50,7 @@ public class DContextEntryTest {
     entry.add(DContextEntryBean.of("S1", null, BeanEntry.SECONDARY));
     entry.add(DContextEntryBean.of("S2", null, BeanEntry.SECONDARY));
 
-    assertEquals(entry.candidate(null).getBean(), "N");
+    assertEquals(entry.get(null), "N");
   }
 
   @Test
@@ -60,7 +60,7 @@ public class DContextEntryTest {
       entry.add(DContextEntryBean.of("S1", null, BeanEntry.SECONDARY));
       entry.add(DContextEntryBean.of("S2", null, BeanEntry.SECONDARY));
 
-      entry.candidate(null);
+      entry.get(null);
     });
   }
 
@@ -72,7 +72,7 @@ public class DContextEntryTest {
     entry.add(DContextEntryBean.of("S1", "a", BeanEntry.SECONDARY));
     entry.add(DContextEntryBean.of("S2", "b", BeanEntry.SECONDARY));
 
-    assertEquals(entry.candidate("b").getBean(), "S2");
+    assertEquals(entry.get("b"), "S2");
   }
 
   @Test
@@ -82,7 +82,7 @@ public class DContextEntryTest {
     entry.add(DContextEntryBean.of("S1", null, BeanEntry.SECONDARY));
     entry.add(DContextEntryBean.of("S2", "b", BeanEntry.SECONDARY));
 
-    assertEquals(entry.candidate("b").getBean(), "S2");
+    assertEquals(entry.get("b"), "S2");
   }
 
   @Test
@@ -92,6 +92,6 @@ public class DContextEntryTest {
     entry.add(DContextEntryBean.of("S1", null, BeanEntry.PRIMARY));
     entry.add(DContextEntryBean.of("S2", "b", BeanEntry.SECONDARY));
 
-    assertEquals(entry.candidate("b").getBean(), "S2");
+    assertEquals(entry.get("b"), "S2");
   }
 }

--- a/inject-test/src/test/java/org/example/coffee/BeanScopeBuilderAddTest.java
+++ b/inject-test/src/test/java/org/example/coffee/BeanScopeBuilderAddTest.java
@@ -1,6 +1,6 @@
 package org.example.coffee;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -8,14 +8,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 
-public class BeanContextBuilderAddTest {
+public class BeanScopeBuilderAddTest {
 
   @Test
   public void withModules_exludingThisOne() {
     assertThrows(IllegalStateException.class, () -> {
       TDPump testDoublePump = new TDPump();
 
-      try (BeanContext context = BeanContext.newBuilder()
+      try (BeanScope context = BeanScope.newBuilder()
         .withBeans(testDoublePump)
         // our module is "org.example.coffee"
         // so this effectively includes no modules
@@ -35,7 +35,7 @@ public class BeanContextBuilderAddTest {
 
     TDPump testDoublePump = new TDPump();
 
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withBeans(testDoublePump)
       .withModules("org.example")
       .build()) {
@@ -53,7 +53,7 @@ public class BeanContextBuilderAddTest {
 
     TDPump testDoublePump = new TDPump();
 
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withBeans(testDoublePump)
       .build()) {
 
@@ -70,7 +70,7 @@ public class BeanContextBuilderAddTest {
 
     Pump mock = Mockito.mock(Pump.class);
 
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withBean(Pump.class, mock)
       .build()) {
 

--- a/inject-test/src/test/java/org/example/coffee/BeanScope_Builder_mockitoSpyTest.java
+++ b/inject-test/src/test/java/org/example/coffee/BeanScope_Builder_mockitoSpyTest.java
@@ -1,6 +1,6 @@
 package org.example.coffee;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.example.coffee.factory.SomeImpl;
 import org.example.coffee.factory.SomeImplBean;
 import org.example.coffee.factory.Unused;
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-public class BeanContext_Builder_mockitoSpyTest {
+public class BeanScope_Builder_mockitoSpyTest {
 
   @Test
   public void withBeans_asMocks() {
@@ -26,7 +26,7 @@ public class BeanContext_Builder_mockitoSpyTest {
     Pump pump = mock(Pump.class);
     Grinder grinder = mock(Grinder.class);
 
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withBeans(pump, grinder)
       .build()) {
 
@@ -47,7 +47,7 @@ public class BeanContext_Builder_mockitoSpyTest {
   @Test
   public void withMockitoSpy_noSetup_expect_spyUsed() {
 
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withSpy(Pump.class)
       .build()) {
 
@@ -63,7 +63,7 @@ public class BeanContext_Builder_mockitoSpyTest {
   @Test
   public void withMockitoSpy_postLoadSetup_expect_spyUsed() {
 
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withSpy(Pump.class)
       .withSpy(Grinder.class)
       .build()) {
@@ -86,7 +86,7 @@ public class BeanContext_Builder_mockitoSpyTest {
   @Test
   public void withMockitoSpy_expect_spyUsed() {
 
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withSpy(Pump.class, pump -> {
         // setup the spy
         doNothing().when(pump).pumpWater();
@@ -109,7 +109,7 @@ public class BeanContext_Builder_mockitoSpyTest {
   @Test
   public void withMockitoSpy_whenPrimary_expect_spyUsed() {
 
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withSpy(PEmailer.class) // has a primary
       .build()) {
 
@@ -124,7 +124,7 @@ public class BeanContext_Builder_mockitoSpyTest {
   @Test
   public void withMockitoSpy_whenOnlySecondary_expect_spyUsed() {
 
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withSpy(Widget.class) // only secondary
       .build()) {
 
@@ -144,7 +144,7 @@ public class BeanContext_Builder_mockitoSpyTest {
   @Test
   public void withMockitoSpy_whenSecondary_expect_spyUsed() {
 
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withSpy(Something.class) // has a secondary and a normal
       .build()) {
 
@@ -168,7 +168,7 @@ public class BeanContext_Builder_mockitoSpyTest {
 
     AtomicReference<Grinder> mock = new AtomicReference<>();
 
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withMock(Pump.class)
       .withMock(Grinder.class, grinder -> {
         // setup the mock

--- a/inject-test/src/test/java/org/example/coffee/CoffeeMakerTest.java
+++ b/inject-test/src/test/java/org/example/coffee/CoffeeMakerTest.java
@@ -1,7 +1,7 @@
 package org.example.coffee;
 
 import io.avaje.inject.ApplicationScope;
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import io.avaje.inject.SystemContext;
 import org.example.coffee.core.DuperPump;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ public class CoffeeMakerTest {
   @Test
   public void makeIt_via_BootContext_withNoShutdownHook() {
 
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withNoShutdownHook()
       .build()) {
 
@@ -38,7 +38,7 @@ public class CoffeeMakerTest {
   @Test
   public void makeIt_via_BootContext() {
 
-    try (BeanContext context = BeanContext.newBuilder().build()) {
+    try (BeanScope context = BeanScope.newBuilder().build()) {
       String makeIt = context.getBean(CoffeeMaker.class).makeIt();
       assertThat(makeIt).isEqualTo("done");
     }

--- a/inject-test/src/test/java/org/example/coffee/ExtensionExample.java
+++ b/inject-test/src/test/java/org/example/coffee/ExtensionExample.java
@@ -1,7 +1,7 @@
 package org.example.coffee;
 
-import io.avaje.inject.BeanContext;
-import io.avaje.inject.BeanContextBuilder;
+import io.avaje.inject.BeanScope;
+import io.avaje.inject.BeanScopeBuilder;
 
 import java.util.List;
 
@@ -15,8 +15,8 @@ class ExtensionExample {
     this.withSpies = withSpies;
   }
 
-  BeanContext build() {
-    BeanContextBuilder bootContext = BeanContext.newBuilder();
+  BeanScope build() {
+    BeanScopeBuilder bootContext = BeanScope.newBuilder();
     withMocks.forEach(bootContext::withMock);
     withSpies.forEach(bootContext::withSpy);
     return bootContext.build();

--- a/inject-test/src/test/java/org/example/coffee/ExtensionExampleTest.java
+++ b/inject-test/src/test/java/org/example/coffee/ExtensionExampleTest.java
@@ -1,7 +1,7 @@
 package org.example.coffee;
 
-import io.avaje.inject.BeanContext;
-import io.avaje.inject.BeanContextBuilder;
+import io.avaje.inject.BeanScope;
+import io.avaje.inject.BeanScopeBuilder;
 import org.example.coffee.qualifier.SomeStore;
 import org.example.coffee.secondary.SEmailer;
 import org.example.coffee.secondary.Widget;
@@ -16,12 +16,12 @@ public class ExtensionExampleTest {
   public void checkForCompilerWarningsOnly_notATestThatRuns() {
 
     ExtensionExample extensionExample = new ExtensionExample(asList(Widget.class, SEmailer.class), asList(SomeStore.class));
-    BeanContext context = extensionExample.build();
+    BeanScope context = extensionExample.build();
 
     Class cls0 = Widget.class;
     Class<?> cls1 = SEmailer.class;
 
-    BeanContextBuilder bootContext = BeanContext.newBuilder()
+    BeanScopeBuilder bootContext = BeanScope.newBuilder()
       .withSpy(cls0)
       .withSpy(cls1)
       .withMock(cls0)

--- a/inject-test/src/test/java/org/example/coffee/FactoryTest.java
+++ b/inject-test/src/test/java/org/example/coffee/FactoryTest.java
@@ -1,6 +1,6 @@
 package org.example.coffee;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.example.coffee.factory.BFact;
 import org.junit.jupiter.api.Test;
 
@@ -11,7 +11,7 @@ public class FactoryTest {
   @Test
   public void test() {
 
-    try (BeanContext context = BeanContext.newBuilder().build()) {
+    try (BeanScope context = BeanScope.newBuilder().build()) {
       BFact bean = context.getBean(BFact.class);
       String b = bean.b();
       assertThat(b).isNotNull();

--- a/inject-test/src/test/java/org/example/coffee/InjectListTest.java
+++ b/inject-test/src/test/java/org/example/coffee/InjectListTest.java
@@ -1,6 +1,6 @@
 package org.example.coffee;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.example.coffee.list.CombinedSetSomei;
 import org.example.coffee.list.CombinedSomei;
 import org.junit.jupiter.api.Test;
@@ -13,7 +13,7 @@ public class InjectListTest {
 
   @Test
   public void test() {
-    try (BeanContext context = BeanContext.newBuilder().build()) {
+    try (BeanScope context = BeanScope.newBuilder().build()) {
       CombinedSomei bean = context.getBean(CombinedSomei.class);
       List<String> somes = bean.lotsOfSomes();
       assertThat(somes).containsOnly("a", "b", "a2");
@@ -22,7 +22,7 @@ public class InjectListTest {
 
   @Test
   public void test_set() {
-    try (BeanContext context = BeanContext.newBuilder().build()) {
+    try (BeanScope context = BeanScope.newBuilder().build()) {
       CombinedSetSomei bean = context.getBean(CombinedSetSomei.class);
       List<String> somes = bean.lotsOfSomes();
       assertThat(somes).containsOnly("a", "b", "a2");

--- a/inject-test/src/test/java/org/example/coffee/ProviderTest.java
+++ b/inject-test/src/test/java/org/example/coffee/ProviderTest.java
@@ -1,6 +1,6 @@
 package org.example.coffee;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.example.coffee.provider.ProvOther;
 import org.example.coffee.provider.ProvOther2;
 import org.junit.jupiter.api.Test;
@@ -12,7 +12,7 @@ public class ProviderTest {
   @Test
   public void test() {
 
-    try (BeanContext context = BeanContext.newBuilder().build()) {
+    try (BeanScope context = BeanScope.newBuilder().build()) {
 
       ProvOther bean = context.getBean(ProvOther.class);
       String other = bean.other();

--- a/inject-test/src/test/java/org/example/coffee/circular/CircularDependencyTest.java
+++ b/inject-test/src/test/java/org/example/coffee/circular/CircularDependencyTest.java
@@ -1,6 +1,6 @@
 package org.example.coffee.circular;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,7 +9,7 @@ class CircularDependencyTest {
 
   @Test
   void wire() {
-    try (BeanContext context = BeanContext.newBuilder().build()) {
+    try (BeanScope context = BeanScope.newBuilder().build()) {
       assertThat(context.getBean(CircA.class)).isNotNull();
       assertThat(context.getBean(CircB.class)).isNotNull();
       assertThat(context.getBean(CircC.class)).isNotNull();

--- a/inject-test/src/test/java/org/example/coffee/factory/AFactTest.java
+++ b/inject-test/src/test/java/org/example/coffee/factory/AFactTest.java
@@ -1,6 +1,6 @@
 package org.example.coffee.factory;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,7 +11,7 @@ public class AFactTest {
   public void postConstruct() {
 
     AFact bean;
-    try (BeanContext context = BeanContext.newBuilder().build()) {
+    try (BeanScope context = BeanScope.newBuilder().build()) {
       bean = context.getBean(AFact.class);
 
       assertThat(bean.getCountConstruct()).isEqualTo(1);

--- a/inject-test/src/test/java/org/example/coffee/factory/BFactTest.java
+++ b/inject-test/src/test/java/org/example/coffee/factory/BFactTest.java
@@ -1,6 +1,6 @@
 package org.example.coffee.factory;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,7 +11,7 @@ public class BFactTest {
   public void getCountInit() {
 
     BFact bFact;
-    try (BeanContext context = BeanContext.newBuilder().build()) {
+    try (BeanScope context = BeanScope.newBuilder().build()) {
       bFact = context.getBean(BFact.class);
       assertThat(bFact.getCountInit()).isEqualTo(1);
       assertThat(bFact.getCountClose()).isEqualTo(0);

--- a/inject-test/src/test/java/org/example/coffee/factory/ConfigurationTest.java
+++ b/inject-test/src/test/java/org/example/coffee/factory/ConfigurationTest.java
@@ -1,6 +1,6 @@
 package org.example.coffee.factory;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -11,7 +11,7 @@ public class ConfigurationTest {
   public void getCountInit() {
 
     Configuration configuration;
-    try (BeanContext context = BeanContext.newBuilder().build()) {
+    try (BeanScope context = BeanScope.newBuilder().build()) {
       configuration = context.getBean(Configuration.class);
       assertEquals(configuration.getCountInit(), 1);
       assertEquals(configuration.getCountClose(), 0);

--- a/inject-test/src/test/java/org/example/coffee/factory/MultipleOtherThingsTest.java
+++ b/inject-test/src/test/java/org/example/coffee/factory/MultipleOtherThingsTest.java
@@ -1,7 +1,7 @@
 package org.example.coffee.factory;
 
 import io.avaje.inject.ApplicationScope;
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,7 +11,7 @@ class MultipleOtherThingsTest {
 
   @Test
   void test() {
-    try (BeanContext context = BeanContext.newBuilder().build()) {
+    try (BeanScope context = BeanScope.newBuilder().build()) {
       final MultipleOtherThings combined = context.getBean(MultipleOtherThings.class);
       assertEquals("blue", combined.blue());
       assertEquals("red", combined.red());

--- a/inject-test/src/test/java/org/example/coffee/factory/MyFactoryTest.java
+++ b/inject-test/src/test/java/org/example/coffee/factory/MyFactoryTest.java
@@ -1,7 +1,7 @@
 package org.example.coffee.factory;
 
 import io.avaje.inject.ApplicationScope;
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.example.coffee.parent.DesEngi;
 import org.junit.jupiter.api.Test;
 
@@ -11,7 +11,7 @@ public class MyFactoryTest {
 
   @Test
   public void methodsCalled() {
-    try (BeanContext context = BeanContext.newBuilder().build()) {
+    try (BeanScope context = BeanScope.newBuilder().build()) {
       final MyFactory myFactory = context.getBean(MyFactory.class);
       assertThat(myFactory.methodsCalled()).contains("|useCFact", "|anotherCFact", "|buildEngi");
     }

--- a/inject-test/src/test/java/org/example/coffee/fruit/AppleServiceTest.java
+++ b/inject-test/src/test/java/org/example/coffee/fruit/AppleServiceTest.java
@@ -1,7 +1,7 @@
 package org.example.coffee.fruit;
 
-import io.avaje.inject.BeanContext;
-import io.avaje.inject.BeanContextBuilder;
+import io.avaje.inject.BeanScope;
+import io.avaje.inject.BeanScopeBuilder;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,12 +13,12 @@ public class AppleServiceTest {
   @Test
   public void test_spyWithFieldInjection() {
 
-    BeanContextBuilder contextBuilder = BeanContext.newBuilder();
+    BeanScopeBuilder contextBuilder = BeanScope.newBuilder();
     contextBuilder.withSpy(AppleService.class);
 
-    try (BeanContext beanContext = contextBuilder.build()) {
+    try (BeanScope beanScope = contextBuilder.build()) {
 
-      AppleService appleService = beanContext.getBean(AppleService.class);
+      AppleService appleService = beanScope.getBean(AppleService.class);
 
       doNothing()
         .when(appleService)
@@ -37,9 +37,9 @@ public class AppleServiceTest {
   @Test
   public void test_whenNoMockOrSpy() {
 
-    try (BeanContext beanContext = BeanContext.newBuilder().build()) {
+    try (BeanScope beanScope = BeanScope.newBuilder().build()) {
 
-      AppleService appleService = beanContext.getBean(AppleService.class);
+      AppleService appleService = beanScope.getBean(AppleService.class);
 
       assertThat(appleService.bananaService).isNotNull();
       assertThat(appleService.peachService).isNotNull();

--- a/inject-test/src/test/java/org/example/coffee/generic/HazManagerTest.java
+++ b/inject-test/src/test/java/org/example/coffee/generic/HazManagerTest.java
@@ -1,7 +1,7 @@
 package org.example.coffee.generic;
 
 import io.avaje.inject.ApplicationScope;
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,7 +22,7 @@ public class HazManagerTest {
   @Test
   public void fin_with_mockHaz() {
 
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withMock(HazRepo.class)
       .build()) {
 
@@ -36,7 +36,7 @@ public class HazManagerTest {
   @Test
   public void find_with_stubHazUsingMockito() {
 
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withMock(HazRepo.class, hazRepo -> {
         when(hazRepo.findById(anyLong())).thenReturn(new Haz(-23L));
       })
@@ -54,7 +54,7 @@ public class HazManagerTest {
 
     TDHazRepo testDouble = new TDHazRepo();
 
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withBeans(testDouble)
       .build()) {
 

--- a/inject-test/src/test/java/org/example/coffee/grind/AMusherTest.java
+++ b/inject-test/src/test/java/org/example/coffee/grind/AMusherTest.java
@@ -1,6 +1,6 @@
 package org.example.coffee.grind;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -11,7 +11,7 @@ public class AMusherTest {
   public void getCountInit() {
 
     AMusher aMusher;
-    try (BeanContext context = BeanContext.newBuilder().build()) {
+    try (BeanScope context = BeanScope.newBuilder().build()) {
       aMusher = context.getBean(AMusher.class);
       assertEquals(aMusher.getCountInit(), 1);
       assertEquals(aMusher.getCountClose(), 0);

--- a/inject-test/src/test/java/org/example/coffee/grind/BMusherTest.java
+++ b/inject-test/src/test/java/org/example/coffee/grind/BMusherTest.java
@@ -1,6 +1,6 @@
 package org.example.coffee.grind;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -11,7 +11,7 @@ public class BMusherTest {
   public void init() {
 
     BMusher bMusher;
-    try (BeanContext context = BeanContext.newBuilder().build()) {
+    try (BeanScope context = BeanScope.newBuilder().build()) {
       bMusher = context.getBean(BMusher.class);
       assertEquals(bMusher.getCountInit(), 1);
       assertEquals(bMusher.getCountClose(), 0);

--- a/inject-test/src/test/java/org/example/coffee/priority/base/PriorityTest.java
+++ b/inject-test/src/test/java/org/example/coffee/priority/base/PriorityTest.java
@@ -1,6 +1,6 @@
 package org.example.coffee.priority.base;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import io.avaje.inject.SystemContext;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +12,7 @@ public class PriorityTest {
 
   @Test
   void getBeansByPriority() {
-    final BeanContext context = SystemContext.context();
+    final BeanScope context = SystemContext.context();
 
     final List<BaseIface> beans = context.getBeansByPriority(BaseIface.class);
     assertExpectedOrder(beans);
@@ -20,7 +20,7 @@ public class PriorityTest {
 
   @Test
   void sortByPriority() {
-    final BeanContext context = SystemContext.context();
+    final BeanScope context = SystemContext.context();
 
     final List<BaseIface> beans = context.getBeans(BaseIface.class);
     final List<BaseIface> sorted = context.sortByPriority(beans);

--- a/inject-test/src/test/java/org/example/coffee/priority/custom/CustomPriorityTest.java
+++ b/inject-test/src/test/java/org/example/coffee/priority/custom/CustomPriorityTest.java
@@ -1,6 +1,6 @@
 package org.example.coffee.priority.custom;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import io.avaje.inject.SystemContext;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +12,7 @@ public class CustomPriorityTest {
 
   @Test
   void test() {
-    final BeanContext context = SystemContext.context();
+    final BeanScope context = SystemContext.context();
 
     final List<OtherIface> beans = context.getBeans(OtherIface.class);
     final List<OtherIface> sorted = context.sortByPriority(beans, CustomPriority.class);

--- a/inject-test/src/test/java/org/example/coffee/qualifier/StoreManagerWithFieldQualifierTest.java
+++ b/inject-test/src/test/java/org/example/coffee/qualifier/StoreManagerWithFieldQualifierTest.java
@@ -1,6 +1,6 @@
 package org.example.coffee.qualifier;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,7 +10,7 @@ public class StoreManagerWithFieldQualifierTest {
   @Test
   public void test() {
 
-    try (BeanContext context = BeanContext.newBuilder().build()) {
+    try (BeanScope context = BeanScope.newBuilder().build()) {
       StoreManagerWithFieldQualifier manager = context.getBean(StoreManagerWithFieldQualifier.class);
       String store = manager.store();
       assertThat(store).isEqualTo("blue");

--- a/inject-test/src/test/java/org/example/coffee/qualifier/StoreManagerWithNamedTest.java
+++ b/inject-test/src/test/java/org/example/coffee/qualifier/StoreManagerWithNamedTest.java
@@ -1,6 +1,6 @@
 package org.example.coffee.qualifier;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,7 +10,7 @@ public class StoreManagerWithNamedTest {
   @Test
   public void test() {
 
-    try (BeanContext context = BeanContext.newBuilder().build()) {
+    try (BeanScope context = BeanScope.newBuilder().build()) {
       StoreManagerWithNamed manager = context.getBean(StoreManagerWithNamed.class);
       String store = manager.store();
       assertThat(store).isEqualTo("blue");

--- a/inject-test/src/test/java/org/example/coffee/qualifier/StoreManagerWithQualifierTest.java
+++ b/inject-test/src/test/java/org/example/coffee/qualifier/StoreManagerWithQualifierTest.java
@@ -1,6 +1,6 @@
 package org.example.coffee.qualifier;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,7 +10,7 @@ public class StoreManagerWithQualifierTest {
   @Test
   public void test() {
 
-    try (BeanContext context = BeanContext.newBuilder().build()) {
+    try (BeanScope context = BeanScope.newBuilder().build()) {
       StoreManagerWithQualifier manager = context.getBean(StoreManagerWithQualifier.class);
       String store = manager.store();
       assertThat(store).isEqualTo("blue");

--- a/inject-test/src/test/java/org/example/coffee/qualifier/StoreManagerWithSetterQualifierTest.java
+++ b/inject-test/src/test/java/org/example/coffee/qualifier/StoreManagerWithSetterQualifierTest.java
@@ -1,6 +1,6 @@
 package org.example.coffee.qualifier;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,7 +9,7 @@ class StoreManagerWithSetterQualifierTest {
 
   @Test
   void redStore() {
-    try (BeanContext context = BeanContext.newBuilder().build()) {
+    try (BeanScope context = BeanScope.newBuilder().build()) {
       StoreManagerWithSetterQualifier manager = context.getBean(StoreManagerWithSetterQualifier.class);
       assertThat(manager.blueStore()).isEqualTo("blue");
       assertThat(manager.greenStore()).isEqualTo("green");
@@ -18,7 +18,7 @@ class StoreManagerWithSetterQualifierTest {
 
   @Test
   void namedTestDouble() {
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withBean("Blue", SomeStore.class, () -> "TD Blue")
       .withBean("Green", SomeStore.class, () -> "TD Green")
       .build()) {
@@ -31,7 +31,7 @@ class StoreManagerWithSetterQualifierTest {
 
   @Test
   void namedTestDouble_expect_otherNamedStillWired() {
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withBean("Blue", SomeStore.class, () -> "TD Blue Only")
       // with GreenStore still wired
       .build()) {

--- a/inject-test/src/test/java/org/example/iface/NestedInterfaceTest.java
+++ b/inject-test/src/test/java/org/example/iface/NestedInterfaceTest.java
@@ -1,7 +1,7 @@
 package org.example.iface;
 
 import io.avaje.inject.ApplicationScope;
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -21,7 +21,7 @@ public class NestedInterfaceTest {
   @Test
   void test_provided() {
 
-    try (BeanContext context = BeanContext.newBuilder()
+    try (BeanScope context = BeanScope.newBuilder()
       .withMock(Some.Nested.class, nested -> when(nested.doNested()).thenReturn("myMock"))
       .build()) {
 

--- a/inject/src/main/java/io/avaje/inject/ApplicationScope.java
+++ b/inject/src/main/java/io/avaje/inject/ApplicationScope.java
@@ -30,10 +30,10 @@ import java.util.List;
  */
 public class ApplicationScope {
 
-  private static final BeanContext rootContext = init();
+  private static final BeanScope rootContext = init();
 
-  private static BeanContext init() {
-    return BeanContext.newBuilder().build();
+  private static BeanScope init() {
+    return BeanScope.newBuilder().build();
   }
 
   private ApplicationScope() {
@@ -43,7 +43,7 @@ public class ApplicationScope {
   /**
    * Return the underlying BeanContext.
    */
-  public static BeanContext scope() {
+  public static BeanScope scope() {
     return rootContext;
   }
 

--- a/inject/src/main/java/io/avaje/inject/BeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/BeanScope.java
@@ -129,11 +129,6 @@ public interface BeanScope extends Closeable {
   }
 
   /**
-   * Return the wiring candidate bean with name and priority.
-   */
-  <T> BeanEntry<T> candidate(Class<T> type, String name);
-
-  /**
    * Return the list of beans that have an annotation.
    *
    * <pre>{@code

--- a/inject/src/main/java/io/avaje/inject/BeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/BeanScope.java
@@ -11,15 +11,15 @@ import java.util.List;
  * preDestroy and are created (wired) via dependency injection.
  * </p>
  *
- * <h3>Create a BeanContext</h3>
+ * <h3>Create a BeanScope</h3>
  * <p>
- * We can programmatically create a BeanContext via BeanContextBuilder.
+ * We can programmatically create a BeanScope via BeanScopeBuilder.
  * </p>
  * <pre>{@code
  *
- *   // create a BeanContext ...
+ *   // create a BeanScope ...
  *
- *   try (BeanContext context = new BeanContextBuilder()
+ *   try (BeanScope scope = BeanScope.newBuilder()
  *     .build()) {
  *
  *     CoffeeMaker coffeeMaker = context.getBean(CoffeeMaker.class);
@@ -30,24 +30,24 @@ import java.util.List;
  *
  * <h3>Implicitly used</h3>
  * <p>
- * The BeanContext is implicitly used by SystemContext.  It will be created as needed and
- * a shutdown hook will close the underlying BeanContext on JVM shutdown.
+ * The BeanScope is implicitly used by ApplicationScope.  It will be created as needed and
+ * a shutdown hook will close the underlying BeanScope on JVM shutdown.
  * </p>
  * <pre>{@code
  *
- *   // BeanContext created as needed under the hood
+ *   // BeanScope created as needed under the hood
  *
- *   CoffeeMaker coffeeMaker = SystemContext.getBean(CoffeeMaker.class);
+ *   CoffeeMaker coffeeMaker = ApplicationScope.get(CoffeeMaker.class);
  *   coffeeMaker.brew();
  *
  * }</pre>
  */
-public interface BeanContext extends Closeable {
+public interface BeanScope extends Closeable {
 
   /**
    * Build a bean context with options for shutdown hook and supplying test doubles.
    * <p>
-   * We would choose to use BeanContextBuilder in test code (for component testing)
+   * We would choose to use BeanScopeBuilder in test code (for component testing)
    * as it gives us the ability to inject test doubles, mocks, spy's etc.
    * </p>
    *
@@ -59,7 +59,7 @@ public interface BeanContext extends Closeable {
    *     MyRedisApi mockRedis = mock(MyRedisApi.class);
    *     MyDbApi mockDatabase = mock(MyDbApi.class);
    *
-   *     try (BeanContext context = BeanContext.newBuilder()
+   *     try (BeanScope context = BeanScope.newBuilder()
    *       .withBeans(mockRedis, mockDatabase)
    *       .build()) {
    *
@@ -73,8 +73,8 @@ public interface BeanContext extends Closeable {
    *
    * }</pre>
    */
-  static BeanContextBuilder newBuilder() {
-    return new DBeanContextBuilder();
+  static BeanScopeBuilder newBuilder() {
+    return new DBeanScopeBuilder();
   }
 
   /**
@@ -95,7 +95,15 @@ public interface BeanContext extends Closeable {
    *
    * @param type an interface or bean type
    */
-  <T> T getBean(Class<T> type);
+  <T> T get(Class<T> type);
+
+  /**
+   * Deprecated - migrate to get(type)
+   */
+  @Deprecated
+  default <T> T getBean(Class<T> type) {
+    return get(type);
+  }
 
   /**
    * Return a single bean given the type and name.
@@ -110,7 +118,15 @@ public interface BeanContext extends Closeable {
    * @param type an interface or bean type
    * @param name the name qualifier of a specific bean
    */
-  <T> T getBean(Class<T> type, String name);
+  <T> T get(Class<T> type, String name);
+
+  /**
+   * Deprecated - migrate to get(type, name).
+   */
+  @Deprecated
+  default <T> T getBean(Class<T> type, String name) {
+    return get(type, name);
+  }
 
   /**
    * Return the wiring candidate bean with name and priority.
@@ -150,12 +166,28 @@ public interface BeanContext extends Closeable {
    *
    * @param interfaceType An interface class.
    */
-  <T> List<T> getBeans(Class<T> interfaceType);
+  <T> List<T> list(Class<T> interfaceType);
+
+  /**
+   * Deprecated - migrate to list(interfaceType).
+   */
+  @Deprecated
+  default <T> List<T> getBeans(Class<T> interfaceType) {
+    return list(interfaceType);
+  }
 
   /**
    * Return the list of beans that implement the interface sorting by priority.
    */
-  <T> List<T> getBeansByPriority(Class<T> interfaceType);
+  <T> List<T> listByPriority(Class<T> interfaceType);
+
+  /**
+   * Deprecated - migrate to listByPriority(interfaceType).
+   */
+  @Deprecated
+  default <T> List<T> getBeansByPriority(Class<T> interfaceType) {
+    return listByPriority(interfaceType);
+  }
 
   /**
    * Return the beans that implement the interface sorting by the priority annotation used.
@@ -166,7 +198,15 @@ public interface BeanContext extends Closeable {
    * @param interfaceType The interface type of the beans to return
    * @param priority      The priority annotation used to sort the beans
    */
-  <T> List<T> getBeansByPriority(Class<T> interfaceType, Class<? extends Annotation> priority);
+  <T> List<T> listByPriority(Class<T> interfaceType, Class<? extends Annotation> priority);
+
+  /**
+   * Deprecated - migrate to listByPriority().
+   */
+  @Deprecated
+  default <T> List<T> getBeansByPriority(Class<T> interfaceType, Class<? extends Annotation> priority) {
+    return listByPriority(interfaceType, priority);
+  }
 
   /**
    * Sort the beans by javax.annotation.Priority annotation.

--- a/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
@@ -17,7 +17,7 @@ import java.util.function.Consumer;
  *     MyRedisApi mockRedis = mock(MyRedisApi.class);
  *     MyDbApi mockDatabase = mock(MyDbApi.class);
  *
- *     try (BeanContext context = BeanContext.newBuilder()
+ *     try (BeanScope context = BeanScope.newBuilder()
  *       .withBeans(mockRedis, mockDatabase)
  *       .build()) {
  *
@@ -31,7 +31,7 @@ import java.util.function.Consumer;
  *
  * }</pre>
  */
-public interface BeanContextBuilder {
+public interface BeanScopeBuilder {
 
   /**
    * Create the bean context without registering a shutdown hook.
@@ -43,7 +43,7 @@ public interface BeanContextBuilder {
    *
    *   // automatically closed via try with resources
    *
-   *   try (BeanContext context = BeanContext.newBuilder()
+   *   try (BeanScope context = BeanScope.newBuilder()
    *     .withNoShutdownHook()
    *     .build()) {
    *
@@ -52,9 +52,9 @@ public interface BeanContextBuilder {
    *
    * }</pre>
    *
-   * @return This BeanContextBuilder
+   * @return This BeanScopeBuilder
    */
-  BeanContextBuilder withNoShutdownHook();
+  BeanScopeBuilder withNoShutdownHook();
 
   /**
    * Specify the modules to include in dependency injection.
@@ -72,7 +72,7 @@ public interface BeanContextBuilder {
    *
    *     EmailServiceApi mockEmailService = mock(EmailServiceApi.class);
    *
-   *     try (BeanContext context = BeanContext.newBuilder()
+   *     try (BeanScope context = BeanScope.newBuilder()
    *       .withBeans(mockEmailService)
    *       .withModules("coffee")
    *       .withIgnoreMissingModuleDependencies()
@@ -91,13 +91,13 @@ public interface BeanContextBuilder {
    * @param modules The names of modules that we want to include in dependency injection.
    * @return This BeanContextBuilder
    */
-  BeanContextBuilder withModules(String... modules);
+  BeanScopeBuilder withModules(String... modules);
 
   /**
    * Set this when building a BeanContext (typically for testing) and supplied beans replace module dependencies.
    * This means we don't need the usual module dependencies as supplied beans are used instead.
    */
-  BeanContextBuilder withIgnoreMissingModuleDependencies();
+  BeanScopeBuilder withIgnoreMissingModuleDependencies();
 
   /**
    * Supply a bean to the context that will be used instead of any
@@ -112,7 +112,7 @@ public interface BeanContextBuilder {
    *   Pump pump = mock(Pump.class);
    *   Grinder grinder = mock(Grinder.class);
    *
-   *   try (BeanContext context = BeanContext.newBuilder()
+   *   try (BeanScope context = BeanScope.newBuilder()
    *     .withBeans(pump, grinder)
    *     .build()) {
    *
@@ -134,7 +134,7 @@ public interface BeanContextBuilder {
    * @param beans The bean used when injecting a dependency for this bean or the interface(s) it implements
    * @return This BeanContextBuilder
    */
-  BeanContextBuilder withBeans(Object... beans);
+  BeanScopeBuilder withBeans(Object... beans);
 
   /**
    * Add a supplied bean instance with the given injection type.
@@ -146,7 +146,7 @@ public interface BeanContextBuilder {
    *
    *   Pump mockPump = ...
    *
-   *   try (BeanContext context = BeanContext.newBuilder()
+   *   try (BeanScope context = BeanScope.newBuilder()
    *     .withBean(Pump.class, mockPump)
    *     .build()) {
    *
@@ -166,7 +166,7 @@ public interface BeanContextBuilder {
    * @param type The dependency injection type this bean is target for
    * @param bean The supplied bean instance to use (typically a test mock)
    */
-  <D> BeanContextBuilder withBean(Class<D> type, D bean);
+  <D> BeanScopeBuilder withBean(Class<D> type, D bean);
 
   /**
    * Add a supplied bean instance with the given name and injection type.
@@ -175,14 +175,14 @@ public interface BeanContextBuilder {
    * @param type The dependency injection type this bean is target for
    * @param bean The supplied bean instance to use (typically a test mock)
    */
-  <D> BeanContextBuilder withBean(String name, Class<D> type, D bean);
+  <D> BeanScopeBuilder withBean(String name, Class<D> type, D bean);
 
   /**
    * Use a mockito mock when injecting this bean type.
    *
    * <pre>{@code
    *
-   *   try (BeanContext context = BeanContext.newBuilder()
+   *   try (BeanScope context = BeanScope.newBuilder()
    *     .withMock(Pump.class)
    *     .withMock(Grinder.class, grinder -> {
    *       // setup the mock
@@ -201,7 +201,7 @@ public interface BeanContextBuilder {
    *
    * }</pre>
    */
-  BeanContextBuilder withMock(Class<?> type);
+  BeanScopeBuilder withMock(Class<?> type);
 
   /**
    * Use a mockito mock when injecting this bean type additionally
@@ -209,7 +209,7 @@ public interface BeanContextBuilder {
    *
    * <pre>{@code
    *
-   *   try (BeanContext context = BeanContext.newBuilder()
+   *   try (BeanScope context = BeanScope.newBuilder()
    *     .withMock(Pump.class)
    *     .withMock(Grinder.class, grinder -> {
    *
@@ -229,14 +229,14 @@ public interface BeanContextBuilder {
    *
    * }</pre>
    */
-  <D> BeanContextBuilder withMock(Class<D> type, Consumer<D> consumer);
+  <D> BeanScopeBuilder withMock(Class<D> type, Consumer<D> consumer);
 
   /**
    * Use a mockito spy when injecting this bean type.
    *
    * <pre>{@code
    *
-   *   try (BeanContext context = BeanContext.newBuilder()
+   *   try (BeanScope context = BeanScope.newBuilder()
    *     .withSpy(Pump.class)
    *     .build()) {
    *
@@ -254,7 +254,7 @@ public interface BeanContextBuilder {
    *
    * }</pre>
    */
-  BeanContextBuilder withSpy(Class<?> type);
+  BeanScopeBuilder withSpy(Class<?> type);
 
   /**
    * Use a mockito spy when injecting this bean type additionally
@@ -262,7 +262,7 @@ public interface BeanContextBuilder {
    *
    * <pre>{@code
    *
-   *   try (BeanContext context = BeanContext.newBuilder()
+   *   try (BeanScope context = BeanScope.newBuilder()
    *     .withSpy(Pump.class, pump -> {
    *       // setup the spy
    *       doNothing().when(pump).pumpWater();
@@ -283,12 +283,12 @@ public interface BeanContextBuilder {
    *
    * }</pre>
    */
-  <D> BeanContextBuilder withSpy(Class<D> type, Consumer<D> consumer);
+  <D> BeanScopeBuilder withSpy(Class<D> type, Consumer<D> consumer);
 
   /**
    * Build and return the bean context.
    *
    * @return The BeanContext
    */
-  BeanContext build();
+  BeanScope build();
 }

--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -193,11 +193,6 @@ class DBeanScopeBuilder implements BeanScopeBuilder {
     }
 
     @Override
-    public <T> BeanEntry<T> candidate(Class<T> type, String name) {
-      return context.candidate(type, name);
-    }
-
-    @Override
     public List<Object> getBeansWithAnnotation(Class<?> annotation) {
       return context.getBeansWithAnnotation(annotation);
     }

--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -15,9 +15,9 @@ import java.util.function.Consumer;
 /**
  * Build a bean context with options for shutdown hook and supplying test doubles.
  */
-class DBeanContextBuilder implements BeanContextBuilder {
+class DBeanScopeBuilder implements BeanScopeBuilder {
 
-  private static final Logger log = LoggerFactory.getLogger(DBeanContextBuilder.class);
+  private static final Logger log = LoggerFactory.getLogger(DBeanScopeBuilder.class);
 
   private boolean shutdownHook = true;
 
@@ -34,30 +34,30 @@ class DBeanContextBuilder implements BeanContextBuilder {
   /**
    * Create a BeanContextBuilder to ultimately load and return a new BeanContext.
    */
-  DBeanContextBuilder() {
+  DBeanScopeBuilder() {
   }
 
   @Override
-  public BeanContextBuilder withNoShutdownHook() {
+  public BeanScopeBuilder withNoShutdownHook() {
     this.shutdownHook = false;
     return this;
   }
 
   @Override
-  public BeanContextBuilder withModules(String... modules) {
+  public BeanScopeBuilder withModules(String... modules) {
     this.includeModules.addAll(Arrays.asList(modules));
     return this;
   }
 
   @Override
-  public BeanContextBuilder withIgnoreMissingModuleDependencies() {
+  public BeanScopeBuilder withIgnoreMissingModuleDependencies() {
     this.ignoreMissingModuleDependencies = true;
     return this;
   }
 
   @Override
   @SuppressWarnings({"unchecked", "rawtypes"})
-  public BeanContextBuilder withBeans(Object... beans) {
+  public BeanScopeBuilder withBeans(Object... beans) {
     for (Object bean : beans) {
       suppliedBeans.add(new SuppliedBean(null, suppliedType(bean.getClass()), bean));
     }
@@ -65,40 +65,40 @@ class DBeanContextBuilder implements BeanContextBuilder {
   }
 
   @Override
-  public <D> BeanContextBuilder withBean(Class<D> type, D bean) {
+  public <D> BeanScopeBuilder withBean(Class<D> type, D bean) {
     return withBean(null, type, bean);
   }
 
   @Override
-  public <D> BeanContextBuilder withBean(String name, Class<D> type, D bean) {
+  public <D> BeanScopeBuilder withBean(String name, Class<D> type, D bean) {
     suppliedBeans.add(new SuppliedBean<>(name, type, bean));
     return this;
   }
 
   @Override
-  public BeanContextBuilder withMock(Class<?> type) {
+  public BeanScopeBuilder withMock(Class<?> type) {
     return withMock(type, null);
   }
 
   @Override
-  public <D> DBeanContextBuilder withMock(Class<D> type, Consumer<D> consumer) {
+  public <D> DBeanScopeBuilder withMock(Class<D> type, Consumer<D> consumer) {
     suppliedBeans.add(new SuppliedBean<>(null, type, null, consumer));
     return this;
   }
 
   @Override
-  public BeanContextBuilder withSpy(Class<?> type) {
+  public BeanScopeBuilder withSpy(Class<?> type) {
     return withSpy(type, null);
   }
 
   @Override
-  public <D> DBeanContextBuilder withSpy(Class<D> type, Consumer<D> consumer) {
+  public <D> DBeanScopeBuilder withSpy(Class<D> type, Consumer<D> consumer) {
     enrichBeans.add(new EnrichBean<>(type, consumer));
     return this;
   }
 
   @Override
-  public BeanContext build() {
+  public BeanScope build() {
     // sort factories by dependsOn
     FactoryOrder factoryOrder = new FactoryOrder(includeModules, !suppliedBeans.isEmpty(), ignoreMissingModuleDependencies);
     ServiceLoader.load(BeanContextFactory.class).forEach(factoryOrder::add);
@@ -117,13 +117,13 @@ class DBeanContextBuilder implements BeanContextBuilder {
       factory.build(builder);
     }
 
-    BeanContext beanContext = builder.build();
+    BeanScope beanScope = builder.build();
     // entire graph built, fire postConstruct
-    beanContext.start();
+    beanScope.start();
     if (shutdownHook) {
-      return new ShutdownAwareBeanContext(beanContext);
+      return new ShutdownAwareBeanScope(beanScope);
     }
-    return beanContext;
+    return beanScope;
   }
 
   /**
@@ -144,9 +144,9 @@ class DBeanContextBuilder implements BeanContextBuilder {
    */
   private static class Hook extends Thread {
 
-    private final ShutdownAwareBeanContext context;
+    private final ShutdownAwareBeanScope context;
 
-    Hook(ShutdownAwareBeanContext context) {
+    Hook(ShutdownAwareBeanScope context) {
       this.context = context;
     }
 
@@ -159,14 +159,14 @@ class DBeanContextBuilder implements BeanContextBuilder {
   /**
    * Proxy that handles shutdown hook registration and de-registration.
    */
-  private static class ShutdownAwareBeanContext implements BeanContext {
+  private static class ShutdownAwareBeanScope implements BeanScope {
 
     private final ReentrantLock lock = new ReentrantLock();
-    private final BeanContext context;
+    private final BeanScope context;
     private final Hook hook;
     private boolean shutdown;
 
-    ShutdownAwareBeanContext(BeanContext context) {
+    ShutdownAwareBeanScope(BeanScope context) {
       this.context = context;
       this.hook = new Hook(this);
       Runtime.getRuntime().addShutdownHook(hook);
@@ -183,13 +183,13 @@ class DBeanContextBuilder implements BeanContextBuilder {
     }
 
     @Override
-    public <T> T getBean(Class<T> beanClass) {
-      return context.getBean(beanClass);
+    public <T> T get(Class<T> beanClass) {
+      return context.get(beanClass);
     }
 
     @Override
-    public <T> T getBean(Class<T> beanClass, String name) {
-      return context.getBean(beanClass, name);
+    public <T> T get(Class<T> beanClass, String name) {
+      return context.get(beanClass, name);
     }
 
     @Override
@@ -203,18 +203,18 @@ class DBeanContextBuilder implements BeanContextBuilder {
     }
 
     @Override
-    public <T> List<T> getBeans(Class<T> interfaceType) {
-      return context.getBeans(interfaceType);
+    public <T> List<T> list(Class<T> interfaceType) {
+      return context.list(interfaceType);
     }
 
     @Override
-    public <T> List<T> getBeansByPriority(Class<T> interfaceType) {
-      return context.getBeansByPriority(interfaceType);
+    public <T> List<T> listByPriority(Class<T> interfaceType) {
+      return context.listByPriority(interfaceType);
     }
 
     @Override
-    public <T> List<T> getBeansByPriority(Class<T> interfaceType, Class<? extends Annotation> priority) {
-      return context.getBeansByPriority(interfaceType, priority);
+    public <T> List<T> listByPriority(Class<T> interfaceType, Class<? extends Annotation> priority) {
+      return context.listByPriority(interfaceType, priority);
     }
 
     @Override

--- a/inject/src/main/java/io/avaje/inject/Priority.java
+++ b/inject/src/main/java/io/avaje/inject/Priority.java
@@ -3,22 +3,20 @@ package io.avaje.inject;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-import java.util.List;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * The <code>Priority</code> annotation can be applied to classes to indicate
- * in what order they should be returned via @{@link SystemContext#getBeansByPriority(Class)}.
+ * in what order they should be returned via @{@link ApplicationScope#listByPriority(Class)}.
  * <p>
  * Beans can be returned using other Priority annotation such as <code>javax.annotation.Priority</code>
  * or any custom priority annotation that has an <code>int value()</code> attribute.
  * </p>
  *
- * @see BeanContext#getBeansByPriority(Class)
- * @see BeanContext#getBeansByPriority(Class, Class)
- * @see BeanContext#sortByPriority(List, Class)
+ * @see BeanScope#listByPriority(Class)
+ * @see BeanScope#listByPriority(Class, Class)
  */
 @Documented
 @Retention(RUNTIME)

--- a/inject/src/main/java/io/avaje/inject/SystemContext.java
+++ b/inject/src/main/java/io/avaje/inject/SystemContext.java
@@ -14,42 +14,13 @@ import java.util.List;
  * <h3>Example: get a bean</h3>
  * <pre>{@code
  *
- *   CoffeeMaker coffeeMaker = SystemContext.getBean(CoffeeMaker.class);
+ *   CoffeeMaker coffeeMaker = ApplicationScope.get(CoffeeMaker.class);
  *   coffeeMaker.brew();
- *
- * }</pre>
- *
- * <h3>Example: get all the beans implementing an interface</h3>
- * <pre>{@code
- *
- *   // e.g. register all WebRoutes for a web framework
- *
- *   List<WebRoute> routes = SystemContext.getBeans(WebRoute.class);
- *
- *   // register all the routes ...
- *
- * }</pre>
- *
- * <h3>Example: get all the beans that have an annotation</h3>
- * <pre>{@code
- *
- *   // e.g. register all controllers with web a framework
- *   // .. where Controller is an annotation on the beans
- *
- *   List<Object> controllers = SystemContext.getBeansWithAnnotation(Controller.class);
- *
- *   // register all the controllers ...
  *
  * }</pre>
  */
 @Deprecated
 public class SystemContext {
-
-  private static final BeanContext rootContext = init();
-
-  private static BeanContext init() {
-    return BeanContext.newBuilder().build();
-  }
 
   private SystemContext() {
     // hide
@@ -57,27 +28,14 @@ public class SystemContext {
 
   /**
    * Deprecated - migrate to ApplicationScope.scope().
-   * <p>
-   * Return the underlying BeanContext.
    */
   @Deprecated
-  public static BeanContext context() {
+  public static BeanScope context() {
     return ApplicationScope.scope();
   }
 
   /**
-   * Deprecated - migrate to ApplicationScope.get().
-   * <p>
-   * Return a single bean given the type.
-   *
-   * <pre>{@code
-   *
-   *   CoffeeMaker coffeeMaker = SystemContext.getBean(CoffeeMaker.class);
-   *   coffeeMaker.brew();
-   *
-   * }</pre>
-   *
-   * @param type an interface or bean type
+   * Deprecated - migrate to ApplicationScope.get(type).
    */
   @Deprecated
   public static <T> T getBean(Class<T> type) {
@@ -86,18 +44,6 @@ public class SystemContext {
 
   /**
    * Deprecated - migrate to ApplicationScope.get(type, name).
-   * <p>
-   * Return a single bean given the type and name.
-   *
-   * <pre>{@code
-   *
-   *   Heater heater = SystemContext.getBean(Heater.class, "electric");
-   *   heater.heat();
-   *
-   * }</pre>
-   *
-   * @param type an interface or bean type
-   * @param name the name qualifier of a specific bean
    */
   @Deprecated
   public static <T> T getBean(Class<T> type, String name) {
@@ -106,39 +52,14 @@ public class SystemContext {
 
   /**
    * Deprecated - removing support for this method.
-   * <p>
-   * Return the list of beans that have an annotation.
-   *
-   * <pre>{@code
-   *
-   *   // e.g. register all controllers with web a framework
-   *   // .. where Controller is an annotation on the beans
-   *
-   *   List<Object> controllers = SystemContext.getBeansWithAnnotation(Controller.class);
-   *
-   * }</pre>
-   *
-   * @param annotation An annotation class.
    */
   @Deprecated
   public static List<Object> getBeansWithAnnotation(Class<?> annotation) {
-    return rootContext.getBeansWithAnnotation(annotation);
+    return ApplicationScope.scope().getBeansWithAnnotation(annotation);
   }
 
   /**
    * Deprecated - migrate to ApplicationScope.list().
-   * <p>
-   * Return the list of beans that implement the interface.
-   *
-   * <pre>{@code
-   *
-   *   // e.g. register all web routes with web a framework
-   *
-   *   List<WebRoute> routes = SystemContext.getBeans(WebRoute.class);
-   *
-   * }</pre>
-   *
-   * @param interfaceType An interface class.
    */
   @Deprecated
   public static <T> List<T> getBeans(Class<T> interfaceType) {
@@ -147,18 +68,6 @@ public class SystemContext {
 
   /**
    * Deprecated - migrate to ApplicationScope.listByPriority().
-   * <p>
-   * Return the list of beans that implement the interface ordering based on <code>@Priority</code>.
-   *
-   * <pre>{@code
-   *
-   *   // e.g. register all web routes with web a framework
-   *
-   *   List<WebRoute> routes = SystemContext.getBeansByPriority(WebRoute.class);
-   *
-   * }</pre>
-   *
-   * @param interfaceType An interface class.
    */
   @Deprecated
   public static <T> List<T> getBeansByPriority(Class<T> interfaceType) {

--- a/inject/src/main/java/io/avaje/inject/package-info.java
+++ b/inject/src/main/java/io/avaje/inject/package-info.java
@@ -1,4 +1,4 @@
 /**
- * Avaje Inject API - see {@link io.avaje.inject.SystemContext} and {@link io.avaje.inject.BeanContext}.
+ * Avaje Inject API - see {@link io.avaje.inject.ApplicationScope} and {@link io.avaje.inject.BeanScope}.
  */
 package io.avaje.inject;

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -1,6 +1,6 @@
 package io.avaje.inject.spi;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import io.avaje.inject.BeanEntry;
 import io.avaje.inject.RequestScopeProvider;
 import jakarta.inject.Provider;
@@ -163,5 +163,5 @@ public interface Builder {
   /**
    * Build and return the bean context.
    */
-  BeanContext build();
+  BeanScope build();
 }

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -146,11 +146,6 @@ public interface Builder {
   <T> Set<T> getSet(Class<T> interfaceType);
 
   /**
-   * Get a candidate dependency allowing it to be null.
-   */
-  <T> BeanEntry<T> candidate(Class<T> cls, String name);
-
-  /**
    * Return a potentially enriched bean for registration into the context.
    * Typically for use with mockito spy.
    *

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
@@ -49,15 +49,16 @@ class DBeanMap {
     }
   }
 
-  <T> BeanEntry<T> candidate(Class<T> type, String name) {
+  @SuppressWarnings("unchecked")
+  <T> T get(Class<T> type, String name) {
     DContextEntry entry = beans.get(type.getCanonicalName());
-    if (entry != null) {
-      if (name != null) {
-        name = name.toLowerCase();
-      }
-      return entry.candidate(name);
+    if (entry == null) {
+      return null;
     }
-    return null;
+    if (name != null) {
+      name = name.toLowerCase();
+    }
+    return (T) entry.get(name);
   }
 
   /**

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
@@ -61,14 +61,12 @@ class DBeanMap {
   }
 
   /**
-   * Add all bean instances matching the given type to the list.
+   * Return all bean instances matching the given type.
    */
-  @SuppressWarnings({"unchecked", "rawtypes"})
-  void addAll(Class type, List list) {
+  @SuppressWarnings("rawtypes")
+  List<Object> all(Class type) {
     DContextEntry entry = beans.get(type.getCanonicalName());
-    if (entry != null) {
-      entry.addAll(list);
-    }
+    return entry != null ? entry.all() : Collections.emptyList();
   }
 
   /**

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
@@ -54,9 +54,7 @@ class DBeanScope implements BeanScope {
 
   @Override
   public <T> List<T> list(Class<T> interfaceType) {
-    List<T> list = new ArrayList<>();
-    beans.addAll(interfaceType, list);
-    return list;
+    return (List<T>)beans.all(interfaceType);
   }
 
   @Override
@@ -101,9 +99,7 @@ class DBeanScope implements BeanScope {
 
   @Override
   public List<Object> getBeansWithAnnotation(Class<?> annotation) {
-    List<Object> list = new ArrayList<>();
-    beans.addAll(annotation, list);
-    return list;
+    return beans.all(annotation);
   }
 
   @Override

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
@@ -13,9 +13,9 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import static io.avaje.inject.spi.KeyUtil.key;
 
-class DBeanContext implements BeanContext {
+class DBeanScope implements BeanScope {
 
-  private static final Logger log = LoggerFactory.getLogger(DBeanContext.class);
+  private static final Logger log = LoggerFactory.getLogger(DBeanScope.class);
 
   private final ReentrantLock lock = new ReentrantLock();
   private final List<BeanLifecycle> lifecycleList;
@@ -24,7 +24,7 @@ class DBeanContext implements BeanContext {
 
   private boolean closed;
 
-  DBeanContext(List<BeanLifecycle> lifecycleList, DBeanMap beans, Map<String, RequestScopeMatch<?>> reqScopeProviders) {
+  DBeanScope(List<BeanLifecycle> lifecycleList, DBeanMap beans, Map<String, RequestScopeMatch<?>> reqScopeProviders) {
     this.lifecycleList = lifecycleList;
     this.beans = beans;
     this.reqScopeProviders = reqScopeProviders;
@@ -42,8 +42,8 @@ class DBeanContext implements BeanContext {
   }
 
   @Override
-  public <T> T getBean(Class<T> beanClass) {
-    return getBean(beanClass, null);
+  public <T> T get(Class<T> beanClass) {
+    return get(beanClass, null);
   }
 
   @Override
@@ -55,25 +55,25 @@ class DBeanContext implements BeanContext {
   }
 
   @Override
-  public <T> T getBean(Class<T> beanClass, String name) {
+  public <T> T get(Class<T> beanClass, String name) {
     BeanEntry<T> candidate = candidate(beanClass, name);
     return (candidate == null) ? null : candidate.getBean();
   }
 
   @Override
-  public <T> List<T> getBeans(Class<T> interfaceType) {
+  public <T> List<T> list(Class<T> interfaceType) {
     List<T> list = new ArrayList<>();
     beans.addAll(interfaceType, list);
     return list;
   }
 
   @Override
-  public <T> List<T> getBeansByPriority(Class<T> interfaceType) {
-    return getBeansByPriority(interfaceType, Priority.class);
+  public <T> List<T> listByPriority(Class<T> interfaceType) {
+    return listByPriority(interfaceType, Priority.class);
   }
 
   @Override
-  public <T> List<T> getBeansByPriority(Class<T> interfaceType, Class<? extends Annotation> priorityAnnotation) {
+  public <T> List<T> listByPriority(Class<T> interfaceType, Class<? extends Annotation> priorityAnnotation) {
     List<T> list = getBeans(interfaceType);
     return list.size() > 1 ? sortByPriority(list, priorityAnnotation) : list;
   }

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
@@ -48,13 +48,13 @@ class DBeanScope implements BeanScope {
 
   @Override
   public <T> T get(Class<T> beanClass, String name) {
-    BeanEntry<T> candidate = beans.candidate(beanClass, name);
-    return (candidate == null) ? null : candidate.getBean();
+    return beans.get(beanClass, name);
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public <T> List<T> list(Class<T> interfaceType) {
-    return (List<T>)beans.all(interfaceType);
+    return (List<T>) beans.all(interfaceType);
   }
 
   @Override

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -1,6 +1,6 @@
 package io.avaje.inject.spi;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import io.avaje.inject.BeanEntry;
 import io.avaje.inject.RequestScopeMatch;
 import io.avaje.inject.RequestScopeProvider;
@@ -89,7 +89,7 @@ class DBuilder implements Builder {
 
   @Override
   public <T> BeanEntry<T> candidate(Class<T> cls, String name) {
-    DBeanContext.EntrySort<T> entrySort = new DBeanContext.EntrySort<>();
+    DBeanScope.EntrySort<T> entrySort = new DBeanScope.EntrySort<>();
     entrySort.add(beanMap.candidate(cls, name));
     return entrySort.get();
   }
@@ -205,8 +205,8 @@ class DBuilder implements Builder {
     }
   }
 
-  public BeanContext build() {
+  public BeanScope build() {
     runInjectors();
-    return new DBeanContext(lifecycleList, beanMap, reqScopeProviders);
+    return new DBeanScope(lifecycleList, beanMap, reqScopeProviders);
   }
 }

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -87,15 +87,8 @@ class DBuilder implements Builder {
     return (List<T>) list;
   }
 
-  @Override
-  public <T> BeanEntry<T> candidate(Class<T> cls, String name) {
-    DBeanScope.EntrySort<T> entrySort = new DBeanScope.EntrySort<>();
-    entrySort.add(beanMap.candidate(cls, name));
-    return entrySort.get();
-  }
-
   private <T> T getMaybe(Class<T> beanClass, String name) {
-    BeanEntry<T> entry = candidate(beanClass, name);
+    BeanEntry<T> entry = beanMap.candidate(beanClass, name);
     return (entry == null) ? null : entry.getBean();
   }
 

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -79,12 +79,10 @@ class DBuilder implements Builder {
     return new LinkedHashSet<>(getList(interfaceType));
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
+  @SuppressWarnings({"unchecked"})
   @Override
   public <T> List<T> getList(Class<T> interfaceType) {
-    List list = new ArrayList<>();
-    beanMap.addAll(interfaceType, list);
-    return (List<T>) list;
+    return (List<T>) beanMap.all(interfaceType);
   }
 
   private <T> T getMaybe(Class<T> beanClass, String name) {

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -86,8 +86,7 @@ class DBuilder implements Builder {
   }
 
   private <T> T getMaybe(Class<T> beanClass, String name) {
-    BeanEntry<T> entry = beanMap.candidate(beanClass, name);
-    return (entry == null) ? null : entry.getBean();
+    return beanMap.get(beanClass, name);
   }
 
   /**

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
@@ -1,7 +1,5 @@
 package io.avaje.inject.spi;
 
-import io.avaje.inject.BeanEntry;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -12,21 +10,17 @@ import java.util.List;
  */
 class DContextEntry {
 
-  private final List<DContextEntryBean> entries = new ArrayList<>();
+  private final List<DContextEntryBean> entries = new ArrayList<>(5);
 
-  @SuppressWarnings("unchecked")
-  <T> BeanEntry<T> candidate(String name) {
-    if (entries.isEmpty()) {
-      return null;
-    }
+  void add(DContextEntryBean entryBean) {
+    entries.add(entryBean);
+  }
+
+  Object get(String name) {
     if (entries.size() == 1) {
-      DContextEntryBean entry = entries.get(0);
-      return entry.candidate(name);
+      return entries.get(0).candidate(name);
     }
-
-    EntryMatcher matcher = new EntryMatcher(name);
-    matcher.match(entries);
-    return matcher.candidate();
+    return new EntryMatcher(name).match(entries);
   }
 
   /**
@@ -38,10 +32,6 @@ class DContextEntry {
       list.add(entry.getBean());
     }
     return list;
-  }
-
-  void add(DContextEntryBean entryBean) {
-    entries.add(entryBean);
   }
 
   /**
@@ -67,12 +57,13 @@ class DContextEntry {
       this.name = name;
     }
 
-    void match(List<DContextEntryBean> entries) {
+    Object match(List<DContextEntryBean> entries) {
       for (DContextEntryBean entry : entries) {
         if (entry.isNameMatch(name)) {
           checkMatch(entry);
         }
       }
+      return candidate();
     }
 
     private void checkMatch(DContextEntryBean entry) {
@@ -114,13 +105,12 @@ class DContextEntry {
       throw new IllegalStateException("Expecting only 1 bean match but have multiple matching beans " + match.getBean() + " and " + entry.getBean());
     }
 
-    @SuppressWarnings("rawtypes")
-    BeanEntry candidate() {
+    private Object candidate() {
       if (match == null) {
         return null;
       }
       checkSecondary();
-      return match.getBeanEntry();
+      return match.getBean();
     }
 
     private void checkSecondary() {

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
@@ -30,12 +30,14 @@ class DContextEntry {
   }
 
   /**
-   * Add all the managed beans to the given list.
+   * Return all the beans.
    */
-  void addAll(List<Object> appendToList) {
+  List<Object> all() {
+    List<Object> list = new ArrayList<>(entries.size());
     for (DContextEntryBean entry : entries) {
-      appendToList.add(entry.getBean());
+      list.add(entry.getBean());
     }
+    return list;
   }
 
   void add(DContextEntryBean entryBean) {

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntryBean.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntryBean.java
@@ -49,13 +49,8 @@ class DContextEntryBean {
     return Objects.equals(qualifierName, name);
   }
 
-  Object obtainInstance() {
-    // its a plain bean, just return it
-    return source;
-  }
-
   Object getBean() {
-    return obtainInstance();
+    return source;
   }
 
   boolean isPrimary() {
@@ -71,14 +66,9 @@ class DContextEntryBean {
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
-  BeanEntry getBeanEntry() {
-    return new BeanEntry(flag, getBean(), name);
-  }
-
-  @SuppressWarnings({"unchecked", "rawtypes"})
-  BeanEntry candidate(String qualifierName) {
+  Object candidate(String qualifierName) {
     if (qualifierName == null || Objects.equals(name, qualifierName)) {
-      return new BeanEntry(flag, obtainInstance(), qualifierName);
+      return getBean();
     } else {
       return null;
     }
@@ -96,7 +86,7 @@ class DContextEntryBean {
     }
 
     @Override
-    Object obtainInstance() {
+    Object getBean() {
       // its a provider, get it once
       if (actualBean == null) {
         actualBean = ((Provider<?>) source).get();

--- a/inject/src/main/java/io/avaje/inject/spi/DRequestScope.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DRequestScope.java
@@ -1,6 +1,6 @@
 package io.avaje.inject.spi;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import io.avaje.inject.RequestScope;
 import io.avaje.inject.RequestScopeMatch;
 import jakarta.inject.Provider;
@@ -20,11 +20,11 @@ class DRequestScope implements RequestScope {
 
   private static final Logger log = LoggerFactory.getLogger(RequestScope.class);
 
-  private final BeanContext beanScope;
+  private final BeanScope beanScope;
   private final ConcurrentHashMap<String, Object> supplied;
   private final List<Closeable> closeables = new ArrayList<>();
 
-  DRequestScope(BeanContext beanScope, ConcurrentHashMap<String, Object> supplied) {
+  DRequestScope(BeanScope beanScope, ConcurrentHashMap<String, Object> supplied) {
     this.beanScope = beanScope;
     this.supplied = supplied;
   }

--- a/inject/src/main/java/io/avaje/inject/spi/DRequestScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DRequestScopeBuilder.java
@@ -1,6 +1,6 @@
 package io.avaje.inject.spi;
 
-import io.avaje.inject.BeanContext;
+import io.avaje.inject.BeanScope;
 import io.avaje.inject.RequestScope;
 import io.avaje.inject.RequestScopeBuilder;
 
@@ -15,9 +15,9 @@ class DRequestScopeBuilder implements RequestScopeBuilder {
 
   private final ConcurrentHashMap<String, Object> supplied = new ConcurrentHashMap<>();
 
-  private final BeanContext beanScope;
+  private final BeanScope beanScope;
 
-  DRequestScopeBuilder(BeanContext beanScope) {
+  DRequestScopeBuilder(BeanScope beanScope) {
     this.beanScope = beanScope;
   }
 

--- a/inject/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
+++ b/inject/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
@@ -10,12 +10,12 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BeanContextBuilderTest {
+public class BeanScopeBuilderTest {
 
   @Test
   public void noDepends() {
 
-    DBeanContextBuilder.FactoryOrder factoryOrder = new DBeanContextBuilder.FactoryOrder(Collections.emptySet(), true, true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(Collections.emptySet(), true, true);
     factoryOrder.add(bc("1", null, null));
     factoryOrder.add(bc("2", null, null));
     factoryOrder.add(bc("3", null, null));
@@ -27,7 +27,7 @@ public class BeanContextBuilderTest {
   @Test
   public void name_depends() {
 
-    DBeanContextBuilder.FactoryOrder factoryOrder = new DBeanContextBuilder.FactoryOrder(Collections.emptySet(), true, true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(Collections.emptySet(), true, true);
     factoryOrder.add(bc("two", null, "one"));
     factoryOrder.add(bc("one", null, null));
     factoryOrder.orderFactories();
@@ -38,7 +38,7 @@ public class BeanContextBuilderTest {
   @Test
   public void name_depends4() {
 
-    DBeanContextBuilder.FactoryOrder factoryOrder = new DBeanContextBuilder.FactoryOrder(Collections.emptySet(), true, true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(Collections.emptySet(), true, true);
     factoryOrder.add(bc("1", null, "3"));
     factoryOrder.add(bc("2", null, "4"));
     factoryOrder.add(bc("3", null, "4"));
@@ -52,7 +52,7 @@ public class BeanContextBuilderTest {
   @Test
   public void nameFeature_depends() {
 
-    DBeanContextBuilder.FactoryOrder factoryOrder = new DBeanContextBuilder.FactoryOrder(Collections.emptySet(), true, true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(Collections.emptySet(), true, true);
     factoryOrder.add(bc("1", "a", "3"));
     factoryOrder.add(bc("2", null, "4,a"));
     factoryOrder.add(bc("3", null, "4"));
@@ -66,7 +66,7 @@ public class BeanContextBuilderTest {
   @Test
   public void feature_depends() {
 
-    DBeanContextBuilder.FactoryOrder factoryOrder = new DBeanContextBuilder.FactoryOrder(Collections.emptySet(), true, true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(Collections.emptySet(), true, true);
     factoryOrder.add(bc("two", null, "myfeature"));
     factoryOrder.add(bc("one", "myfeature", null));
     factoryOrder.orderFactories();
@@ -77,7 +77,7 @@ public class BeanContextBuilderTest {
   @Test
   public void feature_depends2() {
 
-    DBeanContextBuilder.FactoryOrder factoryOrder = new DBeanContextBuilder.FactoryOrder(Collections.emptySet(), true, true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(Collections.emptySet(), true, true);
     factoryOrder.add(bc("two", null, "myfeature"));
     factoryOrder.add(bc("one", "myfeature", null));
     factoryOrder.add(bc("three", "myfeature", null));

--- a/inject/src/test/java/io/avaje/inject/spi/DContextEntryTest.java
+++ b/inject/src/test/java/io/avaje/inject/spi/DContextEntryTest.java
@@ -16,7 +16,7 @@ public class DContextEntryTest {
     entry.add(DContextEntryBean.of("N", null, BeanEntry.NORMAL));
     entry.add(DContextEntryBean.of("S", null, BeanEntry.SECONDARY));
 
-    assertEquals(entry.candidate(null).getBean(), "P");
+    assertEquals(entry.get(null), "P");
   }
 
   @Test
@@ -27,7 +27,7 @@ public class DContextEntryTest {
       entry.add(DContextEntryBean.of("N", null, BeanEntry.NORMAL));
       entry.add(DContextEntryBean.of("S", null, BeanEntry.PRIMARY));
 
-      entry.candidate(null);
+      entry.get(null);
     });
   }
 
@@ -38,7 +38,7 @@ public class DContextEntryTest {
     entry.add(DContextEntryBean.of("N", null, BeanEntry.NORMAL));
     entry.add(DContextEntryBean.of("S", null, BeanEntry.SECONDARY));
 
-    assertEquals(entry.candidate(null).getBean(), "N");
+    assertEquals(entry.get(null), "N");
   }
 
 
@@ -50,7 +50,7 @@ public class DContextEntryTest {
     entry.add(DContextEntryBean.of("S1", null, BeanEntry.SECONDARY));
     entry.add(DContextEntryBean.of("S2", null, BeanEntry.SECONDARY));
 
-    assertEquals(entry.candidate(null).getBean(), "N");
+    assertEquals(entry.get(null), "N");
   }
 
   @Test
@@ -61,7 +61,7 @@ public class DContextEntryTest {
       entry.add(DContextEntryBean.of("S1", null, BeanEntry.SECONDARY));
       entry.add(DContextEntryBean.of("S2", null, BeanEntry.SECONDARY));
 
-      entry.candidate(null);
+      entry.get(null);
     });
   }
 
@@ -73,7 +73,7 @@ public class DContextEntryTest {
     entry.add(DContextEntryBean.of("S1", "a", BeanEntry.SECONDARY));
     entry.add(DContextEntryBean.of("S2", "b", BeanEntry.SECONDARY));
 
-    assertEquals(entry.candidate("b").getBean(), "S2");
+    assertEquals(entry.get("b"), "S2");
   }
 
   @Test
@@ -83,7 +83,7 @@ public class DContextEntryTest {
     entry.add(DContextEntryBean.of("S1", null, BeanEntry.SECONDARY));
     entry.add(DContextEntryBean.of("S2", "b", BeanEntry.SECONDARY));
 
-    assertEquals(entry.candidate("b").getBean(), "S2");
+    assertEquals(entry.get("b"), "S2");
   }
 
   @Test
@@ -93,6 +93,6 @@ public class DContextEntryTest {
     entry.add(DContextEntryBean.of("S1", null, BeanEntry.PRIMARY));
     entry.add(DContextEntryBean.of("S2", "b", BeanEntry.SECONDARY));
 
-    assertEquals(entry.candidate("b").getBean(), "S2");
+    assertEquals(entry.get("b"), "S2");
   }
 }


### PR DESCRIPTION
This is an API breaking change which is unfortunate but I think this is for the best in terms of long term.