### PR TITLE
Now Scripts will Add/Remove `-javax` even if there is no `-SNAPSHOT`

### DIFF
--- a/jakarta-to-javax.sh
+++ b/jakarta-to-javax.sh
@@ -2,13 +2,13 @@
 
 ## adjust pom dependencies
 
-sed -i 's/<version>\(.*\)-SNAPSHOT<\/version>/<version>\1-javax-SNAPSHOT<\/version>/' pom.xml
-sed -i 's/<version>\(.*\)-SNAPSHOT<\/version>/<version>\1-javax-SNAPSHOT<\/version>/' inject/pom.xml
-sed -i 's/<version>\(.*\)-SNAPSHOT<\/version>/<version>\1-javax-SNAPSHOT<\/version>/' inject-generator/pom.xml
-sed -i 's/<version>\(.*\)-SNAPSHOT<\/version>/<version>\1-javax-SNAPSHOT<\/version>/' inject-test/pom.xml
-sed -i 's/<version>\(.*\)-SNAPSHOT<\/version>/<version>\1-javax-SNAPSHOT<\/version>/' blackbox-aspect/pom.xml
-sed -i 's/<version>\(.*\)-SNAPSHOT<\/version>/<version>\1-javax-SNAPSHOT<\/version>/' blackbox-other/pom.xml
-sed -i 's/<version>\(.*\)-SNAPSHOT<\/version>/<version>\1-javax-SNAPSHOT<\/version>/' blackbox-test-inject/pom.xml
+sed -i '0,/<version>[^<]*\(-SNAPSHOT\)\{0,1\}<\/version>/ s/<version>\([^<]*\)\(-SNAPSHOT\)\{0,1\}<\/version>/<version>\1-javax\2<\/version>/' pom.xml
+sed -i '0,/<version>[^<]*\(-SNAPSHOT\)\{0,1\}<\/version>/ s/<version>\([^<]*\)\(-SNAPSHOT\)\{0,1\}<\/version>/<version>\1-javax\2<\/version>/' inject/pom.xml
+sed -i '0,/<version>[^<]*\(-SNAPSHOT\)\{0,1\}<\/version>/ s/<version>\([^<]*\)\(-SNAPSHOT\)\{0,1\}<\/version>/<version>\1-javax\2<\/version>/' inject-generator/pom.xml
+sed -i '0,/<version>[^<]*\(-SNAPSHOT\)\{0,1\}<\/version>/ s/<version>\([^<]*\)\(-SNAPSHOT\)\{0,1\}<\/version>/<version>\1-javax\2<\/version>/' inject-test/pom.xml
+sed -i '0,/<version>[^<]*\(-SNAPSHOT\)\{0,1\}<\/version>/ s/<version>\([^<]*\)\(-SNAPSHOT\)\{0,1\}<\/version>/<version>\1-javax\2<\/version>/' blackbox-aspect/pom.xml
+sed -i '0,/<version>[^<]*\(-SNAPSHOT\)\{0,1\}<\/version>/ s/<version>\([^<]*\)\(-SNAPSHOT\)\{0,1\}<\/version>/<version>\1-javax\2<\/version>/' blackbox-other/pom.xml
+sed -i '0,/<version>[^<]*\(-SNAPSHOT\)\{0,1\}<\/version>/ s/<version>\([^<]*\)\(-SNAPSHOT\)\{0,1\}<\/version>/<version>\1-javax\2<\/version>/' blackbox-test-inject/pom.xml
 
 sed -i'' -e 's|<version>2\.0\.1</version> <!-- jakarta -->|<version>1\.0\.5</version> <!-- javax -->|g' inject/pom.xml
 

--- a/jakarta-to-javax.sh
+++ b/jakarta-to-javax.sh
@@ -2,13 +2,13 @@
 
 ## adjust pom dependencies
 
