### PR TITLE
 #140 - Are scope requirements meant to be transitive?

### DIFF
--- a/inject-generator/pom.xml
+++ b/inject-generator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-inject-parent</artifactId>
-    <version>6.5</version>
+    <version>6.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>avaje-inject-generator</artifactId>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
-      <version>6.5</version>
+      <version>6.6-SNAPSHOT</version>
     </dependency>
 
     <!-- test dependencies -->

--- a/inject-generator/src/main/java/io/avaje/inject/generator/AllScopes.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/AllScopes.java
@@ -64,8 +64,17 @@ class AllScopes {
       if (jfo != null) {
         Writer writer = jfo.openWriter();
         for (Data value : scopeAnnotations.values()) {
-          writer.write(value.moduleFullName());
-          writer.write("\n");
+          final String moduleFullName = value.moduleFullName();
+          if (moduleFullName == null) {
+            // an empty module, custom scope with no beans
+            final TypeElement typeElement = value.annotationType();
+            if (typeElement != null) {
+              context.logWarn("Empty module for "+typeElement);
+            }
+          } else {
+            writer.write(moduleFullName);
+            writer.write("\n");
+          }
         }
         writer.close();
       }
@@ -119,6 +128,10 @@ class AllScopes {
 
     String moduleFullName() {
       return scopeInfo.moduleFullName();
+    }
+
+    TypeElement annotationType() {
+      return scopeInfo.annotationType();
     }
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -52,6 +52,14 @@ class ScopeInfo {
     this.annotationType = type;
   }
 
+  @Override
+  public String toString() {
+    return "ScopeInfo{" +
+      "name=" + name +
+      ", metaData=" + metaData +
+      '}';
+  }
+
   void details(String name, Element contextElement) {
     if (name == null || name.isEmpty()) {
       final String simpleName = contextElement.getSimpleName().toString();
@@ -83,6 +91,10 @@ class ScopeInfo {
       moduleFullName = modulePackage + "." + moduleShortName;
       moduleFile = context.createWriter(moduleFullName);
     }
+  }
+
+  TypeElement annotationType() {
+    return annotationType;
   }
 
   JavaFileObject moduleFile() {
@@ -267,7 +279,7 @@ class ScopeInfo {
     writer.append("@InjectModule(");
     boolean leadingComma = false;
     if (!provides.isEmpty()) {
-      attributeClasses(leadingComma, writer, "provides", provides);
+      attributeClasses(false, writer, "provides", provides);
       leadingComma = true;
     }
     if (!requires.isEmpty()) {
@@ -357,7 +369,7 @@ class ScopeInfo {
       final ScopeInfo requiredScope = scopes.get(require);
       if (requiredScope != null) {
         if (requiredScope.providesDependency(dependency)) {
-          // context.logWarn("dependency "+dependency+" provided by other scope "+requiredScope.name);
+          // context.logWarn("dependency " + dependency + " provided by other scope " + requiredScope.name);
           return true;
         }
       }
@@ -369,6 +381,9 @@ class ScopeInfo {
    * Return true if this module provides the dependency.
    */
   boolean providesDependency(String dependency) {
+    if (requires.contains(dependency)) {
+      return true;
+    }
     for (MetaData meta : metaData.values()) {
       if (dependency.equals(meta.getType())) {
         return true;

--- a/inject-test/pom.xml
+++ b/inject-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-inject-parent</artifactId>
-    <version>6.5</version>
+    <version>6.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>avaje-inject-test</artifactId>

--- a/inject-test/src/test/java/org/example/customext0/Ext0Other.java
+++ b/inject-test/src/test/java/org/example/customext0/Ext0Other.java
@@ -1,0 +1,6 @@
+package org.example.customext0;
+
+@Ext0Scope
+public class Ext0Other {
+
+}

--- a/inject-test/src/test/java/org/example/customext0/Ext0Scope.java
+++ b/inject-test/src/test/java/org/example/customext0/Ext0Scope.java
@@ -1,0 +1,9 @@
+package org.example.customext0;
+
+import io.avaje.inject.InjectModule;
+import jakarta.inject.Scope;
+
+@Scope
+@InjectModule(requires = {Ext0iface.class, Ext0conc.class})
+public @interface Ext0Scope {
+}

--- a/inject-test/src/test/java/org/example/customext0/Ext0ScopeTest.java
+++ b/inject-test/src/test/java/org/example/customext0/Ext0ScopeTest.java
@@ -1,0 +1,26 @@
+package org.example.customext0;
+
+import io.avaje.inject.BeanScope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Ext0ScopeTest {
+
+  @Test
+  void wire() {
+
+    final BeanScope scope = BeanScope.newBuilder()
+      .withBean(Ext0iface.class, new If0())
+      .withBean(Ext0conc.class, new Ext0conc())
+      .withModules(new Ext0Module())
+      .build();
+
+    final Ext0Other other = scope.get(Ext0Other.class);
+    assertThat(other).isNotNull();
+  }
+
+  static class If0 implements Ext0iface {
+
+  }
+}

--- a/inject-test/src/test/java/org/example/customext0/Ext0conc.java
+++ b/inject-test/src/test/java/org/example/customext0/Ext0conc.java
@@ -1,0 +1,4 @@
+package org.example.customext0;
+
+public class Ext0conc {
+}

--- a/inject-test/src/test/java/org/example/customext0/Ext0iface.java
+++ b/inject-test/src/test/java/org/example/customext0/Ext0iface.java
@@ -1,0 +1,4 @@
+package org.example.customext0;
+
+public interface Ext0iface {
+}

--- a/inject-test/src/test/java/org/example/customext1/Ext1Bean.java
+++ b/inject-test/src/test/java/org/example/customext1/Ext1Bean.java
@@ -1,0 +1,43 @@
+package org.example.customext1;
+
+import org.example.customext0.Ext0Other;
+import org.example.customext0.Ext0conc;
+import org.example.customext0.Ext0iface;
+
+@Ext1Scope
+public class Ext1Bean {
+
+  final Ext0iface ext0iface;
+  final Ext0conc ext0conc;
+  final Ext0Other ext0Other;
+  final Ext1iface ext1iface;
+  final Ext1conc ext1conc;
+
+  public Ext1Bean(Ext0iface ext0iface, Ext0conc ext0conc, Ext0Other ext0Other, Ext1iface ext1iface, Ext1conc ext1conc) {
+    this.ext0iface = ext0iface;
+    this.ext0conc = ext0conc;
+    this.ext0Other = ext0Other;
+    this.ext1iface = ext1iface;
+    this.ext1conc = ext1conc;
+  }
+
+  public Ext0iface ext0iface() {
+    return ext0iface;
+  }
+
+  public Ext0conc ext0conc() {
+    return ext0conc;
+  }
+
+  public Ext0Other ext0Other() {
+    return ext0Other;
+  }
+
+  public Ext1iface ext1iface() {
+    return ext1iface;
+  }
+
+  public Ext1conc ext1conc() {
+    return ext1conc;
+  }
+}

--- a/inject-test/src/test/java/org/example/customext1/Ext1Scope.java
+++ b/inject-test/src/test/java/org/example/customext1/Ext1Scope.java
@@ -1,0 +1,10 @@
+package org.example.customext1;
+
+import io.avaje.inject.InjectModule;
+import jakarta.inject.Scope;
+import org.example.customext0.Ext0Scope;
+
+@Scope
+@InjectModule(requires = {Ext0Scope.class, Ext1iface.class, Ext1conc.class})
+public @interface Ext1Scope {
+}

--- a/inject-test/src/test/java/org/example/customext1/Ext1ScopeTest.java
+++ b/inject-test/src/test/java/org/example/customext1/Ext1ScopeTest.java
@@ -1,0 +1,75 @@
+package org.example.customext1;
+
+import io.avaje.inject.BeanScope;
+import org.example.customext0.Ext0Other;
+import org.example.customext0.Ext0conc;
+import org.example.customext0.Ext0iface;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class Ext1ScopeTest {
+
+/*
+  Unfortunately with both modules in test-classes plus this test it can not compile.
+  So this wireParentChild() works when scopes are in src/main (and the test here in src/test).
+
+  @Test
+  void wireParentChild() {
+
+    final BeanScope parentScope = BeanScope.newBuilder()
+      .withBean(Ext0iface.class, new If0())
+      .withBean(Ext0conc.class, new Ext0conc())
+      .withModules(new Ext0Module())
+      .build();
+
+    final BeanScope scope = BeanScope.newBuilder()
+      .withBean(Ext1iface.class, new If1())
+      .withBean(Ext1conc.class, new Ext1conc())
+      .withModules(new Ext1Module())
+      .withParent(parentScope)
+      .build();
+
+    final Ext1Bean ext1Bean = scope.get(Ext1Bean.class);
+    assertThat(ext1Bean).isNotNull();
+
+    assertNotNull(ext1Bean.ext0iface());
+    assertNotNull(ext1Bean.ext0conc());
+    assertNotNull(ext1Bean.ext0Other());
+    assertNotNull(ext1Bean.ext1iface());
+    assertNotNull(ext1Bean.ext1conc());
+  }
+*/
+
+  @Test
+  void wireBoth() {
+
+    // wire everything using only Ext1Module so simulating
+    // Ext0Module via external dependencies
+    final BeanScope scope = BeanScope.newBuilder()
+      .withBean(Ext0iface.class, new If0())
+      .withBean(Ext0conc.class, new Ext0conc())
+      .withBean(Ext0Other.class, new Ext0Other())
+      .withBean(Ext1iface.class, new If1())
+      .withBean(Ext1conc.class, new Ext1conc())
+      .withModules(new Ext1Module()) //new Ext0Module(),
+      .build();
+
+    final Ext1Bean ext1Bean = scope.get(Ext1Bean.class);
+    assertThat(ext1Bean).isNotNull();
+
+    assertNotNull(ext1Bean.ext0iface());
+    assertNotNull(ext1Bean.ext0conc());
+    assertNotNull(ext1Bean.ext0Other());
+    assertNotNull(ext1Bean.ext1iface());
+    assertNotNull(ext1Bean.ext1conc());
+  }
+
+  static class If0 implements Ext0iface {
+
+  }
+  static class If1 implements Ext1iface {
+
+  }
+}

--- a/inject-test/src/test/java/org/example/customext1/Ext1conc.java
+++ b/inject-test/src/test/java/org/example/customext1/Ext1conc.java
@@ -1,0 +1,4 @@
+package org.example.customext1;
+
+public class Ext1conc {
+}

--- a/inject-test/src/test/java/org/example/customext1/Ext1iface.java
+++ b/inject-test/src/test/java/org/example/customext1/Ext1iface.java
@@ -1,0 +1,4 @@
+package org.example.customext1;
+
+public interface Ext1iface {
+}

--- a/inject/pom.xml
+++ b/inject/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-inject-parent</artifactId>
-    <version>6.5</version>
+    <version>6.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>avaje-inject</artifactId>

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -200,6 +200,8 @@ class DBuilder implements Builder {
       if (!beanList.isEmpty()) {
         msg += ". Check @Named or Qualifier being used";
       }
+      msg += ". Check for missing module? [ missing beanScopeBuilder.withModules() ]";
+      msg += ". If it is expected to be externally provided, missing beanScopeBuilder.withBean() ?";
       throw new IllegalStateException(msg);
     }
     return bean;

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>io.avaje</groupId>
   <artifactId>avaje-inject-parent</artifactId>
-  <version>6.5</version>
+  <version>6.6-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>avaje inject parent</name>
   <description>parent pom for avaje inject library</description>
@@ -20,7 +20,7 @@
   </scm>
 
   <properties>
-    <nexus.staging.autoReleaseAfterClose>false</nexus.staging.autoReleaseAfterClose>
+    <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
   </properties>
 
   <modules>


### PR DESCRIPTION
If a scope depends on a parent scope and that parent scope has
external dependencies - then the scope should also be able to
depend on those external dependencies.

Ultimately the fix for this is in ScopeInfo.providesDependency()
adding in the check to see if the dependency is in requires
(is an external dependency of the scope).

