### PR TITLE
Write Custom modules early (not in last round of processing)

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/AllScopes.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/AllScopes.java
@@ -53,6 +53,9 @@ final class AllScopes {
     for (Data value : scopeAnnotations.values()) {
       value.write(processingOver);
     }
+    for (Data value : scopeAnnotations.values()) {
+      value.writeCustomModule();
+    }
   }
 
   void readModules(List<String> customScopeModules) {
@@ -94,6 +97,10 @@ final class AllScopes {
 
     void write(boolean processingOver) {
       scopeInfo.write(processingOver);
+    }
+
+    void writeCustomModule() {
+      scopeInfo.writeCustomModule();
     }
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/AllScopes.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/AllScopes.java
@@ -53,6 +53,8 @@ final class AllScopes {
     for (Data value : scopeAnnotations.values()) {
       value.write(processingOver);
     }
+    // after all scopes have read their meta-data write
+    // custom modules (not in last round of processing)
     for (Data value : scopeAnnotations.values()) {
       value.writeCustomModule();
     }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -221,7 +221,6 @@ final class ScopeInfo {
 
   void writeModule() {
     if (moduleWritten) {
-      logError("already written module " + name);
       return;
     }
     final Collection<MetaData> meta = metaData.values();
@@ -322,6 +321,17 @@ final class ScopeInfo {
       readBeanMeta(element, factory);
     } else {
       logDebug("skipping already processed bean " + element);
+    }
+  }
+
+  /**
+   * Write Custom modules during processing (not last round) so that they are
+   * visible to code in src/main. This means that Custom scopes do NOT support
+   * other annotation processors generating beans that use those Custom scopes.
+   */
+  void writeCustomModule() {
+    if (type() == Type.CUSTOM && !metaData.isEmpty()) {
+      writeModule();
     }
   }
 


### PR DESCRIPTION
This adds the limitation that custom scopes can not support other annotation processors generating beans that have those custom scopes.