### PR TITLE
Update Javax/Jakarta Scripts to Add/Remove `-javax` in Parent Version.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,5 @@ jobs:
       run: mvn --version
     - name: Build with Maven
       run: mvn clean test
+    - name: Build with Maven (javax)
+      run: ./jakarta-to-javax.sh && mvn clean test && ./javax-to-jakarta.sh

--- a/blackbox-test-inject/pom.xml
+++ b/blackbox-test-inject/pom.xml
@@ -84,7 +84,7 @@
 			<plugin>
 				<groupId>io.avaje</groupId>
 				<artifactId>avaje-inject-maven-plugin</artifactId>
-				<version>1.0-SNAPSHOT</version>
+				<version>1.0</version>
 				<executions>
 					<execution>
 						<phase>process-sources</phase>

--- a/jakarta-to-javax.sh
+++ b/jakarta-to-javax.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 
 ## adjust pom dependencies
+
+sed -i 's/<version>\(.*\)-SNAPSHOT<\/version>/<version>\1-javax-SNAPSHOT<\/version>/' pom.xml
+sed -i 's/<version>\(.*\)-SNAPSHOT<\/version>/<version>\1-javax-SNAPSHOT<\/version>/' inject/pom.xml
+sed -i 's/<version>\(.*\)-SNAPSHOT<\/version>/<version>\1-javax-SNAPSHOT<\/version>/' inject-generator/pom.xml
+sed -i 's/<version>\(.*\)-SNAPSHOT<\/version>/<version>\1-javax-SNAPSHOT<\/version>/' inject-test/pom.xml
+sed -i 's/<version>\(.*\)-SNAPSHOT<\/version>/<version>\1-javax-SNAPSHOT<\/version>/' blackbox-aspect/pom.xml
+sed -i 's/<version>\(.*\)-SNAPSHOT<\/version>/<version>\1-javax-SNAPSHOT<\/version>/' blackbox-other/pom.xml
+sed -i 's/<version>\(.*\)-SNAPSHOT<\/version>/<version>\1-javax-SNAPSHOT<\/version>/' blackbox-test-inject/pom.xml
+
 sed -i'' -e 's|<version>2\.0\.1</version> <!-- jakarta -->|<version>1\.0\.5</version> <!-- javax -->|g' inject/pom.xml
 
 ## adjust module-info

--- a/javax-to-jakarta.sh
+++ b/javax-to-jakarta.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 
 ## adjust pom dependencies
+
+sed -i 's/\(<version>[^<]*\)-javax\([^<]*<\/version>\)/\1\2/' pom.xml
+sed -i 's/\(<version>[^<]*\)-javax\([^<]*<\/version>\)/\1\2/' inject/pom.xml
+sed -i 's/\(<version>[^<]*\)-javax\([^<]*<\/version>\)/\1\2/' inject-generator/pom.xml
+sed -i 's/\(<version>[^<]*\)-javax\([^<]*<\/version>\)/\1\2/' inject-test/pom.xml
+sed -i 's/\(<version>[^<]*\)-javax\([^<]*<\/version>\)/\1\2/' blackbox-aspect/pom.xml
+sed -i 's/\(<version>[^<]*\)-javax\([^<]*<\/version>\)/\1\2/' blackbox-other/pom.xml
+sed -i 's/\(<version>[^<]*\)-javax\([^<]*<\/version>\)/\1\2/' blackbox-test-inject/pom.xml
 sed -i'' -e 's|<version>1\.0\.5</version> <!-- javax -->|<version>2\.0\.1</version> <!-- jakarta -->|g' inject/pom.xml
 
 ## adjust module-info
 sed -i'' -e 's| java\.inject| jakarta\.inject|g' inject/src/main/java/module-info.java
 
 ## adjust code
-find . -type f -name '*.java' -exec sed -i'' -e 's| javax\.inject\.| jakarta\.inject\.|g' {} +
+find . -type f -not -name 'IncludeAnnotations.java' -name '*.java' -exec sed -i'' -e 's|javax\.inject\.|jakarta\.inject\.|g' {} +


### PR DESCRIPTION
I for one welcome our new AI overlords.

- Will add/remove `-javax` from the parent version (will even work on RC versions)
- Now correctly replaces javax when going back to jakarta.
- update GitHub actions to test javax build.