### PR TITLE
Opps, use build_ prefix for reading meta data annotations from build methods

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
@@ -242,7 +242,7 @@ public class Processor extends AbstractProcessor {
 
   private void readBuildMethodDependencyMeta(Element element) {
     Name simpleName = element.getSimpleName();
-    if (simpleName.toString().startsWith("build")) {
+    if (simpleName.toString().startsWith("build_")) {
       // read a build method - DependencyMeta
       DependencyMeta meta = element.getAnnotation(DependencyMeta.class);
       if (meta == null) {


### PR DESCRIPTION
To avoid "Missing @DependencyMeta on method build" error on partial rebuild