### PR TITLE
ProxyBeanScope Can Call `listByAnnotation` While Scope is Being Built

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -99,10 +99,7 @@ final class BeanReader {
     if (constructor != null) {
       for (MethodReader.MethodParam param : constructor.params()) {
         Dependency dependsOn = param.dependsOn();
-        // BeanScope is always injectable with no impact on injection ordering
-        if (!dependsOn.dependsOn().equals(Constants.BEANSCOPE)) {
-          list.add(dependsOn);
-        }
+        list.add(dependsOn);
       }
     }
     return list;

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -1,14 +1,15 @@
 package io.avaje.inject.spi;
 
-import io.avaje.inject.BeanScope;
-import jakarta.inject.Provider;
-
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+
+import io.avaje.inject.BeanScope;
+import jakarta.inject.Provider;
 
 /**
  * Mutable builder object used when building a bean scope.
@@ -209,6 +210,11 @@ public interface Builder {
    * Get a list of dependencies for the generic type.
    */
   <T> List<T> list(Type type);
+
+  /**
+   * Return the list of beans that have an annotation. The annotation must have a @Retention policy of RUNTIME
+   */
+  List<Object> listByAnnotation(Class<? extends Annotation> annotation);
 
   /**
    * Get a set of dependencies for the type.

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Map of types (class types, interfaces and annotations) to a DContextEntry where the
@@ -115,6 +116,14 @@ final class DBeanMap {
   List<Object> all(Type type) {
     DContextEntry entry = beans.get(type.getTypeName());
     return entry != null ? entry.all() : Collections.emptyList();
+  }
+
+  List<DContextEntryBean> all() {
+	  
+    return beans.values().stream()
+        .map(DContextEntry::entries)
+        .flatMap(List::stream)
+        .collect(Collectors.toList());
   }
 
   /**

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScopeProxy.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScopeProxy.java
@@ -82,8 +82,7 @@ final class DBeanScopeProxy implements BeanScope {
     if (delegate != null) {
       return delegate.listByAnnotation(annotation);
     } else {
-      throw new IllegalStateException(
-          "Proxy BeanScope can't use listByAnnotation while scope is being built");
+      return builder.listByAnnotation(annotation);
     }
   }
 

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -4,9 +4,11 @@ import io.avaje.inject.BeanEntry;
 import io.avaje.inject.BeanScope;
 import jakarta.inject.Provider;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static io.avaje.inject.spi.DBeanScope.combine;
 
@@ -114,6 +116,19 @@ class DBuilder implements Builder {
   @Override
   public final <T> List<T> list(Type type) {
     return listOf(type);
+  }
+
+  @Override
+  public List<Object> listByAnnotation(Class<? extends Annotation> annotation) {
+    final List<Object> values =
+        beanMap.all().stream()
+            .filter(entry -> entry.entry().type().isAnnotationPresent(annotation))
+            .map(DContextEntryBean::bean)
+            .collect(Collectors.toList());
+    if (parent == null) {
+      return values;
+    }
+    return combine(values, parent.listByAnnotation(annotation));
   }
 
   @SuppressWarnings({"unchecked"})


### PR DESCRIPTION
- Modify proxy scope to support listByAnnnotaion while scope is being built
- change the ordering of beans that require `BeanScope` (Will try to order as late as possible so that using the proxy scope is more useful)