### PR TITLE
Bump test dependency avaje-jsonb to 1.3-RC2 to support both javax and jakarta

### DIFF
--- a/blackbox-test-inject/pom.xml
+++ b/blackbox-test-inject/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-jsonb</artifactId>
-      <version>1.2-RC2</version>
+      <version>1.3-RC2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Prior to this avaje-jsonb only supported the jakarta version of avaje-inject