### PR TITLE
Inject is no longer an optional dependency for generators

### DIFF
--- a/inject-generator/pom.xml
+++ b/inject-generator/pom.xml
@@ -18,8 +18,6 @@
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
       <version>${project.version}</version>
-      <optional>true</optional>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This would actually fix the #281 issue with Jsonb. Though we still need to create a grade plugin for non-annotation processor dependencies