### PR TITLE
Remove Deprecated Methods

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/aspect/MyBefore.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/aspect/MyBefore.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Aspect(target = MyBeforeAspect.class)
+@Aspect
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MyBefore {

--- a/blackbox-test-inject/src/main/java/org/example/myapp/aspect/MyMultiInvoke.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/aspect/MyMultiInvoke.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Aspect(target = MyMultiInvokeAspect.class)
+@Aspect
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MyMultiInvoke {

--- a/blackbox-test-inject/src/main/java/org/example/myapp/aspect/MySkip.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/aspect/MySkip.java
@@ -10,7 +10,7 @@ import java.lang.annotation.Target;
 /**
  * Test for Aspect that sets result and never invokes underlying method.
  */
-@Aspect(target = MySkipAspect.class)
+@Aspect
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MySkip {

--- a/blackbox-test-inject/src/main/java/org/example/myapp/aspect/MyThrowing.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/aspect/MyThrowing.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Aspect(target = MyThrowingAspect.class)
+@Aspect
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MyThrowing {

--- a/blackbox-test-inject/src/main/java/org/example/myapp/aspect/MyTimed.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/aspect/MyTimed.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Aspect(target = MyTimedAspect.class, ordering = 2000)
+@Aspect(ordering = 2000)
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MyTimed {

--- a/blackbox-test-inject/src/main/java/org/example/myapp/resilience4j/MyRetry.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/resilience4j/MyRetry.java
@@ -5,8 +5,8 @@ import io.avaje.inject.aop.Aspect;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+@Aspect
 @Retention(RetentionPolicy.RUNTIME)
-@Aspect(target = RetryProvider.class)
 public @interface MyRetry {
 
   String fallbackMethod() default "";

--- a/inject-generator/src/main/java/io/avaje/inject/generator/FieldReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/FieldReader.java
@@ -14,14 +14,16 @@ final class FieldReader {
   private final GenericType type;
   private boolean requestParam;
   private String requestParamName;
+  private final boolean isBeanMap;
 
   FieldReader(Element element) {
     this.element = element;
     this.name = Util.getNamed(element);
     this.nullable = Util.isNullable(element);
     this.utype = Util.determineType(element.asType());
-    this.fieldType = Util.unwrapProvider(utype.rawType());
-    this.type = GenericType.parse(utype.rawType());
+    this.isBeanMap = QualifiedMapPrism.isPresent(element);
+    this.fieldType = Util.unwrapProvider(utype.rawType(isBeanMap));
+    this.type = GenericType.parse(utype.rawType(isBeanMap));
   }
 
   boolean isGenericParam() {
@@ -44,7 +46,7 @@ final class FieldReader {
 
   String builderGetDependency(String builder) {
     StringBuilder sb = new StringBuilder();
-    sb.append(builder).append(".").append(utype.getMethod(nullable));
+    sb.append(builder).append(".").append(utype.getMethod(nullable, isBeanMap));
     if (isGenericParam()) {
       sb.append("TYPE_").append(type.shortName());
     } else {
@@ -65,9 +67,9 @@ final class FieldReader {
    * Check for request scoped dependency.
    */
   void checkRequest(BeanRequestParams requestParams) {
-    requestParam = requestParams.check(utype.rawType());
+    requestParam = requestParams.check(utype.rawType(isBeanMap));
     if (requestParam) {
-      requestParamName = requestParams.argumentName(utype.rawType());
+      requestParamName = requestParams.argumentName(utype.rawType(isBeanMap));
     }
   }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -342,13 +342,15 @@ final class MethodReader {
     private final String simpleName;
     private boolean requestParam;
     private String requestParamName;
+    private final boolean isBeanMap;
 
     MethodParam(VariableElement param) {
       this.simpleName = param.getSimpleName().toString();
       this.named = Util.getNamed(param);
       this.nullable = Util.isNullable(param);
       this.utilType = Util.determineType(param.asType());
-      this.paramType = utilType.rawType();
+      this.isBeanMap = QualifiedMapPrism.isPresent(param);
+      this.paramType = utilType.rawType(isBeanMap);
       this.genericType = GenericType.parse(paramType);
       this.fullGenericType = GenericType.parse(utilType.full());
     }
@@ -365,7 +367,7 @@ final class MethodReader {
     }
 
     void builderGetDependency(Append writer, String builderName, boolean forFactory) {
-      writer.append(builderName).append(".").append(utilType.getMethod(nullable));
+      writer.append(builderName).append(".").append(utilType.getMethod(nullable, isBeanMap));
       if (!genericType.isGenericType()) {
         writer.append(Util.shortName(genericType.topType())).append(".class");
       } else if (isProvider()) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/UtilType.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/UtilType.java
@@ -50,14 +50,17 @@ final class UtilType {
     return rawType;
   }
 
-  String rawType() {
+  String rawType(boolean beanMap) {
     switch (type) {
       case SET:
         return Util.extractSet(rawType);
       case LIST:
         return Util.extractList(rawType);
       case MAP:
-        return Util.extractMap(rawType);
+        if (beanMap) {
+          return Util.extractMap(rawType);
+        }
+        return rawType;
       case OPTIONAL:
         return Util.extractOptionalType(rawType);
       default:
@@ -65,14 +68,17 @@ final class UtilType {
     }
   }
 
-  String getMethod(boolean nullable) {
+  String getMethod(boolean nullable, boolean beanMap) {
     switch (type) {
       case SET:
         return "set(";
       case LIST:
         return "list(";
       case MAP:
-        return "map(";
+        if (beanMap) {
+          return "map(";
+        }
+        break;
       case OPTIONAL:
         return "getOptional(";
       case PROVIDER:

--- a/inject-generator/src/main/java/io/avaje/inject/generator/package-info.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/package-info.java
@@ -13,6 +13,7 @@
 @GeneratePrism(Proxy.class)
 @GeneratePrism(DependencyMeta.class)
 @GeneratePrism(Bean.class)
+@GeneratePrism(QualifiedMap.class)
 @GeneratePrism(Generated.class)
 package io.avaje.inject.generator;
 
@@ -22,6 +23,7 @@ import io.avaje.inject.Factory;
 import io.avaje.inject.InjectModule;
 import io.avaje.inject.Primary;
 import io.avaje.inject.Prototype;
+import io.avaje.inject.QualifiedMap;
 import io.avaje.inject.Secondary;
 import io.avaje.inject.aop.Aspect;
 import io.avaje.inject.spi.DependencyMeta;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/package-info.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/package-info.java
@@ -1,21 +1,19 @@
-@io.avaje.prism.GeneratePrisms({
-  @GeneratePrism(value = InjectModule.class),
-  @GeneratePrism(value = Factory.class),
-  @GeneratePrism(value = Singleton.class),
-  @GeneratePrism(value = Component.class),
-  @GeneratePrism(value = Prototype.class),
-  @GeneratePrism(value = Scope.class),
-  @GeneratePrism(value = Qualifier.class),
-  @GeneratePrism(value = Named.class),
-  @GeneratePrism(value = Inject.class),
-  @GeneratePrism(value = Aspect.class),
-  @GeneratePrism(value = Primary.class),
-  @GeneratePrism(value = Secondary.class),
-  @GeneratePrism(value = Proxy.class),
-  @GeneratePrism(value = DependencyMeta.class),
-  @GeneratePrism(value = Bean.class),
-  @GeneratePrism(value = io.avaje.inject.spi.Generated.class),
-})
+@GeneratePrism(InjectModule.class)
+@GeneratePrism(Factory.class)
+@GeneratePrism(Singleton.class)
+@GeneratePrism(Component.class)
+@GeneratePrism(Prototype.class)
+@GeneratePrism(Scope.class)
+@GeneratePrism(Qualifier.class)
+@GeneratePrism(Named.class)
+@GeneratePrism(Inject.class)
+@GeneratePrism(Aspect.class)
+@GeneratePrism(Primary.class)
+@GeneratePrism(Secondary.class)
+@GeneratePrism(Proxy.class)
+@GeneratePrism(DependencyMeta.class)
+@GeneratePrism(Bean.class)
+@GeneratePrism(Generated.class)
 package io.avaje.inject.generator;
 
 import io.avaje.inject.Bean;
@@ -27,6 +25,7 @@ import io.avaje.inject.Prototype;
 import io.avaje.inject.Secondary;
 import io.avaje.inject.aop.Aspect;
 import io.avaje.inject.spi.DependencyMeta;
+import io.avaje.inject.spi.Generated;
 import io.avaje.inject.spi.Proxy;
 import io.avaje.prism.GeneratePrism;
 import jakarta.inject.Inject;

--- a/inject-test/src/test/java/org/example/coffee/list/CombinedMapSomei.java
+++ b/inject-test/src/test/java/org/example/coffee/list/CombinedMapSomei.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import io.avaje.inject.QualifiedMap;
+
 @Singleton
 public class CombinedMapSomei {
 
@@ -17,7 +19,7 @@ public class CombinedMapSomei {
    * Inject map of beans keyed by qualifier name.
    */
   @Inject
-  public CombinedMapSomei(Map<String, Somei> somes) {
+  public CombinedMapSomei(@QualifiedMap Map<String, Somei> somes) {
     this.somes = somes;
   }
 

--- a/inject/src/main/java/io/avaje/inject/BeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/BeanScope.java
@@ -109,14 +109,6 @@ public interface BeanScope extends AutoCloseable {
   }
 
   /**
-   * Deprecated - migrate to builder().
-   */
-  @Deprecated
-  static BeanScopeBuilder newBuilder() {
-    return builder();
-  }
-
-  /**
    * Return a single bean given the type.
    *
    * <pre>{@code

--- a/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
@@ -56,14 +56,6 @@ public interface BeanScopeBuilder {
   BeanScopeBuilder shutdownHook(boolean shutdownHook);
 
   /**
-   * Deprecated - migrate to shutdownHook().
-   */
-  @Deprecated
-  default BeanScopeBuilder withShutdownHook(boolean shutdownHook) {
-    return shutdownHook(shutdownHook);
-  }
-
-  /**
    * Specify the modules to include in dependency injection.
    * <p>
    * Only beans related to the module are included in the BeanScope that is built.
@@ -86,14 +78,6 @@ public interface BeanScopeBuilder {
    * @return This BeanScopeBuilder
    */
   BeanScopeBuilder modules(Module... modules);
-
-  /**
-   * Deprecated - migrate to modules()
-   */
-  @Deprecated
-  default BeanScopeBuilder withModules(Module... modules) {
-    return modules(modules);
-  }
 
   /**
    * Supply a bean to the scope that will be used instead of any
@@ -125,14 +109,6 @@ public interface BeanScopeBuilder {
   BeanScopeBuilder beans(Object... beans);
 
   /**
-   * Deprecated - migrate to beans().
-   */
-  @Deprecated
-  default BeanScopeBuilder withBeans(Object... beans) {
-    return beans(beans);
-  }
-
-  /**
    * Add a supplied bean instance with the given injection type (typically an interface type).
    *
    * <pre>{@code
@@ -158,14 +134,6 @@ public interface BeanScopeBuilder {
   <D> BeanScopeBuilder bean(Class<D> type, D bean);
 
   /**
-   * Deprecated - migrate to bean().
-   */
-  @Deprecated
-  default <D> BeanScopeBuilder withBean(Class<D> type, D bean) {
-    return bean(type, bean);
-  }
-
-  /**
    * Add a supplied bean instance with the given name and injection type.
    *
    * @param name The name qualifier
@@ -173,14 +141,6 @@ public interface BeanScopeBuilder {
    * @param bean The supplied bean instance to use for injection
    */
   <D> BeanScopeBuilder bean(String name, Class<D> type, D bean);
-
-  /**
-   * Deprecated - migrate to bean().
-   */
-  @Deprecated
-  default <D> BeanScopeBuilder withBean(String name, Class<D> type, D bean) {
-    return bean(name, type, bean);
-  }
 
   /**
    * Add a supplied bean instance with the given name and generic type.
@@ -192,31 +152,12 @@ public interface BeanScopeBuilder {
   <D> BeanScopeBuilder bean(String name, Type type, D bean);
 
   /**
-   * Deprecated - migrate to bean().
-   */
-  @Deprecated
-  default <D> BeanScopeBuilder withBean(String name, Type type, D bean) {
-    return bean(name, type, bean);
-  }
-
-  /**
    * Add a supplied bean instance with a generic type.
    *
    * @param type The dependency injection type this bean is target for
    * @param bean The supplied bean instance to use for injection
    */
   <D> BeanScopeBuilder bean(Type type, D bean);
-
-  /**
-   * Deprecated - migrate to use Supplier rather than Provider.
-   * <p>
-   * Doing this deprecation so that plugins can be used with both the jakarta and javax versions of avaje-inject
-   * so we need to use Supplier instead of Provider.
-   */
-  @Deprecated
-  default <D> BeanScopeBuilder provideDefault(Type type, Provider<D> provider) {
-    return provideDefault(null, type, provider::get);
-  }
 
   /**
    * Add a supplied bean provider that acts as a default fallback for a dependency.
@@ -244,14 +185,6 @@ public interface BeanScopeBuilder {
   <D> BeanScopeBuilder provideDefault(@Nullable String name, Type type, Supplier<D> provider);
 
   /**
-   * Deprecated - migrate to bean().
-   */
-  @Deprecated
-  default <D> BeanScopeBuilder withBean(Type type, D bean) {
-    return bean(type, bean);
-  }
-
-  /**
    * Set the ClassLoader to use when loading modules.
    *
    * @param classLoader The ClassLoader to use
@@ -265,14 +198,6 @@ public interface BeanScopeBuilder {
    * @param parent The BeanScope that acts as the parent
    */
   BeanScopeBuilder parent(BeanScope parent);
-
-  /**
-   * Deprecated - migrate to parent().
-   */
-  @Deprecated
-  default BeanScopeBuilder withParent(BeanScope parent) {
-    return parent(parent);
-  }
 
   /**
    * Use the given BeanScope as the parent additionally specifying if beans
@@ -290,14 +215,6 @@ public interface BeanScopeBuilder {
    *                       When true add beans regardless of whether they exist in the parent scope.
    */
   BeanScopeBuilder parent(BeanScope parent, boolean parentOverride);
-
-  /**
-   * Deprecated - migrate to parent().
-   */
-  @Deprecated
-  default BeanScopeBuilder withParent(BeanScope parent, boolean parentOverride) {
-    return parent(parent, parentOverride);
-  }
 
   /**
    * Extend the builder to support testing using mockito with
@@ -349,14 +266,6 @@ public interface BeanScopeBuilder {
     BeanScopeBuilder.ForTesting mock(Class<?> type);
 
     /**
-     * Deprecated - migrate to mock().
-     */
-    @Deprecated
-    default BeanScopeBuilder.ForTesting withMock(Class<?> type) {
-      return mock(type);
-    }
-
-    /**
      * Register as a Mockito mock with a qualifier name.
      *
      * <pre>{@code
@@ -373,14 +282,6 @@ public interface BeanScopeBuilder {
      * }</pre>
      */
     BeanScopeBuilder.ForTesting mock(Class<?> type, String name);
-
-    /**
-     * Deprecated - migrate to mock().
-     */
-    @Deprecated
-    default BeanScopeBuilder.ForTesting withMock(Class<?> type, String name) {
-      return mock(type, name);
-    }
 
     /**
      * Use a mockito mock when injecting this bean type additionally
@@ -412,14 +313,6 @@ public interface BeanScopeBuilder {
     <D> BeanScopeBuilder.ForTesting mock(Class<D> type, Consumer<D> consumer);
 
     /**
-     * Deprecated - migrate to mock().
-     */
-    @Deprecated
-    default <D> BeanScopeBuilder.ForTesting withMock(Class<D> type, Consumer<D> consumer) {
-      return mock(type, consumer);
-    }
-
-    /**
      * Use a mockito spy when injecting this bean type.
      *
      * <pre>{@code
@@ -446,14 +339,6 @@ public interface BeanScopeBuilder {
     BeanScopeBuilder.ForTesting spy(Class<?> type);
 
     /**
-     * Deprecated - migrate to spy().
-     */
-    @Deprecated
-    default BeanScopeBuilder.ForTesting withSpy(Class<?> type) {
-      return spy(type);
-    }
-
-    /**
      * Register a Mockito spy with a qualifier name.
      *
      * <pre>{@code
@@ -470,15 +355,6 @@ public interface BeanScopeBuilder {
      * }</pre>
      */
     BeanScopeBuilder.ForTesting spy(Class<?> type, String name);
-
-    /**
-     * Deprecated - migrate to spy().
-     */
-    @Deprecated
-    default BeanScopeBuilder.ForTesting withSpy(Class<?> type, String name) {
-      return spy(type, name);
-    }
-
     /**
      * Use a mockito spy when injecting this bean type additionally
      * running setup on the spy instance.
@@ -508,14 +384,5 @@ public interface BeanScopeBuilder {
      * }</pre>
      */
     <D> BeanScopeBuilder.ForTesting spy(Class<D> type, Consumer<D> consumer);
-
-    /**
-     * Deprecated - migrate to spy().
-     */
-    @Deprecated
-    default <D> BeanScopeBuilder.ForTesting withSpy(Class<D> type, Consumer<D> consumer) {
-      return spy(type, consumer);
-    }
-
   }
 }

--- a/inject/src/main/java/io/avaje/inject/QualifiedMap.java
+++ b/inject/src/main/java/io/avaje/inject/QualifiedMap.java
@@ -1,0 +1,29 @@
+package io.avaje.inject;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks an <code>Map&lt;String, T&gt; </code> field/parameter to receive a map of beans keyed
+ * by qualifier name.
+ *
+ * <pre>{@code
+ * class CrewMate {
+ *
+ *   private final Map<String, Tasks> taskMap;
+ *
+ *   @Inject
+ *   CrewMate(@QualifiedMap Map&lt;String, Tasks&gt taskMap) {
+ *     this.taskMap = taskMap;
+ *   }
+ *
+ * }
+ * }</pre>
+ */
+@Target({PARAMETER, FIELD})
+@Retention(RUNTIME)
+public @interface QualifiedMap {}

--- a/inject/src/main/java/io/avaje/inject/aop/Aspect.java
+++ b/inject/src/main/java/io/avaje/inject/aop/Aspect.java
@@ -18,12 +18,6 @@ import java.lang.annotation.Target;
 public @interface Aspect {
 
   /**
-   * Deprecated - the target() attribute is no longer required and should be removed.
-   */
-  @Deprecated
-  Class<?> target() default Void.class;
-
-  /**
    * Specify the priority ordering when multiple aspects are on a method.
    * <p>
    * When multiple aspects are on a method they are nested. The highest


### PR DESCRIPTION
If we're bumping major versions, let's remove the deprecated stuff.

Deprecated methods removed are:

```java

 public @interface Aspect {

  /**
   * Deprecated - the target() attribute is no longer required and should be removed.
   */
  @Deprecated
  Class<?> target() default Void.class;

```
```java
  /**
   * Deprecated - migrate to builder().
   */
  @Deprecated
  static BeanScopeBuilder newBuilder()
```
```java
  /**
   * Deprecated - migrate to shutdownHook().
   */
  @Deprecated
  default BeanScopeBuilder withShutdownHook(boolean shutdownHook)
```
```java
  /**
   * Deprecated - migrate to modules()
   */
  @Deprecated
  default BeanScopeBuilder withModules(Module... modules)
```
```java
  /**
   * Deprecated - migrate to bean().
   */
  @Deprecated
  default <D> BeanScopeBuilder withBean(Class<D> type, D bean)
```
```java
 /**
   * Deprecated - migrate to bean().
   */
  @Deprecated
  default <D> BeanScopeBuilder withBean(String name, Class<D> type, D bean)
```
```java
  /**
   * Deprecated - migrate to bean().
   */
  @Deprecated
  default <D> BeanScopeBuilder withBean(String name, Type type, D bean) 
```
```java
  /**
   * Deprecated - migrate to use Supplier rather than Provider.
   * <p>
   * Doing this deprecation so that plugins can be used with both the jakarta and javax versions of avaje-inject
   * so we need to use Supplier instead of Provider.
   */
  @Deprecated
  default <D> BeanScopeBuilder provideDefault(Type type, Provider<D> provider) 
```
```java
  /**
   * Deprecated - migrate to bean().
   */
  @Deprecated
  default <D> BeanScopeBuilder withBean(Type type, D bean)

```
```java
  /**
   * Deprecated - migrate to parent().
   */
  @Deprecated
  default BeanScopeBuilder withParent(BeanScope parent)
```
```java
  /**
   * Deprecated - migrate to parent().
   */
  @Deprecated
  default BeanScopeBuilder withParent(BeanScope parent, boolean parentOverride)
```
```java
  /**
   * Deprecated - migrate to mock().
   */
  @Deprecated
  default BeanScopeBuilder.ForTesting withMock(Class<?> type)
```
```java
  /**
   * Deprecated - migrate to spy().
   */
  @Deprecated
  default BeanScopeBuilder.ForTesting withSpy(Class<?> type)
```