### PR TITLE
Now Aspect Targets are Added to AutoProvides

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -400,13 +400,6 @@ final class ScopeInfo {
     }
   }
 
-  void buildAutoProvidesAspects(Append writer, Set<String> autoProvidesAspects) {
-    autoProvidesAspects.removeAll(provides);
-    if (!autoProvidesAspects.isEmpty()) {
-      buildProvidesMethod(writer, "autoProvidesAspects", autoProvidesAspects);
-    }
-  }
-
   void buildAutoRequires(Append writer, Set<String> autoRequires) {
     autoRequires.removeAll(requires);
     if (!autoRequires.isEmpty()) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
@@ -1,14 +1,15 @@
 package io.avaje.inject.generator;
 
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.TypeElement;
-import javax.tools.FileObject;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.tools.FileObject;
 
 /**
  * Write the source code for the factory.
@@ -99,6 +100,9 @@ final class SimpleModuleWriter {
       if (forExternal != null && !forExternal.isEmpty()) {
         if (Util.isAspectProvider(forExternal)) {
           autoProvidesAspects.add(Util.extractAspectType(forExternal));
+          context
+              .getAspectTarget(forExternal)
+              .ifPresent(autoProvides::add);
         } else if (!forExternal.contains("<")) {
           autoProvides.add(forExternal);
         }
@@ -107,10 +111,8 @@ final class SimpleModuleWriter {
     if (!autoProvides.isEmpty()) {
       scopeInfo.buildAutoProvides(writer, autoProvides);
     }
-    if (!autoProvidesAspects.isEmpty()) {
-      scopeInfo.buildAutoProvidesAspects(writer, autoProvidesAspects);
-    }
-    Set<String> autoRequires = ordering.autoRequires();
+ 
+    final var autoRequires = ordering.autoRequires();
     if (!autoRequires.isEmpty()) {
       scopeInfo.buildAutoRequires(writer, autoRequires);
     }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
@@ -92,17 +92,13 @@ final class SimpleModuleWriter {
   }
 
   private void writeProvides() {
-    Set<String> autoProvidesAspects = new TreeSet<>();
     Set<String> autoProvides = new TreeSet<>();
 
     for (MetaData metaData : ordering.ordered()) {
       String forExternal = metaData.autoProvides();
       if (forExternal != null && !forExternal.isEmpty()) {
         if (Util.isAspectProvider(forExternal)) {
-          autoProvidesAspects.add(Util.extractAspectType(forExternal));
-          context
-              .getAspectTarget(forExternal)
-              .ifPresent(autoProvides::add);
+          context.getAspectTarget(forExternal).ifPresent(autoProvides::add);
         } else if (!forExternal.contains("<")) {
           autoProvides.add(forExternal);
         }

--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -213,7 +213,6 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
       providesMap.computeIfAbsent(module.getClass().getTypeName(), s -> new FactoryList()).add(factoryState);
       addFactoryProvides(factoryState, module.provides());
       addFactoryProvides(factoryState, module.autoProvides());
-      addFactoryProvides(factoryState, module.autoProvidesAspects());
 
       if (factoryState.isRequiresEmpty()) {
         if (factoryState.explicitlyProvides()) {

--- a/inject/src/main/java/io/avaje/inject/aop/Aspect.java
+++ b/inject/src/main/java/io/avaje/inject/aop/Aspect.java
@@ -20,7 +20,7 @@ public @interface Aspect {
   /**
    * Specify the {@link AspectProvider} for this aspect.
    */
-  Class<?> target();
+  Class<? extends AspectProvider> target();
 
   /**
    * Specify the priority ordering when multiple aspects are on a method.

--- a/inject/src/main/java/io/avaje/inject/spi/Module.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Module.java
@@ -44,16 +44,6 @@ public interface Module {
   }
 
   /**
-   * Return the aspects that this module provides.
-   * <p>
-   * This is a convenience when using multiple modules that we otherwise manually specify via
-   * {@link InjectModule#provides()}.
-   */
-  default Class<?>[] autoProvidesAspects() {
-    return EMPTY_CLASSES;
-  }
-
-  /**
    * These are the classes that this module requires for wiring that are provided by other
    * external modules (that are in the classpath at compile time).
    * <p>


### PR DESCRIPTION
Now modules can auto-expose their aspect implementations for wiring.

- add method to ProcessingContext that can find the target AspectProvider class name
- Update SimpleModuleWriter to directly add aspect targets to autoProvides
- make @Aspect only accept classes that implement AspectProvider.
- remove buildAutoProvidesAspects method
- remove autoProvidesAspects