### PR TITLE
Add Aspect Auto Requires

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/AspectAnnotationReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/AspectAnnotationReader.java
@@ -31,7 +31,7 @@ final class AspectAnnotationReader {
       if (aspect != null) {
         Meta meta = readTarget(anElement);
         if (meta != null) {
-          aspects.add(new AspectPair(anElement, meta.target, meta.ordering));
+          aspects.add(new AspectPair(anElement, meta.ordering));
         }
       }
     }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/AspectMethod.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/AspectMethod.java
@@ -107,10 +107,10 @@ final class AspectMethod {
   }
 
   void writeSetupFields(Append writer) {
-    writer.append("  private Method %s;", localName).eol();
+    writer.append("  private final Method %s;", localName).eol();
     for (AspectPair aspectPair : aspectPairs) {
       String sn = aspectPair.annotationShortName();
-      writer.append("  private MethodInterceptor %s%s;", localName, sn).eol();
+      writer.append("  private final MethodInterceptor %s%s;", localName, sn).eol();
     }
   }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/AspectPair.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/AspectPair.java
@@ -4,24 +4,18 @@ import javax.lang.model.element.Element;
 
 final class AspectPair implements Comparable<AspectPair> {
 
-  private final String target;
   private final int ordering;
   private final String annotationFullName;
   private final String annotationShortName;
 
-  AspectPair(Element anElement, String target, int ordering) {
-    this.target = target;
+  AspectPair(Element anElement, int ordering) {
     this.ordering = ordering;
     this.annotationFullName = anElement.asType().toString();
     this.annotationShortName = Util.shortName(annotationFullName);
   }
 
-  String target() {
-    return target;
-  }
-
   void addImports(ImportTypeMap importTypes) {
-    importTypes.add("io.avaje.inject.aop.AspectProvider");
+    importTypes.add(Constants.ASPECT_PROVIDER);
     importTypes.add(annotationFullName);
   }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
@@ -33,6 +33,7 @@ final class Constants {
 
   static final String REFLECT_METHOD = "java.lang.reflect.Method";
   static final String ASPECT = "io.avaje.inject.aop.Aspect";
+  static final String ASPECT_PROVIDER ="io.avaje.inject.aop.AspectProvider";
   static final String INVOCATION = "io.avaje.inject.aop.Invocation";
   static final String INVOCATION_EXCEPTION = "io.avaje.inject.aop.InvocationException";
   static final String METHOD_INTERCEPTOR = "io.avaje.inject.aop.MethodInterceptor";

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -21,8 +21,11 @@ final class ExternalProvider {
       for (final Class<?> provide : module.provides()) {
         providedTypes.add(provide.getCanonicalName());
       }
-      for (Class<?> provide : module.autoProvides()) {
+      for (final Class<?> provide : module.autoProvides()) {
         providedTypes.add(provide.getCanonicalName());
+      }
+      for (final Class<?> provide : module.autoProvidesAspects()) {
+        providedTypes.add(Constants.ASPECT_PROVIDER + "<" + provide.getCanonicalName() + ">");
       }
     }
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -414,6 +414,13 @@ final class ScopeInfo {
     }
   }
 
+  void buildAutoRequiresAspects(Append writer, Set<String> autoRequires) {
+    autoRequires.removeAll(requires);
+    if (!autoRequires.isEmpty()) {
+      buildProvidesMethod(writer, "autoRequiresAspects", autoRequires);
+    }
+  }
+
   void readModuleMetaData(TypeElement moduleType) {
     InjectModule module = moduleType.getAnnotation(InjectModule.class);
     details(module.name(), moduleType);

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
@@ -114,6 +114,11 @@ final class SimpleModuleWriter {
     if (!autoRequires.isEmpty()) {
       scopeInfo.buildAutoRequires(writer, autoRequires);
     }
+
+    Set<String> autoRequiresAspects = ordering.autoRequiresAspects();
+    if (!autoRequires.isEmpty()) {
+      scopeInfo.buildAutoRequiresAspects(writer, autoRequiresAspects);
+    }
   }
 
   private void writeClassesMethod() {

--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -338,13 +338,27 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
      */
     private boolean satisfiedDependencies(FactoryState factory) {
       return satisfiedDependencies(factory.requires())
-        && satisfiedDependencies(factory.requiresPackages())
-        && satisfiedDependencies(factory.autoRequires());
+          && satisfiedDependencies(factory.requiresPackages())
+          && satisfiedAspectDependencies(factory.autoRequiresAspects())
+          && satisfiedDependencies(factory.autoRequires());
     }
 
     private boolean satisfiedDependencies(Class<?>[] requires) {
-      for (Class<?> dependency : requires) {
-        if (notProvided(dependency.getTypeName())) {
+      for (final Class<?> dependency : requires) {
+          if (notProvided(dependency.getTypeName())) {
+              return false;
+            }
+      }
+      return true;
+    }
+
+    private boolean satisfiedAspectDependencies(Class<?>[] requiresAspects) {
+      for (final Class<?> dependency : requiresAspects) {
+
+        if (notProvided(
+            "interface io.avaje.inject.aop.AspectProvider<"
+                + dependency.getCanonicalName()
+                + ">")) {
           return false;
         }
       }
@@ -393,6 +407,10 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
 
     Class<?>[] autoRequires() {
       return factory.autoRequires();
+    }
+
+    Class<?>[] autoRequiresAspects() {
+      return factory.autoRequiresAspects();
     }
 
     @Override

--- a/inject/src/main/java/io/avaje/inject/spi/Module.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Module.java
@@ -63,6 +63,17 @@ public interface Module {
   default Class<?>[] autoRequires() {
     return EMPTY_CLASSES;
   }
+  /**
+   * These are the classes that this module requires for wiring that are provided by other external
+   * modules (that are in the classpath at compile time).
+   *
+   * <p>This is a convenience when using multiple modules that is otherwise controlled manually by
+   * explicitly using {@link InjectModule#requires()} or {@link InjectModule#requiresPackages()}.
+   */
+
+  default Class<?>[] autoRequiresAspects() {
+    return EMPTY_CLASSES;
+  }
 
   /**
    * Return public classes of the beans that would be registered by this module.

--- a/inject/src/main/java/io/avaje/inject/spi/Module.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Module.java
@@ -10,7 +10,7 @@ public interface Module {
   /**
    * Empty array of classes.
    */
-  Class<?>[] EMPTY_CLASSES = new Class<?>[]{};
+  Class<?>[] EMPTY_CLASSES = {};
 
   /**
    * Return the set of types this module explicitly provides to other modules.
@@ -64,13 +64,10 @@ public interface Module {
     return EMPTY_CLASSES;
   }
   /**
-   * These are the classes that this module requires for wiring that are provided by other external
+   * These are the apects that this module requires whose implementations are provided by other external
    * modules (that are in the classpath at compile time).
    *
-   * <p>This is a convenience when using multiple modules that is otherwise controlled manually by
-   * explicitly using {@link InjectModule#requires()} or {@link InjectModule#requiresPackages()}.
    */
-
   default Class<?>[] autoRequiresAspects() {
     return EMPTY_CLASSES;
   }


### PR DESCRIPTION
Now modules can automatically provide aspects for use in other modules without directly exposing the underlying aspect target.

- Modifies the ExternalProvider to read the `autoProvidesAspects` from loaded modules
- adds `autoRequiresAspects` to Module Class
- updates DBeanScopeBuilder to read the autoRequiresAspects and use it for module ordering.

Fixes #269 (nice)

Now that I consider it, do we even need the target field in the `@Aspect` annotation anymore?