### PR TITLE
Support Meta-Annotations on Meta-Annotations

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/conditional/BirdFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/conditional/BirdFactory.java
@@ -16,6 +16,7 @@ public class BirdFactory {
 
   @Bean
   @NoKiwi
+  @RequiresProperty(missing = "finch-time")
   public BlueJay jay() {
     return new BlueJay();
   }
@@ -27,7 +28,7 @@ public class BirdFactory {
   }
 
   @Bean
-  @NoFinches
+  @Finches
   public StrawberryFinch finch() {
     return new StrawberryFinch();
   }

--- a/blackbox-test-inject/src/main/java/org/example/myapp/conditional/BirdFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/conditional/BirdFactory.java
@@ -2,6 +2,7 @@ package org.example.myapp.conditional;
 
 import org.example.myapp.conditional.Bird.BlueJay;
 import org.example.myapp.conditional.Bird.Cassowary;
+import org.example.myapp.conditional.Bird.StrawberryFinch;
 
 import io.avaje.inject.Bean;
 import io.avaje.inject.Factory;
@@ -25,4 +26,9 @@ public class BirdFactory {
     return new Cassowary();
   }
 
+  @Bean
+  @NoFinches
+  public StrawberryFinch finch() {
+    return new StrawberryFinch();
+  }
 }

--- a/blackbox-test-inject/src/main/java/org/example/myapp/conditional/Finches.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/conditional/Finches.java
@@ -3,5 +3,5 @@ package org.example.myapp.conditional;
 import io.avaje.inject.RequiresProperty;
 
 @NoKiwi
-@RequiresProperty(missing = "noFinches")
-public @interface NoFinches {}
+@RequiresProperty("finch-time")
+public @interface Finches {}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/conditional/NoFinches.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/conditional/NoFinches.java
@@ -1,0 +1,7 @@
+package org.example.myapp.conditional;
+
+import io.avaje.inject.RequiresProperty;
+
+@NoKiwi
+@RequiresProperty(missing = "noFinches")
+public @interface NoFinches {}

--- a/blackbox-test-inject/src/test/java/org/example/myapp/ConditionalTests.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/ConditionalTests.java
@@ -27,6 +27,7 @@ class ConditionalTests {
         .remove("factory")
         .remove("watcher")
         .remove("kiwi")
+        .remove("finch-time")
         .publish();
   }
 
@@ -114,5 +115,17 @@ class ConditionalTests {
     final BeanScope beanScope =
         BeanScope.builder().bean("finch", Bird.class, new StrawberryFinch()).build();
     assertTrue(beanScope.getOptional(QualifiedBirdWatcher.class).isPresent());
+  }
+
+  @Test
+  void metaMetaAnnotationTest() throws IOException {
+
+    Config.setProperty("finch-time", "somethin");
+    Config.setProperty("factory", "bird");
+    Config.setProperty("watcher", "bird");
+
+    final BeanScope beanScope = BeanScope.builder().build();
+    assertTrue(beanScope.getOptional(BirdWatcher.class).isPresent());
+    assertEquals("StrawBerryFinch", beanScope.get(Bird.class).toString());
   }
 }

--- a/inject-generator/pom.xml
+++ b/inject-generator/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-prisms</artifactId>
-      <version>1.5</version>
+      <version>1.6</version>
       <optional>true</optional>
       <scope>provided</scope>
     </dependency>
@@ -53,7 +53,7 @@
             <path>
               <groupId>io.avaje</groupId>
               <artifactId>avaje-prisms</artifactId>
-              <version>1.5</version>
+              <version>1.6</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/inject/src/main/java/io/avaje/inject/RequiresBean.java
+++ b/inject/src/main/java/io/avaje/inject/RequiresBean.java
@@ -54,8 +54,8 @@ public @interface RequiresBean {
    */
   String[] qualifiers() default {};
 
-  @Retention(RetentionPolicy.RUNTIME)
-  @Target({ElementType.TYPE, ElementType.METHOD})
+  @Retention(RUNTIME)
+  @Target({TYPE, METHOD, ANNOTATION_TYPE})
   @interface Container {
 
     /** @return The required dependencies */

--- a/inject/src/main/java/io/avaje/inject/RequiresProperty.java
+++ b/inject/src/main/java/io/avaje/inject/RequiresProperty.java
@@ -71,8 +71,8 @@ public @interface RequiresProperty {
    */
   String notEqualTo() default "";
 
-  @Retention(RetentionPolicy.RUNTIME)
-  @Target({ElementType.TYPE, ElementType.METHOD})
+  @Retention(RUNTIME)
+  @Target({TYPE, METHOD, ANNOTATION_TYPE})
   @interface Container {
 
     /** @return The required dependencies */


### PR DESCRIPTION
Now can get even more meta with the annotations. Observe:

```
@RequiresBean(Bird.class)
@RequiresProperty(value = "watcher", equalTo = "bird")
public @interface RequiresBirdWatcher {}
```

```
@RequiresBirdWatcher
@RequiresProperty(value = "whale.whale.whale", equalTo = "what do we have here")
public @interface RequiresWatcherAndWhale {}
```

```
@Singleton
@RequiresWatcherAndWhale
public class OtherClass {
...
}
```
The generator will read all the meta-annotations and correctly add the conditions. 

This relies on [avaje-prisms 1.6](https://github.com/avaje/avaje-prisms/pull/11) being deployed.