### PR TITLE
To make Plugins support both jakarta and javax versions we need to use Supplier

### DIFF
--- a/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
@@ -7,6 +7,7 @@ import jakarta.inject.Provider;
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Build a bean scope with options for shutdown hook and supplying external dependencies.
@@ -207,6 +208,17 @@ public interface BeanScopeBuilder {
   <D> BeanScopeBuilder bean(Type type, D bean);
 
   /**
+   * Deprecated - migrate to use Supplier rather than Provider.
+   * <p>
+   * Doing this deprecation so that plugins can be used with both the jakarta and javax versions of avaje-inject
+   * so we need to use Supplier instead of Provider.
+   */
+  @Deprecated
+  default <D> BeanScopeBuilder provideDefault(Type type, Provider<D> provider) {
+    return provideDefault(null, type, provider::get);
+  }
+
+  /**
    * Add a supplied bean provider that acts as a default fallback for a dependency.
    * <p>
    * This provider is only called if nothing else provides the dependency. It effectively
@@ -215,7 +227,7 @@ public interface BeanScopeBuilder {
    * @param type     The type of the dependency
    * @param provider The provider of the dependency.
    */
-  default <D> BeanScopeBuilder provideDefault(Type type, Provider<D> provider) {
+  default <D> BeanScopeBuilder provideDefault(Type type, Supplier<D> provider) {
     return provideDefault(null, type, provider);
   }
 
@@ -229,7 +241,7 @@ public interface BeanScopeBuilder {
    * @param type     The type of the dependency
    * @param provider The provider of the dependency.
    */
-  <D> BeanScopeBuilder provideDefault(@Nullable String name, Type type, Provider<D> provider);
+  <D> BeanScopeBuilder provideDefault(@Nullable String name, Type type, Supplier<D> provider);
 
   /**
    * Deprecated - migrate to bean().

--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -11,6 +11,7 @@ import java.lang.System.Logger.Level;
 import java.lang.reflect.Type;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Build a bean scope with options for shutdown hook and supplying test doubles.
@@ -83,7 +84,8 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
   }
 
   @Override
-  public <D> BeanScopeBuilder provideDefault(String name, Type type, Provider<D> provider) {
+  public <D> BeanScopeBuilder provideDefault(String name, Type type, Supplier<D> supplier) {
+    final Provider<D> provider = supplier::get;
     suppliedBeans.add(SuppliedBean.secondary(name, type, provider));
     return this;
   }

--- a/inject/src/main/java/io/avaje/inject/spi/Plugin.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Plugin.java
@@ -8,7 +8,7 @@ import java.lang.reflect.Type;
 /**
  * A Plugin that can be applied when creating a bean scope.
  * <p>
- * Typically, a plugin might provide a default dependency via {@link BeanScopeBuilder#provideDefault(Type, Provider)}.
+ * Typically, a plugin might provide a default dependency via {@link BeanScopeBuilder#provideDefault(Type, java.util.function.Supplier)}.
  */
 public interface Plugin {
 


### PR DESCRIPTION
Change BeanScopeBuilder.provideDefault() to use Supplier rather than Provider as then the Plugin implementation is tied to either the jakarta or javax version it is compiled against.