### PR TITLE
Auto add nullable beans to auto-requires/Fix Proxy not writing `@Nullable`

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/FieldReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/FieldReader.java
@@ -25,7 +25,7 @@ final class FieldReader {
     this.fieldType = Util.unwrapProvider(utype.rawType(isBeanMap));
     this.type = GenericType.parse(utype.rawType(isBeanMap));
     if (nullable || element.asType().toString().startsWith("java.util.Optional<"))
-      ProcessingContext.getOptionalTypes().add(fieldType);
+      ProcessingContext.addOptionalType(fieldType);
   }
 
   boolean isGenericParam() {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/FieldReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/FieldReader.java
@@ -24,6 +24,8 @@ final class FieldReader {
     this.isBeanMap = QualifiedMapPrism.isPresent(element);
     this.fieldType = Util.unwrapProvider(utype.rawType(isBeanMap));
     this.type = GenericType.parse(utype.rawType(isBeanMap));
+    if (nullable || element.asType().toString().startsWith("java.util.Optional<"))
+      ProcessingContext.getOptionalTypes().add(fieldType);
   }
 
   boolean isGenericParam() {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
@@ -19,8 +19,7 @@ final class MetaDataOrdering {
   private final Set<String> missingDependencyTypes = new LinkedHashSet<>();
   private final Set<String> autoRequires = new TreeSet<>();
   private final Set<String> autoRequiresAspects = new TreeSet<>();
-  private final Set<String> optionalTypes = ProcessingContext.getOptionalTypes();
-  
+
   MetaDataOrdering(Collection<MetaData> values, ScopeInfo scopeInfo) {
     this.scopeInfo = scopeInfo;
     for (MetaData metaData : values) {
@@ -202,10 +201,6 @@ final class MetaDataOrdering {
                 autoRequires.add(dependencyName);
               }
               queuedMeta.markWithExternalDependency(dependencyName);
-            } else if (!optionalTypes.contains(dependencyName)) {
-              logWarn(
-                  "No modules in the classPath provide %s's optional dependency: %s. Add a module that provides it or proceed at your own peril.",
-                  queuedMeta.toString(), dependencyName);
             } else {
               return false;
             }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
@@ -19,7 +19,8 @@ final class MetaDataOrdering {
   private final Set<String> missingDependencyTypes = new LinkedHashSet<>();
   private final Set<String> autoRequires = new TreeSet<>();
   private final Set<String> autoRequiresAspects = new TreeSet<>();
-
+  private final Set<String> optionalTypes = ProcessingContext.getOptionalTypes();
+  
   MetaDataOrdering(Collection<MetaData> values, ScopeInfo scopeInfo) {
     this.scopeInfo = scopeInfo;
     for (MetaData metaData : values) {
@@ -201,6 +202,10 @@ final class MetaDataOrdering {
                 autoRequires.add(dependencyName);
               }
               queuedMeta.markWithExternalDependency(dependencyName);
+            } else if (!optionalTypes.contains(dependencyName)) {
+              logWarn(
+                  "No modules in the classPath provide %s's optional dependency: %s. Add a module that provides it or proceed at your own peril.",
+                  queuedMeta.toString(), dependencyName);
             } else {
               return false;
             }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -355,6 +355,11 @@ final class MethodReader {
       this.paramType = utilType.rawType(isBeanMap);
       this.genericType = GenericType.parse(paramType);
       this.fullGenericType = GenericType.parse(utilType.full());
+   
+      if (nullable || param.asType().toString().startsWith("java.util.Optional<")) {
+        ProcessingContext.getOptionalTypes().add(paramType);
+      }
+      
     }
 
     @Override

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -335,6 +335,7 @@ final class MethodReader {
 
   static class MethodParam {
 
+    private VariableElement element;
     private final String named;
     private final UtilType utilType;
     private final String paramType;
@@ -347,6 +348,7 @@ final class MethodReader {
     private final boolean isBeanMap;
 
     MethodParam(VariableElement param) {
+      this.element = param;
       this.simpleName = param.getSimpleName().toString();
       this.named = Util.getNamed(param);
       this.nullable = Util.isNullable(param);
@@ -357,7 +359,7 @@ final class MethodReader {
       this.fullGenericType = GenericType.parse(utilType.full());
    
       if (nullable || param.asType().toString().startsWith("java.util.Optional<")) {
-        ProcessingContext.getOptionalTypes().add(paramType);
+        ProcessingContext.addOptionalType(paramType);
       }
       
     }
@@ -424,6 +426,7 @@ final class MethodReader {
 
     void addImports(ImportTypeMap importTypes) {
       fullGenericType.addImports(importTypes);
+      Util.getNullableAnnotation(element).map(Object::toString).ifPresent(importTypes::add);
     }
 
     void checkRequest(BeanRequestParams requestParams) {
@@ -448,6 +451,11 @@ final class MethodReader {
     }
 
     void writeMethodParam(Append writer) {
+
+      if (nullable) {
+        writer.append("@Nullable ");
+      }
+
       if (genericType.isGenericType()) {
         genericType.writeShort(writer);
       } else {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -158,8 +158,6 @@ final class ProcessingContext {
     return providedTypes.contains(type) || optionalTypes.contains(type);
   }
 
-  static Set<String> getOptionalTypes() {
-    return optionalTypes;
  static void addOptionalType(String paramType) {
     if (!providedTypes.contains(paramType)) {
       optionalTypes.add(paramType);

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -35,7 +35,7 @@ final class ProcessingContext {
   private static Set<String> uniqueModuleNames = new HashSet<>();
   private static Set<String> providedTypes = new HashSet<>();
   private static final Set<String> optionalTypes = new LinkedHashSet<>();
-  
+
  static void init(ProcessingEnvironment env, Set<String> moduleFileProvided) {
     processingEnv = env;
     messager = processingEnv.getMessager();
@@ -75,7 +75,7 @@ final class ProcessingContext {
     return loadMetaInf(Constants.META_INF_CUSTOM);
   }
 
- static private List<String> loadMetaInf(String fullName) {
+ private static List<String> loadMetaInf(String fullName) {
     try {
       final var fileObject = processingEnv.getFiler().getResource(StandardLocation.CLASS_OUTPUT, "", fullName);
       if (fileObject != null) {
@@ -117,7 +117,7 @@ final class ProcessingContext {
     return createMetaInfWriterFor(serviceName);
   }
 
- static private FileObject createMetaInfWriterFor(String interfaceType) throws IOException {
+ private static FileObject createMetaInfWriterFor(String interfaceType) throws IOException {
     return filer.createResource(StandardLocation.CLASS_OUTPUT, "", interfaceType);
   }
 
@@ -155,10 +155,15 @@ final class ProcessingContext {
   }
 
  static boolean externallyProvided(String type) {
-    return providedTypes.contains(type);
+    return providedTypes.contains(type) || optionalTypes.contains(type);
   }
 
   static Set<String> getOptionalTypes() {
     return optionalTypes;
+ static void addOptionalType(String paramType) {
+    if (!providedTypes.contains(paramType)) {
+      optionalTypes.add(paramType);
+    }
   }
+
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -7,6 +7,7 @@ import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -33,7 +34,8 @@ final class ProcessingContext {
   private static Types typeUtils;
   private static Set<String> uniqueModuleNames = new HashSet<>();
   private static Set<String> providedTypes = new HashSet<>();
-
+  private static final Set<String> optionalTypes = new LinkedHashSet<>();
+  
  static void init(ProcessingEnvironment env, Set<String> moduleFileProvided) {
     processingEnv = env;
     messager = processingEnv.getMessager();
@@ -154,5 +156,9 @@ final class ProcessingContext {
 
  static boolean externallyProvided(String type) {
     return providedTypes.contains(type);
+  }
+
+  static Set<String> getOptionalTypes() {
+    return optionalTypes;
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -1,5 +1,7 @@
 package io.avaje.inject.generator;
 
+import java.util.Optional;
+
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.DeclaredType;
@@ -222,6 +224,15 @@ final class Util {
       }
     }
     return false;
+  }
+
+  public static Optional<DeclaredType> getNullableAnnotation(Element p) {
+    for (AnnotationMirror mirror : p.getAnnotationMirrors()) {
+      if (NULLABLE.equals(shortName(mirror.getAnnotationType().toString()))) {
+        return Optional.of(mirror.getAnnotationType());
+      }
+    }
+    return Optional.empty();
   }
 
   public static String addForInterface(String interfaceType) {


### PR DESCRIPTION
So after all this autoRequires stuff, wouldn't it be easier to have avaje auto add nullable types to auto requires instead of 
needing to manually define `@InjectModule(requires={X,Y,Z})` for every single nullable bean?

- Adds a static set to ProcessingContext that we can use to keep track of nullable/optional types
- Update Field and Method Readers to add the bean type to the set when nullable or Optional Type is detected
- Fixes Proxy Writer not writing `@Nullable` annotations when needed 

Fixes https://github.com/avaje/avaje-inject/issues/244