### PR TITLE
Refactor AutoProvides

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -25,7 +25,7 @@ import javax.tools.FileObject;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
 
-import io.avaje.inject.InjectModule.AutoProvideLevel;
+import io.avaje.inject.InjectModule.AutoProvideStrategy;
 
 final class ProcessingContext {
 
@@ -36,7 +36,7 @@ final class ProcessingContext {
   private final Types typeUtils;
   private final Set<String> uniqueModuleNames = new HashSet<>();
   private final ExternalProvider externalProvide = new ExternalProvider();
-  private AutoProvideLevel autoProvideLv;
+  private AutoProvideStrategy autoProvideStrategy;
 
   ProcessingContext(ProcessingEnvironment processingEnv) {
     this.processingEnv = processingEnv;
@@ -155,11 +155,11 @@ final class ProcessingContext {
     return externalProvide.provides(type);
   }
 
-  public void setAutoProvideLv(AutoProvideLevel autoProvideScope) {
-    this.autoProvideLv = autoProvideScope;
+  public void setAutoProvideStrategy(AutoProvideStrategy autoProvideScope) {
+    this.autoProvideStrategy = autoProvideScope;
   }
 
-  public AutoProvideLevel autoProvideLv() {
-    return autoProvideLv;
+  public AutoProvideStrategy autoProvideStrategy() {
+    return autoProvideStrategy;
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -1,5 +1,16 @@
 package io.avaje.inject.generator;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.LineNumberReader;
+import java.io.Reader;
+import java.nio.file.NoSuchFileException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.FilerException;
 import javax.annotation.processing.Messager;
@@ -13,12 +24,8 @@ import javax.tools.Diagnostic;
 import javax.tools.FileObject;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.LineNumberReader;
-import java.io.Reader;
-import java.nio.file.NoSuchFileException;
-import java.util.*;
+
+import io.avaje.inject.InjectModule.AutoProvideLevel;
 
 final class ProcessingContext {
 
@@ -29,6 +36,7 @@ final class ProcessingContext {
   private final Types typeUtils;
   private final Set<String> uniqueModuleNames = new HashSet<>();
   private final ExternalProvider externalProvide = new ExternalProvider();
+  private AutoProvideLevel autoProvideLv;
 
   ProcessingContext(ProcessingEnvironment processingEnv) {
     this.processingEnv = processingEnv;
@@ -145,5 +153,13 @@ final class ProcessingContext {
 
   boolean externallyProvided(String type) {
     return externalProvide.provides(type);
+  }
+
+  public void setAutoProvideLv(AutoProvideLevel autoProvideScope) {
+    this.autoProvideLv = autoProvideScope;
+  }
+
+  public AutoProvideLevel autoProvideLv() {
+    return autoProvideLv;
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
@@ -30,9 +30,6 @@ public final class Processor extends AbstractProcessor {
   private AllScopes allScopes;
   private boolean readModuleInfo;
 
-  public Processor() {
-  }
-
   @Override
   public SourceVersion getSupportedSourceVersion() {
     return SourceVersion.latest();
@@ -186,6 +183,7 @@ public final class Processor extends AbstractProcessor {
         // it it not a custom scope annotation
         InjectModule annotation = element.getAnnotation(InjectModule.class);
         if (annotation != null) {
+          context.setAutoProvideLv(annotation.autoProvideLv());
           defaultScope.details(annotation.name(), element);
         }
       }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
@@ -183,7 +183,7 @@ public final class Processor extends AbstractProcessor {
         // it it not a custom scope annotation
         InjectModule annotation = element.getAnnotation(InjectModule.class);
         if (annotation != null) {
-          context.setAutoProvideLv(annotation.autoProvideLv());
+          context.setAutoProvideStrategy(annotation.autoProvideStrategy());
           defaultScope.details(annotation.name(), element);
         }
       }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -52,7 +52,8 @@ final class TypeExtendsReader {
     } catch (final ClassNotFoundException e) {
       isController = false;
     }
-    return baseType.getAnnotation(Factory.class) == null
+    return !baseType.toString().startsWith("java.lang")
+        && baseType.getAnnotation(Factory.class) == null
         && baseType.getAnnotation(Proxy.class) == null
         && baseType.getAnnotation(Generated.class) == null
         && !isController

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -26,7 +26,7 @@ final class TypeExtendsReader {
   private final List<String> providesTypes = new ArrayList<>();
   private final String beanSimpleName;
   private final String baseTypeRaw;
-  private final boolean dontAutoProvide;
+  private final boolean autoProvide;
   private boolean closeable;
   /** The implied qualifier name based on naming convention. */
   private String qualifierName;
@@ -38,24 +38,23 @@ final class TypeExtendsReader {
     this.extendsInjection = new TypeExtendsInjection(baseType, context, factory, importTypes);
     this.beanSimpleName = baseType.getSimpleName().toString();
     this.baseTypeRaw = Util.unwrapProvider(baseGenericType.toString());
-
-    this.dontAutoProvide = autoProvide();
+    this.autoProvide = autoProvide();
   }
 
   private boolean autoProvide() {
 
-    boolean controller;
+    boolean isController;
 
     try {
-      final var c = (Class<Annotation>) Class.forName(Constants.CONTROLLER);
-      controller = baseType.getAnnotation(c) != null;
+      isController =
+          baseType.getAnnotation((Class<Annotation>) Class.forName(Constants.CONTROLLER)) != null;
     } catch (final ClassNotFoundException e) {
       controller = false;
     }
-    return baseType.getAnnotation(Factory.class) != null
-        || baseType.getAnnotation(Proxy.class) != null
-        || controller
-        || !context
+    return baseType.getAnnotation(Factory.class) == null
+        && baseType.getAnnotation(Proxy.class) == null
+        && !isController
+        && context
             .element(Util.trimGenerics(baseTypeRaw))
             .getModifiers()
             .contains(Modifier.PUBLIC);
@@ -99,7 +98,7 @@ final class TypeExtendsReader {
 
   String autoProvides() {
 
-    if (dontAutoProvide) {
+    if (!autoProvide) {
       return null;
     }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -10,6 +10,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 
 import io.avaje.inject.Factory;
+import io.avaje.inject.spi.Generated;
 import io.avaje.inject.spi.Proxy;
 
 /** Read the inheritance types for a given bean type. */
@@ -53,11 +54,9 @@ final class TypeExtendsReader {
     }
     return baseType.getAnnotation(Factory.class) == null
         && baseType.getAnnotation(Proxy.class) == null
+        && baseType.getAnnotation(Generated.class) == null
         && !isController
-        && context
-            .element(Util.trimGenerics(baseTypeRaw))
-            .getModifiers()
-            .contains(Modifier.PUBLIC);
+        && context.element(Util.trimGenerics(baseTypeRaw)).getModifiers().contains(Modifier.PUBLIC);
   }
 
   GenericType baseType() {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -104,27 +104,13 @@ final class TypeExtendsReader {
     }
 
     if (!interfaceTypes.isEmpty()) {
-      for (var i = 0; i <= interfaceTypes.size(); i++) {
 
-        final var superType = interfaceTypes.get(i);
-
-        if (context.element(Util.trimGenerics(superType)).getModifiers().contains(Modifier.PUBLIC))
-          return superType;
-      }
-      return null;
+      return interfaceTypes.get(0);
     }
 
     if (!extendsTypes.isEmpty()) {
 
-      for (var i = extendsTypes.size() - 1; i >= 0; i--) {
-
-        final var superType = extendsTypes.get(i);
-
-        if (context.element(Util.trimGenerics(superType)).getModifiers().contains(Modifier.PUBLIC))
-          return superType;
-      }
-
-      return null;
+      return extendsTypes.get(extendsTypes.size()-1);
     }
 
     return baseTypeRaw;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -10,7 +10,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 
 import io.avaje.inject.Factory;
-import io.avaje.inject.InjectModule.AutoProvideLevel;
+import io.avaje.inject.InjectModule.AutoProvideStrategy;
 import io.avaje.inject.spi.Generated;
 import io.avaje.inject.spi.Proxy;
 
@@ -35,7 +35,7 @@ final class TypeExtendsReader {
    */
   private String qualifierName;
 
-  private final AutoProvideLevel autoProvideLv;
+  private final AutoProvideStrategy autoProvideLv;
 
   TypeExtendsReader(
       GenericType baseGenericType,
@@ -49,7 +49,7 @@ final class TypeExtendsReader {
     this.extendsInjection = new TypeExtendsInjection(baseType, context, factory, importTypes);
     this.beanSimpleName = baseType.getSimpleName().toString();
     this.baseTypeRaw = Util.unwrapProvider(baseGenericType.toString());
-    this.autoProvideLv = context.autoProvideLv();
+    this.autoProvideLv = context.autoProvideStrategy();
     this.autoProvide = autoProvide();
   }
 
@@ -64,7 +64,7 @@ final class TypeExtendsReader {
       isController = false;
     }
 
-    return autoProvideLv != AutoProvideLevel.NONE
+    return autoProvideLv != AutoProvideStrategy.NONE
         && baseType.getAnnotation(Factory.class) == null
         && baseType.getAnnotation(Proxy.class) == null
         && baseType.getAnnotation(Generated.class) == null
@@ -113,7 +113,7 @@ final class TypeExtendsReader {
     if (!autoProvide) {
       return null;
 
-    } else if (autoProvideLv == AutoProvideLevel.ALL) {
+    } else if (autoProvideLv == AutoProvideStrategy.ALL) {
 
       return interfaceTypes.stream().filter(Util::isAspectProvider).findFirst().orElse(baseTypeRaw);
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -49,7 +49,7 @@ final class TypeExtendsReader {
       isController =
           baseType.getAnnotation((Class<Annotation>) Class.forName(Constants.CONTROLLER)) != null;
     } catch (final ClassNotFoundException e) {
-      controller = false;
+      isController = false;
     }
     return baseType.getAnnotation(Factory.class) == null
         && baseType.getAnnotation(Proxy.class) == null

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -16,6 +16,7 @@ import io.avaje.inject.spi.Proxy;
 final class TypeExtendsReader {
 
   private static final String JAVA_LANG_OBJECT = "java.lang.Object";
+  private static final String JAVA_LANG_RECORD = "java.lang.Record";
   private final GenericType baseGenericType;
   private final TypeElement baseType;
   private final ProcessingContext context;
@@ -148,6 +149,7 @@ final class TypeExtendsReader {
     String fullName = element.getQualifiedName().toString();
     if (!fullName.equals(JAVA_LANG_OBJECT)) {
       String type = Util.unwrapProvider(fullName);
+    if (!JAVA_LANG_OBJECT.equals(fullName) || !JAVA_LANG_RECORD.equals(fullName)) {
       if (isPublic(element)) {
         extendsTypes.add(type);
         extendsInjection.read(element);

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -111,7 +111,7 @@ final class TypeExtendsReader {
       return extendsTypes.get(extendsTypes.size() - 1);
     }
 
-    return baseTypeRaw;
+    return null;
   }
 
   List<String> provides() {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -110,7 +110,7 @@ final class TypeExtendsReader {
 
     if (!extendsTypes.isEmpty()) {
 
-      return extendsTypes.get(extendsTypes.size()-1);
+      return extendsTypes.get(extendsTypes.size() - 1);
     }
 
     return baseTypeRaw;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -111,7 +111,7 @@ final class TypeExtendsReader {
       return extendsTypes.get(extendsTypes.size() - 1);
     }
 
-    return null;
+    return baseTypeRaw;
   }
 
   List<String> provides() {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -52,8 +52,7 @@ final class TypeExtendsReader {
     } catch (final ClassNotFoundException e) {
       isController = false;
     }
-    return !baseType.toString().startsWith("java.lang")
-        && baseType.getAnnotation(Factory.class) == null
+    return baseType.getAnnotation(Factory.class) == null
         && baseType.getAnnotation(Proxy.class) == null
         && baseType.getAnnotation(Generated.class) == null
         && !isController

--- a/inject/src/main/java/io/avaje/inject/InjectModule.java
+++ b/inject/src/main/java/io/avaje/inject/InjectModule.java
@@ -60,13 +60,19 @@ public @interface InjectModule {
   Class<?>[] provides() default {};
 
   /**
-   * The dependencies that are provided externally or by other modules and that are required
-   * when wiring this module.
-   * <p>
-   * This effectively tells the annotation processor that these types are expected to be
-   * provided and to not treat them as missing dependencies. If we don't do this the annotation
-   * processor thinks the dependency is missing and will error the compilation saying there is
-   * a missing dependency.
+   * Set autoprovide strategy. By default will only expose the top level interfaces/classes to other
+   * modules
+   */
+  AutoProvideLevel autoProvideLv() default AutoProvideLevel.TOP_LEVEL_CLASSES;
+
+  /**
+   * The dependencies that are provided externally or by other modules and that are required when
+   * wiring this module.
+   *
+   * <p>This effectively tells the annotation processor that these types are expected to be provided
+   * and to not treat them as missing dependencies. If we don't do this the annotation processor
+   * thinks the dependency is missing and will error the compilation saying there is a missing
+   * dependency.
    */
   Class<?>[] requires() default {};
 
@@ -89,4 +95,13 @@ public @interface InjectModule {
    */
   String customScopeType() default "";
 
+  public enum AutoProvideLevel {
+
+    /** Autoprovide only the top level interfaces/classes of this modules beans. */
+    TOP_LEVEL_CLASSES,
+    /** Autoprovide all the beans of this module as they are defined. */
+    ALL,
+    /** Disable AutoProvide. */
+    NONE
+  }
 }

--- a/inject/src/main/java/io/avaje/inject/InjectModule.java
+++ b/inject/src/main/java/io/avaje/inject/InjectModule.java
@@ -63,7 +63,7 @@ public @interface InjectModule {
    * Set autoprovide strategy. By default will only expose the top level interfaces/classes to other
    * modules
    */
-  AutoProvideLevel autoProvideLv() default AutoProvideLevel.TOP_LEVEL_CLASSES;
+  AutoProvideStrategy autoProvideStrategy() default AutoProvideStrategy.TOP_LEVEL_CLASSES;
 
   /**
    * The dependencies that are provided externally or by other modules and that are required when
@@ -95,13 +95,13 @@ public @interface InjectModule {
    */
   String customScopeType() default "";
 
-  public enum AutoProvideLevel {
+  public enum AutoProvideStrategy {
 
-    /** Autoprovide only the top level interfaces/classes of this modules beans. */
+    /** Auto provide only the top level interfaces/classes of this module's beans. */
     TOP_LEVEL_CLASSES,
-    /** Autoprovide all the beans of this module as they are defined. */
+    /** Auto provide all the beans of this module as they are defined. */
     ALL,
-    /** Disable AutoProvide. */
+    /** Disable Auto Provide. */
     NONE
   }
 }


### PR DESCRIPTION
Now we can control what beans get auto-provided through `@InjectModules`.

- adds new parameter to `@InjectModules` to control auto provide strategy
- adds  strategy to get all top level interfaces/classes
- adds  strategy to get all beans as they are defined (Was talking to a dev that was trying to autoprovide a customized ObjectMapper, but got the technically true but useless `Versioned` interface )
- adds strategy to not autoprovide at all.