### PR TITLE
Remove Format Plugin

### DIFF
--- a/inject-maven-plugin/pom.xml
+++ b/inject-maven-plugin/pom.xml
@@ -36,21 +36,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.spotify.fmt</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.19</version>
-        <configuration>
-          <skipSortingImports>true</skipSortingImports>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>format</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
         <version>3.7.1</version>


### PR DESCRIPTION
looks like the format plugin was the cause of the EA failures, in any case, the code is already formatted fine so we can toss it.