### PR TITLE
Return all qualified beans from BeanScope map method

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/UtilType.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/UtilType.java
@@ -58,7 +58,12 @@ final class UtilType {
         return Util.extractList(rawType);
       case MAP:
         if (beanMap) {
-          return Util.extractMap(rawType);
+          var listType = Util.extractMap(rawType);
+          if (!listType.startsWith("java.util.List<")) {
+            throw new IllegalStateException(
+                "Qualified Maps must be in the form Map<String, List<T>>");
+          }
+          return Util.extractList(listType);
         }
         return rawType;
       case OPTIONAL:

--- a/inject-test/src/test/java/org/example/coffee/list/CombinedMapSomei.java
+++ b/inject-test/src/test/java/org/example/coffee/list/CombinedMapSomei.java
@@ -13,13 +13,13 @@ import io.avaje.inject.QualifiedMap;
 @Singleton
 public class CombinedMapSomei {
 
-  private final Map<String, Somei> somes;
+  private final Map<String, List<Somei>> somes;
 
   /**
    * Inject map of beans keyed by qualifier name.
    */
   @Inject
-  public CombinedMapSomei(@QualifiedMap Map<String, Somei> somes) {
+  public CombinedMapSomei(@QualifiedMap Map<String, List<Somei>> somes) {
     this.somes = somes;
   }
 
@@ -29,7 +29,8 @@ public class CombinedMapSomei {
 
   public List<String> someVals() {
     return somes.values().stream()
-      .map(Somei::some)
-      .collect(Collectors.toList());
+        .flatMap(List::stream)
+        .map(Somei::some)
+        .collect(Collectors.toList());
   }
 }

--- a/inject-test/src/test/java/org/example/coffee/qualifier/StoreManagerWithNamedTest.java
+++ b/inject-test/src/test/java/org/example/coffee/qualifier/StoreManagerWithNamedTest.java
@@ -4,6 +4,7 @@ import io.avaje.inject.BeanScope;
 import org.example.autonamed.MyAutoB2;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,15 +20,15 @@ class StoreManagerWithNamedTest {
 
       SomeStore greenStore = beanScope.get(SomeStore.class, "green");
       SomeStore blueStore = beanScope.get(SomeStore.class, "blue");
-      Map<String, SomeStore> stores = beanScope.map(SomeStore.class);
+      Map<String, List<SomeStore>> stores = beanScope.map(SomeStore.class);
 
-      SomeStore green = stores.get("green");
+      SomeStore green = stores.get("green").get(0);
       assertThat(green).isSameAs(greenStore);
-      SomeStore blue = stores.get("blue");
+      SomeStore blue = stores.get("blue").get(0);
       assertThat(blue).isSameAs(blueStore);
 
       // a map with unnamed component
-      Map<String, MyAutoB2> mapWithUnnamed = beanScope.map(MyAutoB2.class);
+      var mapWithUnnamed = beanScope.map(MyAutoB2.class);
       assertThat(mapWithUnnamed).hasSize(1);
     }
   }

--- a/inject/src/main/java/io/avaje/inject/BeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/BeanScope.java
@@ -1,13 +1,13 @@
 package io.avaje.inject;
 
-import io.avaje.lang.NonNullApi;
-import io.avaje.lang.Nullable;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import io.avaje.lang.NonNullApi;
+import io.avaje.lang.Nullable;
 
 /**
  * Holds beans created by dependency injection.
@@ -220,7 +220,7 @@ public interface BeanScope extends AutoCloseable {
    * <p>
    * Beans with no qualifier name get a generated unique key to use instead.
    */
-  <T> Map<String, T> map(Type type);
+  <T> Map<String, List<T>> map(Type type);
 
   /**
    * Return all the bean entries from the scope.

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -223,12 +223,12 @@ public interface Builder {
   /**
    * Return a map of dependencies for the type keyed by qualifier name.
    */
-  <T> Map<String, T> map(Class<T> type);
+  <T> Map<String, List<T>> map(Class<T> type);
 
   /**
    * Return a map of dependencies for the generic type keyed by qualifier name.
    */
-  <T> Map<String, T> map(Type type);
+  <T> Map<String, List<T>> map(Type type);
 
   /**
    * Build and return the bean scope.

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
@@ -120,16 +120,16 @@ final class DBeanMap {
   /**
    * Return a map of bean instances keyed by qualifier name.
    */
-  Map<String, Object> map(Type type, BeanScope parent) {
+ <T> Map<String, List<T>> map(Type type, BeanScope parent) {
     if (parent == null) {
       return map(type);
     }
-    Map<String, Object> result = parent.map(type);
+    Map<String, List<T>> result = parent.map(type);
     result.putAll(map(type));
     return result;
   }
 
-  private Map<String, Object> map(Type type) {
+  private <T> Map<String, List<T>> map(Type type) {
     DContextEntry entry = beans.get(type.getTypeName());
     return entry != null ? entry.map() : Collections.emptyMap();
   }

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
@@ -137,8 +137,8 @@ final class DBeanScope implements BeanScope {
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> Map<String, T> map(Type type) {
-    return (Map<String, T>) beans.map(type, parent);
+  public <T> Map<String, List<T>> map(Type type) {
+    return beans.map(type, parent);
   }
 
   @Override

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScopeProxy.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScopeProxy.java
@@ -127,7 +127,7 @@ final class DBeanScopeProxy implements BeanScope {
   }
 
   @Override
-  public <T> Map<String, T> map(Type type) {
+  public <T> Map<String, List<T>> map(Type type) {
 
     if (delegate != null) {
       return delegate.map(type);

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -126,12 +126,12 @@ class DBuilder implements Builder {
   }
 
   @Override
-  public final <T> Map<String, T> map(Class<T> type) {
+  public final <T> Map<String, List<T>> map(Class<T> type) {
     return mapOf(type);
   }
 
   @Override
-  public final <T> Map<String, T> map(Type type) {
+  public final <T> Map<String, List<T>> map(Type type) {
     return mapOf(type);
   }
 

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
@@ -64,18 +64,17 @@ final class DContextEntry {
     return list;
   }
 
-  /**
-   * Return a map of beans keyed by qualifier name.
-   */
-  Map<String, Object> map() {
-    Map<String, Object> map = new LinkedHashMap<>();
+  /** Return a map of beans keyed by qualifier name. */
+  @SuppressWarnings("unchecked")
+  <T> Map<String, List<T>> map() {
+    Map<String, List<T>> map = new LinkedHashMap<>();
     for (DContextEntryBean entry : entries) {
       Object bean = entry.bean();
       String nm = entry.name();
       if (nm == null) {
         nm = "$Unnamed-" + System.identityHashCode(bean) + "-" + bean;
       }
-      map.put(nm, bean);
+      map.computeIfAbsent(nm, k -> new ArrayList<>()).add((T) bean);
     }
     return map;
   }

--- a/inject/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
+++ b/inject/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
@@ -300,7 +300,7 @@ class BeanScopeBuilderTest {
     }
 
     @Override
-    public <T> Map<String, T> map(Type type) {
+    public <T> Map<String, List<T>> map(Type type) {
       return Collections.emptyMap();
     }
 


### PR DESCRIPTION
Before the map didn't actually contain all the qualified beans. (say you had an interface and wanted to get all the implementations annotated with a @Qualifier annotation, it wouldn't work)

Fixes #289 (because you can get the list of qualified beans from a qualified map)
