### PR TITLE
Use different classloader for ServiceLoader

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -11,13 +11,14 @@ import java.util.Set;
  * <p>
  * When we depend on these types they add to the module autoRequires() classes.
  */
-final class ExternalProvide {
+final class ExternalProvider {
 
   private final Set<String> providedTypes = new HashSet<>();
 
   void init() {
-    for (Module module : ServiceLoader.load(Module.class)) {
-      for (Class<?> provide : module.provides()) {
+    for (final Module module :
+        ServiceLoader.load(Module.class, ExternalProvider.class.getClassLoader())) {
+      for (final Class<?> provide : module.provides()) {
         providedTypes.add(provide.getCanonicalName());
       }
       for (Class<?> provide : module.autoProvides()) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -28,7 +28,7 @@ final class ProcessingContext {
   private final Elements elementUtils;
   private final Types typeUtils;
   private final Set<String> uniqueModuleNames = new HashSet<>();
-  private final ExternalProvide externalProvide = new ExternalProvide();
+  private final ExternalProvider externalProvide = new ExternalProvider();
 
   ProcessingContext(ProcessingEnvironment processingEnv) {
     this.processingEnv = processingEnv;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
@@ -53,8 +53,8 @@ public final class Processor extends AbstractProcessor {
    * on these types and the only thing providing them is the plugin.
    */
   private void registerPluginProvidedTypes() {
-    for (Plugin plugin : ServiceLoader.load(Plugin.class)) {
-      for (Class<?> provide : plugin.provides()) {
+    for (final Plugin plugin : ServiceLoader.load(Plugin.class, Processor.class.getClassLoader())) {
+      for (final Class<?> provide : plugin.provides()) {
         defaultScope.pluginProvided(provide.getCanonicalName());
       }
     }


### PR DESCRIPTION
ServiceLoader uses `Thread.currentThread().getContextClassLoader()` when a ClassLoader is not specified which cannot see the META-INF\services files of the project/dependencies. This PR fixes that.