### PR TITLE
Add get method to Property Plugin

### DIFF
--- a/blackbox-test-inject/pom.xml
+++ b/blackbox-test-inject/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-config</artifactId>
-      <version>3.0</version>
+      <version>3.1-RC1</version>
     </dependency>
 
     <dependency>

--- a/blackbox-test-inject/src/main/java/org/example/myapp/ConfigPropertiesPlugin.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/ConfigPropertiesPlugin.java
@@ -1,27 +1,34 @@
 package org.example.myapp;
 
+import java.util.Optional;
+
 import io.avaje.config.Config;
 import io.avaje.inject.spi.PropertyRequiresPlugin;
 
-
 public class ConfigPropertiesPlugin implements PropertyRequiresPlugin {
+
+  @Override
+  public Optional<String> get(String property) {
+    return Config.getOptional(property);
+  }
+
   @Override
   public boolean contains(String property) {
-    return Config.getOptional(property).isPresent();
+    return Config.getNullable(property) != null;
   }
 
   @Override
   public boolean missing(String property) {
-    return Config.getOptional(property).isEmpty();
+    return Config.getNullable(property) == null;
   }
 
   @Override
   public boolean equalTo(String property, String value) {
-    return Config.getOptional(property).filter(value::equals).isPresent();
+    return value.equals(Config.getNullable(property));
   }
 
   @Override
   public boolean notEqualTo(String property, String value) {
-    return Config.getOptional(property).filter(value::equals).isEmpty();
+    return !value.equals(Config.getNullable(property));
   }
 }

--- a/inject-generator/pom.xml
+++ b/inject-generator/pom.xml
@@ -13,7 +13,7 @@
   <name>avaje inject generator</name>
   <description>annotation processor generating di as source code</description>
   <properties>
-    <avaje.prisms.version>1.6</avaje.prisms.version>
+    <avaje.prisms.version>1.8</avaje.prisms.version>
   </properties>
   <dependencies>
 

--- a/inject/src/main/java/io/avaje/inject/DSystemProps.java
+++ b/inject/src/main/java/io/avaje/inject/DSystemProps.java
@@ -1,6 +1,14 @@
 package io.avaje.inject;
 
+import java.util.Optional;
+
 final class DSystemProps implements io.avaje.inject.spi.PropertyRequiresPlugin {
+
+  @Override
+  public Optional<String> get(String property) {
+    return Optional.ofNullable(System.getProperty(property))
+        .or(() -> Optional.ofNullable(System.getenv(property)));
+  }
 
   @Override
   public boolean contains(String property) {

--- a/inject/src/main/java/io/avaje/inject/spi/PropertyRequiresPlugin.java
+++ b/inject/src/main/java/io/avaje/inject/spi/PropertyRequiresPlugin.java
@@ -1,5 +1,7 @@
 package io.avaje.inject.spi;
 
+import java.util.Optional;
+
 /**
  * Plugin interface used with {@link io.avaje.inject.RequiresProperty}.
  * <p>
@@ -8,9 +10,10 @@ package io.avaje.inject.spi;
  */
 public interface PropertyRequiresPlugin {
 
-  /**
-   * Return true if the property is defined.
-   */
+  /** Return a configuration value that might not exist. */
+  Optional<String> get(String property);
+
+  /** Return true if the property is defined. */
   boolean contains(String property);
 
   /**


### PR DESCRIPTION
I'm thinking it would be even more useful for plugins if they could get the bean scope's properties without needing any config dependencies.