### PR TITLE
Update Requires Javadoc/Rename Missing Methods

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/conditional/BirdFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/conditional/BirdFactory.java
@@ -9,7 +9,7 @@ import io.avaje.inject.RequiresProperty;
 import io.avaje.inject.Secondary;
 
 @Factory
-@RequiresProperty(value = "factory", equalTo = "bird", missingProperties = "neverExisted")
+@RequiresProperty(value = "factory", equalTo = "bird", missing = "neverExisted")
 @RequiresProperty(value = "somethingElse", notEqualTo = "testRepeatable")
 public class BirdFactory {
 

--- a/blackbox-test-inject/src/main/java/org/example/myapp/conditional/BirdWatcher.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/conditional/BirdWatcher.java
@@ -7,8 +7,8 @@ import java.awt.*;
 import java.util.Properties;
 
 @Singleton
-@RequiresBean(missingBeans = Properties.class)
-@RequiresBean(missingBeans = SystemColor.class)
+@RequiresBean(missing = Properties.class)
+@RequiresBean(missing = SystemColor.class)
 @RequiresBird
 public class BirdWatcher {
 

--- a/blackbox-test-inject/src/main/java/org/example/myapp/conditional/NoKiwi.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/conditional/NoKiwi.java
@@ -3,6 +3,6 @@ package org.example.myapp.conditional;
 import io.avaje.inject.RequiresBean;
 import io.avaje.inject.RequiresProperty;
 
-@RequiresBean(missingBeans = Kiwi.class)
-@RequiresProperty(missingProperties = "secondary")
+@RequiresBean(missing = Kiwi.class)
+@RequiresProperty(missing = "secondary")
 public @interface NoKiwi {}

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanConditions.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanConditions.java
@@ -1,8 +1,12 @@
 package io.avaje.inject.generator;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
-import java.util.*;
 
 final class BeanConditions {
 
@@ -41,7 +45,7 @@ final class BeanConditions {
 
   private void read(RequiresBeanPrism prism) {
     prism.value().forEach(t -> requireTypes.add(t.toString()));
-    prism.missingBeans().forEach(t -> missingTypes.add(t.toString()));
+    prism.missing().forEach(t -> missingTypes.add(t.toString()));
     qualifierNames.addAll(prism.qualifiers());
   }
 
@@ -55,7 +59,7 @@ final class BeanConditions {
         containsProps.add(prism.value());
       }
     }
-    missingProps.addAll(prism.missingProperties());
+    missingProps.addAll(prism.missing());
   }
 
   void addImports(ImportTypeMap importTypes) {

--- a/inject/src/main/java/io/avaje/inject/RequiresBean.java
+++ b/inject/src/main/java/io/avaje/inject/RequiresBean.java
@@ -16,7 +16,7 @@ import java.lang.annotation.*;
  *   public class MyAutoConfiguration {
  *
  *     @Bean
- *     @Requires(beans = OtherService.class)
+ *     @Requires(OtherService.class)
  *     public MyService myService() {
  *         ...
  *     }
@@ -53,7 +53,7 @@ public @interface RequiresBean {
    * @return the names of beans to check
    */
   String[] qualifiers() default {};
-  
+
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.TYPE, ElementType.METHOD})
   @interface Container {

--- a/inject/src/main/java/io/avaje/inject/RequiresBean.java
+++ b/inject/src/main/java/io/avaje/inject/RequiresBean.java
@@ -16,7 +16,7 @@ import java.lang.annotation.*;
  *   public class MyAutoConfiguration {
  *
  *     @Bean
- *     @Requires(OtherService.class)
+ *     @RequiresBean(OtherService.class)
  *     public MyService myService() {
  *         ...
  *     }

--- a/inject/src/main/java/io/avaje/inject/RequiresBean.java
+++ b/inject/src/main/java/io/avaje/inject/RequiresBean.java
@@ -44,7 +44,7 @@ public @interface RequiresBean {
    *
    * @return the class types of beans to check
    */
-  Class<?>[] missingBeans() default {};
+  Class<?>[] missing() default {};
 
   /**
    * Expresses that a {@link @Named} or {@link @Qualifier} annotation marker of the given name should be

--- a/inject/src/main/java/io/avaje/inject/RequiresBean.java
+++ b/inject/src/main/java/io/avaje/inject/RequiresBean.java
@@ -12,7 +12,7 @@ import java.lang.annotation.*;
  *
  * <pre>{@code
  *
- *   @Configuration
+ *   @Factory
  *   public class MyAutoConfiguration {
  *
  *     @Bean
@@ -53,6 +53,7 @@ public @interface RequiresBean {
    * @return the names of beans to check
    */
   String[] qualifiers() default {};
+  
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.TYPE, ElementType.METHOD})
   @interface Container {

--- a/inject/src/main/java/io/avaje/inject/RequiresProperty.java
+++ b/inject/src/main/java/io/avaje/inject/RequiresProperty.java
@@ -29,8 +29,7 @@ import java.lang.annotation.*;
  * In the sample above the MyService bean will get wired only if <code>use.service</code>
  * is set in Java system properties / Avaje Config.
  * <p>
- * {@link io.avaje.inject.spi.PropertyRequiresPlugin} is used to test the property
- * conditions and is loaded via {@link java.util.ServiceLoader}.
+ * {@link io.avaje.inject.spi.PropertyRequiresPlugin} is used to test the property conditions and is loaded via {@link java.util.ServiceLoader}.
  * <p>
  * Avaje Config provides an implementation and if it is included in the classpath then
  * Avaje Config will be used to test the property conditions.

--- a/inject/src/main/java/io/avaje/inject/RequiresProperty.java
+++ b/inject/src/main/java/io/avaje/inject/RequiresProperty.java
@@ -55,7 +55,7 @@ public @interface RequiresProperty {
    *
    * @return the properties to check
    */
-  String[] missingProperties() default {};
+  String[] missing() default {};
 
   /**
    * Used in combination with value() to express the required value of the property.

--- a/inject/src/main/java/io/avaje/inject/RequiresProperty.java
+++ b/inject/src/main/java/io/avaje/inject/RequiresProperty.java
@@ -12,7 +12,7 @@ import java.lang.annotation.*;
  *
  * <pre>{@code
  *
- *   @Configuration
+ *   @Factory
  *   public class MyAutoConfiguration {
  *
  *     @Bean


### PR DESCRIPTION
- fix javadocs
- rename methods to missing (because prop/bean annotations are separate I'd say there are enough context clues)
