### PR TITLE
#312 Follow up for @Requires - read repeatable container annotations

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/conditional/BirdFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/conditional/BirdFactory.java
@@ -10,6 +10,7 @@ import io.avaje.inject.Secondary;
 
 @Factory
 @RequiresProperty(value = "factory", equalTo = "bird", missingProperties = "neverExisted")
+@RequiresProperty(value = "somethingElse", notEqualTo = "testRepeatable")
 public class BirdFactory {
 
   @Bean

--- a/blackbox-test-inject/src/main/java/org/example/myapp/conditional/BirdWatcher.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/conditional/BirdWatcher.java
@@ -1,8 +1,14 @@
 package org.example.myapp.conditional;
 
+import io.avaje.inject.RequiresBean;
 import jakarta.inject.Singleton;
 
+import java.awt.*;
+import java.util.Properties;
+
 @Singleton
+@RequiresBean(missingBeans = Properties.class)
+@RequiresBean(missingBeans = SystemColor.class)
 @RequiresBird
 public class BirdWatcher {
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanConditions.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanConditions.java
@@ -1,5 +1,7 @@
 package io.avaje.inject.generator;
 
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
 import java.util.*;
 
 final class BeanConditions {
@@ -12,13 +14,38 @@ final class BeanConditions {
   final Map<String, String> propertyEquals = new HashMap<>();
   final Map<String, String> propertyNotEquals = new HashMap<>();
 
-  void read(RequiresBeanPrism prism) {
+
+  void readAll(Element element) {
+    readMetaAnnotations(element);
+    readAllDirect(element);
+  }
+
+  private void readAllDirect(Element element) {
+    RequiresBeanPrism.getAllInstancesOn(element).forEach(this::read);
+    RequiresBeanContainerPrism.getOptionalOn(element).ifPresent( container -> {
+      container.value().forEach(this::read);
+    });
+    RequiresPropertyPrism.getAllInstancesOn(element).forEach(this::read);
+    RequiresPropertyContainerPrism.getOptionalOn(element).ifPresent( container -> {
+      container.value().forEach(this::read);
+    });
+  }
+
+  private void readMetaAnnotations(Element element) {
+    element.getAnnotationMirrors().forEach(this::findRequiresOnAnnotation);
+  }
+
+  private void findRequiresOnAnnotation(AnnotationMirror a) {
+    readAllDirect(a.getAnnotationType().asElement());
+  }
+
+  private void read(RequiresBeanPrism prism) {
     prism.value().forEach(t -> requireTypes.add(t.toString()));
     prism.missingBeans().forEach(t -> missingTypes.add(t.toString()));
     qualifierNames.addAll(prism.qualifiers());
   }
 
-  void read(RequiresPropertyPrism prism) {
+  private void read(RequiresPropertyPrism prism) {
     if (!prism.value().isBlank()) {
       if (!prism.notEqualTo().isBlank()) {
         propertyNotEquals.put(prism.value(), prism.notEqualTo());

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -44,10 +44,7 @@ final class BeanReader {
     this.proxy = ProxyPrism.isPresent(beanType);
     this.typeReader = new TypeReader(GenericType.parse(type), beanType, importTypes, factory);
 
-    beanType.getAnnotationMirrors().forEach(this::findRequiresOnAnnotation);
-
-    RequiresBeanPrism.getAllInstancesOn(beanType).forEach(this::processBeanPrism);
-    RequiresPropertyPrism.getAllInstancesOn(beanType).forEach(this::processPropertyPrism);
+    conditions.readAll(beanType);
 
     typeReader.process();
     this.requestParams = new BeanRequestParams(type);
@@ -64,21 +61,6 @@ final class BeanReader {
   @Override
   public String toString() {
     return beanType.toString();
-  }
-
-  void processBeanPrism(RequiresBeanPrism prism) {
-    conditions.read(prism);
-  }
-
-  void processPropertyPrism(RequiresPropertyPrism prism) {
-    conditions.read(prism);
-  }
-
-  private void findRequiresOnAnnotation(AnnotationMirror a) {
-    final var annotationElement = a.getAnnotationType().asElement();
-
-    RequiresBeanPrism.getAllInstancesOn(annotationElement).forEach(this::processBeanPrism);
-    RequiresPropertyPrism.getAllInstancesOn(annotationElement).forEach(this::processPropertyPrism);
   }
 
   TypeElement beanType() {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -47,9 +47,7 @@ final class MethodReader {
       primary = PrimaryPrism.isPresent(element);
       secondary = SecondaryPrism.isPresent(element);
 
-      element.getAnnotationMirrors().forEach(this::findRequiresOnAnnotation);
-      RequiresBeanPrism.getAllInstancesOn(element).forEach(this::processBeanPrism);
-      RequiresPropertyPrism.getAllInstancesOn(element).forEach(this::processPropertyPrism);
+      conditions.readAll(element);
 
     } else {
       prototype = false;
@@ -96,21 +94,6 @@ final class MethodReader {
       "element=" + element +
       ", params=" + params +
       '}';
-  }
-
-  void processBeanPrism(RequiresBeanPrism prism) {
-    conditions.read(prism);
-  }
-
-  void processPropertyPrism(RequiresPropertyPrism prism) {
-    conditions.read(prism);
-  }
-
-  private void findRequiresOnAnnotation(AnnotationMirror a) {
-    final var annotationElement = a.getAnnotationType().asElement();
-
-    RequiresBeanPrism.getAllInstancesOn(annotationElement).forEach(this::processBeanPrism);
-    RequiresPropertyPrism.getAllInstancesOn(annotationElement).forEach(this::processPropertyPrism);
   }
 
   void addDependsOnGeneric(Set<GenericType> set) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/package-info.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/package-info.java
@@ -18,18 +18,11 @@
 @GeneratePrism(Generated.class)
 @GeneratePrism(RequiresBean.class)
 @GeneratePrism(RequiresProperty.class)
+@GeneratePrism(value = RequiresBean.Container.class, name = "RequiresBeanContainerPrism")
+@GeneratePrism(value = RequiresProperty.Container.class, name = "RequiresPropertyContainerPrism")
 package io.avaje.inject.generator;
 
-import io.avaje.inject.Bean;
-import io.avaje.inject.Component;
-import io.avaje.inject.Factory;
-import io.avaje.inject.InjectModule;
-import io.avaje.inject.Primary;
-import io.avaje.inject.Prototype;
-import io.avaje.inject.QualifiedMap;
-import io.avaje.inject.RequiresBean;
-import io.avaje.inject.RequiresProperty;
-import io.avaje.inject.Secondary;
+import io.avaje.inject.*;
 import io.avaje.inject.aop.Aspect;
 import io.avaje.inject.spi.DependencyMeta;
 import io.avaje.inject.spi.Generated;

--- a/inject/src/main/java/io/avaje/inject/RequiresBean.java
+++ b/inject/src/main/java/io/avaje/inject/RequiresBean.java
@@ -10,7 +10,7 @@ import java.lang.annotation.*;
 /**
  * Expresses a requirement for a bean to be wired/registered into the {@link BeanScope}.
  *
- * <pre class="code">{@code
+ * <pre>{@code
  *
  *   @Configuration
  *   public class MyAutoConfiguration {

--- a/inject/src/main/java/io/avaje/inject/RequiresBean.java
+++ b/inject/src/main/java/io/avaje/inject/RequiresBean.java
@@ -28,7 +28,7 @@ import java.lang.annotation.*;
  * OtherService} is already registered in the {@link BeanScope}.
  */
 @Retention(RUNTIME)
-@Repeatable(RequiresBean.RequireBeans.class)
+@Repeatable(RequiresBean.Container.class)
 @Target({TYPE, METHOD, ANNOTATION_TYPE})
 public @interface RequiresBean {
 
@@ -55,7 +55,7 @@ public @interface RequiresBean {
   String[] qualifiers() default {};
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.TYPE, ElementType.METHOD})
-  @interface RequireBeans {
+  @interface Container {
 
     /** @return The required dependencies */
     RequiresBean[] value();

--- a/inject/src/main/java/io/avaje/inject/RequiresProperty.java
+++ b/inject/src/main/java/io/avaje/inject/RequiresProperty.java
@@ -29,7 +29,7 @@ import java.lang.annotation.*;
  * system properties / Avaje Config.
  */
 @Retention(RUNTIME)
-@Repeatable(RequiresProperty.RequireProperties.class)
+@Repeatable(RequiresProperty.Container.class)
 @Target({TYPE, METHOD, ANNOTATION_TYPE})
 public @interface RequiresProperty {
 
@@ -64,7 +64,7 @@ public @interface RequiresProperty {
 
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.TYPE, ElementType.METHOD})
-  @interface RequireProperties {
+  @interface Container {
 
     /** @return The required dependencies */
     RequiresProperty[] value();

--- a/inject/src/main/java/io/avaje/inject/RequiresProperty.java
+++ b/inject/src/main/java/io/avaje/inject/RequiresProperty.java
@@ -10,7 +10,7 @@ import java.lang.annotation.*;
 /**
  * Expresses a requirement for a bean to be wired/registered into the {@link BeanScope}.
  *
- * <pre class="code">{@code
+ * <pre>{@code
  *
  *   @Configuration
  *   public class MyAutoConfiguration {
@@ -25,8 +25,18 @@ import java.lang.annotation.*;
  *
  * }</pre>
  *
- * <p>In the sample above the MyService bean will get wired only if use.service is set in Java
- * system properties / Avaje Config.
+ * <p>
+ * In the sample above the MyService bean will get wired only if <code>use.service</code>
+ * is set in Java system properties / Avaje Config.
+ * <p>
+ * {@link io.avaje.inject.spi.PropertyRequiresPlugin} is used to test the property
+ * conditions and is loaded via {@link java.util.ServiceLoader}.
+ * <p>
+ * Avaje Config provides an implementation and if it is included in the classpath then
+ * Avaje Config will be used to test the property conditions.
+ * <p>
+ * If no PropertyRequiresPlugin is found then the default implementation is used which uses
+ * {@link System#getProperty(String)} and {@link System#getenv(String)}.
  */
 @Retention(RUNTIME)
 @Repeatable(RequiresProperty.Container.class)

--- a/inject/src/main/java/io/avaje/inject/spi/PropertyRequiresPlugin.java
+++ b/inject/src/main/java/io/avaje/inject/spi/PropertyRequiresPlugin.java
@@ -1,12 +1,30 @@
 package io.avaje.inject.spi;
 
+/**
+ * Plugin interface used with {@link io.avaje.inject.RequiresProperty}.
+ * <p>
+ * The plugin is loaded via ServiceLoader and defaults to an implementation
+ * that uses {@link System#getProperty(String)} and {@link System#getenv(String)}.
+ */
 public interface PropertyRequiresPlugin {
 
+  /**
+   * Return true if the property is defined.
+   */
   boolean contains(String property);
 
+  /**
+   * Return true if the property is not defined.
+   */
   boolean missing(String property);
 
+  /**
+   * Return true if the property is equal to the given value.
+   */
   boolean equalTo(String property, String value);
 
+  /**
+   * Return true if the property is not defined or not equal to the given value.
+   */
   boolean notEqualTo(String property, String value);
 }


### PR DESCRIPTION
- Read the repeatable Container annotations
- Move the annotation reading into BeanConditions
- Rename the inner repeatable annotations to Container (so IDE autocompletion for Requires* only sees our 2 @RequiresBean and @RequiresProperty annotations