### PR TITLE
#336 - Fix dependency relationship with avaje-config

### DIFF
--- a/blackbox-test-inject/pom.xml
+++ b/blackbox-test-inject/pom.xml
@@ -35,11 +35,11 @@
       <artifactId>avaje-jsonb</artifactId>
       <version>1.3</version>
     </dependency>
-    
+
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-config</artifactId>
-      <version>3.1-RC1</version>
+      <version>3.2-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/inject/pom.xml
+++ b/inject/pom.xml
@@ -32,6 +32,13 @@
     </dependency>
 
     <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-config</artifactId>
+      <version>3.2-SNAPSHOT</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>4.7.0</version>

--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -102,7 +102,7 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
   }
 
   @Override
-  public <D> BeanScopeBuilder provideDefault(String name, Type type, Supplier<D> supplier) {
+  public <D> BeanScopeBuilder provideDefault(@Nullable String name, Type type, Supplier<D> supplier) {
     final Provider<D> provider = supplier::get;
     suppliedBeans.add(SuppliedBean.secondary(name, type, provider));
     return this;
@@ -189,7 +189,20 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
     propertyRequiresPlugin =
       ServiceLoader.load(PropertyRequiresPlugin.class, classLoader)
         .findFirst()
-        .orElse(new DSystemProps());
+        .orElse(defaultPropertyPlugin());
+  }
+
+  private PropertyRequiresPlugin defaultPropertyPlugin() {
+    return detectAvajeConfig() ? new DConfigProps() : new DSystemProps();
+  }
+
+  private boolean detectAvajeConfig() {
+    try {
+      Class.forName("io.avaje.config.Configuration", false, classLoader);
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
   }
 
   @Override

--- a/inject/src/main/java/io/avaje/inject/DConfigProps.java
+++ b/inject/src/main/java/io/avaje/inject/DConfigProps.java
@@ -1,0 +1,38 @@
+package io.avaje.inject;
+
+import io.avaje.config.Config;
+import io.avaje.inject.spi.PropertyRequiresPlugin;
+
+import java.util.Optional;
+
+
+/**
+ * Avaje-Config based implementation of PropertyRequiresPlugin.
+ */
+final class DConfigProps implements PropertyRequiresPlugin {
+
+  @Override
+  public Optional<String> get(String property) {
+    return Config.getOptional(property);
+  }
+
+  @Override
+  public boolean contains(String property) {
+    return Config.getNullable(property) != null;
+  }
+
+  @Override
+  public boolean missing(String property) {
+    return Config.getNullable(property) == null;
+  }
+
+  @Override
+  public boolean equalTo(String property, String value) {
+    return value.equals(Config.getNullable(property));
+  }
+
+  @Override
+  public boolean notEqualTo(String property, String value) {
+    return !value.equals(Config.getNullable(property));
+  }
+}

--- a/inject/src/main/java/module-info.java
+++ b/inject/src/main/java/module-info.java
@@ -7,6 +7,7 @@ module io.avaje.inject {
   requires transitive io.avaje.lang;
   requires transitive io.avaje.applog;
   requires transitive jakarta.inject;
+  requires static io.avaje.config;
   requires static org.mockito;
 
   uses io.avaje.inject.spi.Module;


### PR DESCRIPTION
Due to module-path working differently to classpath wrt optional services we need to make this change to enable avaje-config to not have a hard dependency on avaje-inject in module-path.