### PR TITLE
Now doesn't fail compilation on nullable types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@ build/
 .idea/
 *.iml
 .gradle
+*.prefs
+*.class*
+*.factorypath
+*.project
+*.processors
+*/bin/
+*.editorconfig
+*.Module

--- a/inject-generator/src/main/java/io/avaje/inject/generator/FieldReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/FieldReader.java
@@ -22,6 +22,8 @@ class FieldReader {
     this.utype = Util.determineType(element.asType());
     this.fieldType = Util.unwrapProvider(utype.rawType());
     this.type = GenericType.parse(utype.rawType());
+    if (nullable || element.asType().toString().startsWith("java.util.Optional<"))
+      ProcessingContext.getOptionalTypes().add(fieldType);
   }
 
   boolean isGenericParam() {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
@@ -17,11 +17,13 @@ class MetaDataOrdering {
   private final Map<String, ProviderList> providers = new HashMap<>();
   private final List<DependencyLink> circularDependencies = new ArrayList<>();
   private final Set<String> missingDependencyTypes = new LinkedHashSet<>();
+  private final Set<String> optionalTypes;
 
   MetaDataOrdering(Collection<MetaData> values, ProcessingContext context, ScopeInfo scopeInfo) {
     this.context = context;
     this.scopeInfo = scopeInfo;
-    for (MetaData metaData : values) {
+    this.optionalTypes = ProcessingContext.getOptionalTypes();
+    for (final MetaData metaData : values) {
       if (metaData.noDepends()) {
         orderedList.add(metaData);
         metaData.setWired();
@@ -120,9 +122,11 @@ class MetaDataOrdering {
   }
 
   private void checkMissingDependencies(MetaData metaData) {
-    for (Dependency dependency : metaData.getDependsOn()) {
-      if (providers.get(dependency.getName()) == null && !scopeInfo.providedByOtherModule(dependency.getName())) {
-        TypeElement element = context.elementMaybe(metaData.getType());
+    for (final Dependency dependency : metaData.getDependsOn()) {
+      if (providers.get(dependency.getName()) == null
+          && !scopeInfo.providedByOtherModule(dependency.getName())
+          && !optionalTypes.contains(dependency.getName())) {
+        final var element = context.elementMaybe(metaData.getType());
         context.logError(element, "No dependency provided for " + dependency + " on " + metaData.getType());
         missingDependencyTypes.add(dependency.getName());
       }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -327,6 +327,8 @@ class MethodReader {
       this.utilType = Util.determineType(param.asType());
       this.paramType = utilType.rawType();
       this.genericType = GenericType.parse(paramType);
+      if (nullable || param.asType().toString().startsWith("java.util.Optional<"))
+        ProcessingContext.getOptionalTypes().add(paramType);
     }
 
     @Override

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -1,17 +1,5 @@
 package io.avaje.inject.generator;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.LineNumberReader;
-import java.io.Reader;
-import java.nio.file.NoSuchFileException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.FilerException;
 import javax.annotation.processing.Messager;
@@ -25,6 +13,12 @@ import javax.tools.Diagnostic;
 import javax.tools.FileObject;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.LineNumberReader;
+import java.io.Reader;
+import java.nio.file.NoSuchFileException;
+import java.util.*;
 
 class ProcessingContext {
 
@@ -64,7 +58,7 @@ class ProcessingContext {
   }
 
   String loadMetaInfServices() {
-    final var lines = loadMetaInf(Constants.META_INF_MODULE);
+    final List<String> lines = loadMetaInf(Constants.META_INF_MODULE);
     return lines.isEmpty() ? null : lines.get(0);
   }
 
@@ -74,11 +68,11 @@ class ProcessingContext {
 
   private List<String> loadMetaInf(String fullName) {
     try {
-      final var fileObject = processingEnv.getFiler().getResource(StandardLocation.CLASS_OUTPUT, "", fullName);
+      FileObject fileObject = processingEnv.getFiler().getResource(StandardLocation.CLASS_OUTPUT, "", fullName);
       if (fileObject != null) {
-        final List<String> lines = new ArrayList<>();
-        final var reader = fileObject.openReader(true);
-        final var lineReader = new LineNumberReader(reader);
+        List<String> lines = new ArrayList<>();
+        Reader reader = fileObject.openReader(true);
+        LineNumberReader lineReader = new LineNumberReader(reader);
         String line;
         while ((line = lineReader.readLine()) != null) {
           line = line.trim();
@@ -92,10 +86,10 @@ class ProcessingContext {
     } catch (FileNotFoundException | NoSuchFileException e) {
       // logDebug("no services file yet");
 
-    } catch (final FilerException e) {
+    } catch (FilerException e) {
       logDebug("FilerException reading services file");
 
-    } catch (final Exception e) {
+    } catch (Exception e) {
       e.printStackTrace();
       logWarn("Error reading services file: " + e.getMessage());
     }
@@ -110,7 +104,7 @@ class ProcessingContext {
   }
 
   FileObject createMetaInfWriter(ScopeInfo.Type scopeType) throws IOException {
-    final var serviceName = scopeType == ScopeInfo.Type.DEFAULT ? Constants.META_INF_MODULE : Constants.META_INF_TESTMODULE;
+    String serviceName = scopeType == ScopeInfo.Type.DEFAULT ? Constants.META_INF_MODULE : Constants.META_INF_TESTMODULE;
     return createMetaInfWriterFor(serviceName);
   }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -1,5 +1,17 @@
 package io.avaje.inject.generator;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.LineNumberReader;
+import java.io.Reader;
+import java.nio.file.NoSuchFileException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.FilerException;
 import javax.annotation.processing.Messager;
@@ -13,12 +25,6 @@ import javax.tools.Diagnostic;
 import javax.tools.FileObject;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.LineNumberReader;
-import java.io.Reader;
-import java.nio.file.NoSuchFileException;
-import java.util.*;
 
 class ProcessingContext {
 
@@ -28,6 +34,7 @@ class ProcessingContext {
   private final Elements elementUtils;
   private final Types typeUtils;
   private final Set<String> uniqueModuleNames = new HashSet<>();
+  private static final Set<String> optionalTypes = new LinkedHashSet<>();
 
   ProcessingContext(ProcessingEnvironment processingEnv) {
     this.processingEnv = processingEnv;
@@ -57,7 +64,7 @@ class ProcessingContext {
   }
 
   String loadMetaInfServices() {
-    final List<String> lines = loadMetaInf(Constants.META_INF_MODULE);
+    final var lines = loadMetaInf(Constants.META_INF_MODULE);
     return lines.isEmpty() ? null : lines.get(0);
   }
 
@@ -67,11 +74,11 @@ class ProcessingContext {
 
   private List<String> loadMetaInf(String fullName) {
     try {
-      FileObject fileObject = processingEnv.getFiler().getResource(StandardLocation.CLASS_OUTPUT, "", fullName);
+      final var fileObject = processingEnv.getFiler().getResource(StandardLocation.CLASS_OUTPUT, "", fullName);
       if (fileObject != null) {
-        List<String> lines = new ArrayList<>();
-        Reader reader = fileObject.openReader(true);
-        LineNumberReader lineReader = new LineNumberReader(reader);
+        final List<String> lines = new ArrayList<>();
+        final var reader = fileObject.openReader(true);
+        final var lineReader = new LineNumberReader(reader);
         String line;
         while ((line = lineReader.readLine()) != null) {
           line = line.trim();
@@ -85,10 +92,10 @@ class ProcessingContext {
     } catch (FileNotFoundException | NoSuchFileException e) {
       // logDebug("no services file yet");
 
-    } catch (FilerException e) {
+    } catch (final FilerException e) {
       logDebug("FilerException reading services file");
 
-    } catch (Exception e) {
+    } catch (final Exception e) {
       e.printStackTrace();
       logWarn("Error reading services file: " + e.getMessage());
     }
@@ -103,7 +110,7 @@ class ProcessingContext {
   }
 
   FileObject createMetaInfWriter(ScopeInfo.Type scopeType) throws IOException {
-    String serviceName = scopeType == ScopeInfo.Type.DEFAULT ? Constants.META_INF_MODULE : Constants.META_INF_TESTMODULE;
+    final var serviceName = scopeType == ScopeInfo.Type.DEFAULT ? Constants.META_INF_MODULE : Constants.META_INF_TESTMODULE;
     return createMetaInfWriterFor(serviceName);
   }
 
@@ -141,4 +148,7 @@ class ProcessingContext {
     return uniqueModuleNames.contains(moduleFullName);
   }
 
+  public static Set<String> getOptionalTypes() {
+    return optionalTypes;
+  }
 }


### PR DESCRIPTION
Now will work as expected when there is no module that provides the Optional/Nullable Bean.

- Adds a static set to ProcessingContext that we can use to keep track of nullable/optional types
- Update Field and Method Readers to add the bean type to the set when @Nullable or Optional Type is detected

Fixes #244 