-sed -i '0,/<version>[^<]*\(-SNAPSHOT\)\{0,1\}<\/version>/ s/<version>\([^<]*\)\(-SNAPSHOT\)\{0,1\}<\/version>/<version>\1-javax\2<\/version>/' pom.xml
-sed -i '0,/<version>[^<]*\(-SNAPSHOT\)\{0,1\}<\/version>/ s/<version>\([^<]*\)\(-SNAPSHOT\)\{0,1\}<\/version>/<version>\1-javax\2<\/version>/' inject/pom.xml
-sed -i '0,/<version>[^<]*\(-SNAPSHOT\)\{0,1\}<\/version>/ s/<version>\([^<]*\)\(-SNAPSHOT\)\{0,1\}<\/version>/<version>\1-javax\2<\/version>/' inject-generator/pom.xml
-sed -i '0,/<version>[^<]*\(-SNAPSHOT\)\{0,1\}<\/version>/ s/<version>\([^<]*\)\(-SNAPSHOT\)\{0,1\}<\/version>/<version>\1-javax\2<\/version>/' inject-test/pom.xml
-sed -i '0,/<version>[^<]*\(-SNAPSHOT\)\{0,1\}<\/version>/ s/<version>\([^<]*\)\(-SNAPSHOT\)\{0,1\}<\/version>/<version>\1-javax\2<\/version>/' blackbox-aspect/pom.xml
-sed -i '0,/<version>[^<]*\(-SNAPSHOT\)\{0,1\}<\/version>/ s/<version>\([^<]*\)\(-SNAPSHOT\)\{0,1\}<\/version>/<version>\1-javax\2<\/version>/' blackbox-other/pom.xml
-sed -i '0,/<version>[^<]*\(-SNAPSHOT\)\{0,1\}<\/version>/ s/<version>\([^<]*\)\(-SNAPSHOT\)\{0,1\}<\/version>/<version>\1-javax\2<\/version>/' blackbox-test-inject/pom.xml
+sed -i -E '0,/<version>[^<]*<\/version>/ s/<version>([^-]*)-?([^<]*)(<\/version>)/<version>\1-javax-\2\3/' pom.xml
+sed -i -E '0,/<version>[^<]*<\/version>/ s/<version>([^-]*)-?([^<]*)(<\/version>)/<version>\1-javax-\2\3/' inject/pom.xml
+sed -i -E '0,/<version>[^<]*<\/version>/ s/<version>([^-]*)-?([^<]*)(<\/version>)/<version>\1-javax-\2\3/' inject-generator/pom.xml
+sed -i -E '0,/<version>[^<]*<\/version>/ s/<version>([^-]*)-?([^<]*)(<\/version>)/<version>\1-javax-\2\3/' inject-test/pom.xml
+sed -i -E '0,/<version>[^<]*<\/version>/ s/<version>([^-]*)-?([^<]*)(<\/version>)/<version>\1-javax-\2\3/' blackbox-aspect/pom.xml
+sed -i -E '0,/<version>[^<]*<\/version>/ s/<version>([^-]*)-?([^<]*)(<\/version>)/<version>\1-javax-\2\3/' blackbox-other/pom.xml
+sed -i -E '0,/<version>[^<]*<\/version>/ s/<version>([^-]*)-?([^<]*)(<\/version>)/<version>\1-javax-\2\3/' blackbox-test-inject/pom.xml
 
 sed -i'' -e 's|<version>2\.0\.1</version> <!-- jakarta -->|<version>1\.0\.5</version> <!-- javax -->|g' inject/pom.xml
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.avaje</groupId>
-    <artifactId>java11-oss</artifactId>
-    <version>3.9</version>
-  </parent>
-
   <groupId>io.avaje</groupId>
   <artifactId>avaje-inject-parent</artifactId>
   <version>9.0-RC1</version>
@@ -14,6 +8,11 @@
   <name>avaje inject parent</name>
   <description>parent pom for avaje inject library</description>
 
+  <parent>
+    <groupId>org.avaje</groupId>
+    <artifactId>java11-oss</artifactId>
+    <version>3.9</version>
+  </parent>
   <scm>
     <developerConnection>scm:git:git@github.com:avaje/avaje-inject.git</developerConnection>
     <tag>HEAD</tag>


### PR DESCRIPTION
Brought to you by ChatGPT.

>In summary, this sed command uses regular expressions to match and replace the first occurrence of `<version>...</version>` in the file. If the original version contains the -SNAPSHOT suffix, it adds the -javax suffix before the -SNAPSHOT suffix. If the original version doesn't contain the -SNAPSHOT suffix, it adds the -javax suffix after the version number.
