### PR TITLE
Refactor rename Invocation.Build -> Invocation.Base

### DIFF
--- a/inject/src/main/java/io/avaje/inject/aop/FallbackFinder.java
+++ b/inject/src/main/java/io/avaje/inject/aop/FallbackFinder.java
@@ -7,8 +7,8 @@ import java.lang.reflect.Parameter;
 final class FallbackFinder {
 
   static Fallback find(String name, Method method) throws NoSuchMethodException {
-    Class<?> type = method.getDeclaringClass();
-    Parameter[] parameters = method.getParameters();
+    final Class<?> type = method.getDeclaringClass();
+    final Parameter[] parameters = method.getParameters();
     try {
       return new WithThrowable(type.getDeclaredMethod(name, paramTypesWithThrowable(parameters)));
     } catch (NoSuchMethodException e) {
@@ -17,7 +17,7 @@ final class FallbackFinder {
   }
 
   private static Class<?>[] paramTypes(Parameter[] parameters) {
-    Class<?>[] paramTypes = new Class[parameters.length];
+    final Class<?>[] paramTypes = new Class[parameters.length];
     for (int i = 0; i < parameters.length; i++) {
       paramTypes[i] = parameters[i].getType();
     }
@@ -25,7 +25,7 @@ final class FallbackFinder {
   }
 
   private static Class<?>[] paramTypesWithThrowable(Parameter[] parameters) {
-    Class<?>[] paramTypes = new Class[parameters.length + 1];
+    final Class<?>[] paramTypes = new Class[parameters.length + 1];
     for (int i = 0; i < parameters.length; i++) {
       paramTypes[i] = parameters[i].getType();
     }
@@ -33,7 +33,7 @@ final class FallbackFinder {
     return paramTypes;
   }
 
-  static class WithThrowable implements Fallback {
+  static final class WithThrowable implements Fallback {
 
     private final Method fallbackMethod;
 
@@ -53,7 +53,7 @@ final class FallbackFinder {
     }
   }
 
-  static class WithoutThrowable implements Fallback {
+  static final class WithoutThrowable implements Fallback {
 
     private final Method fallbackMethod;
 

--- a/inject/src/main/java/io/avaje/inject/aop/Invocation.java
+++ b/inject/src/main/java/io/avaje/inject/aop/Invocation.java
@@ -51,11 +51,11 @@ public interface Invocation {
   Object instance();
 
   /**
-   * Builds Invocation for both callable and runnable methods.
+   * Invocation base type for both callable and runnable methods.
    *
    * @param <T> The result type
    */
-  abstract class Build<T> implements Invocation {
+  abstract class Base<T> implements Invocation {
 
     protected Method method;
     protected Object[] args;
@@ -65,7 +65,7 @@ public interface Invocation {
     /**
      * Set the instance, method and arguments for the invocation.
      */
-    public Build<T> with(Object instance, Method method, Object... args) {
+    public Base<T> with(Object instance, Method method, Object... args) {
       this.instance = instance;
       this.method = method;
       this.args = args;
@@ -119,13 +119,13 @@ public interface Invocation {
      * @param methodInterceptor The method interceptor to use to wrap this call with
      * @return The wrapped call
      */
-    public abstract Build<T> wrap(MethodInterceptor methodInterceptor);
+    public abstract Base<T> wrap(MethodInterceptor methodInterceptor);
   }
 
   /**
    * Runnable based Invocation.
    */
-  final class Run extends Build<Void> {
+  final class Run extends Base<Void> {
 
     private final CheckedRunnable delegate;
 
@@ -143,7 +143,7 @@ public interface Invocation {
     }
 
     @Override
-    public Build<Void> wrap(MethodInterceptor methodInterceptor) {
+    public Base<Void> wrap(MethodInterceptor methodInterceptor) {
       return new Invocation.Run(() -> methodInterceptor.invoke(this))
         .with(instance, method, args);
     }
@@ -153,7 +153,7 @@ public interface Invocation {
   /**
    * Callable based Invocation with checked exceptions.
    */
-  final class Call<T> extends Build<T> {
+  final class Call<T> extends Base<T> {
 
     private final CheckedSupplier<T> delegate;
 
@@ -176,7 +176,7 @@ public interface Invocation {
     }
 
     @Override
-    public Build<T> wrap(MethodInterceptor methodInterceptor) {
+    public Base<T> wrap(MethodInterceptor methodInterceptor) {
       return new Invocation.Call<T>(() -> {
         final Call<T> delegate = this;
         methodInterceptor.invoke(delegate);

--- a/inject/src/test/java/io/avaje/inject/aop/InvocationCallTest.java
+++ b/inject/src/test/java/io/avaje/inject/aop/InvocationCallTest.java
@@ -36,7 +36,7 @@ class InvocationCallTest {
 
   @Test
   void single() throws Throwable {
-    Invocation.Build<String> call = new Invocation.Call<>(() -> this.doStuff(myArg))
+    Invocation.Base<String> call = new Invocation.Call<>(() -> this.doStuff(myArg))
       .with(this, doStuffMethod, myArg);
 
     new Inter0().invoke(call);
@@ -50,7 +50,7 @@ class InvocationCallTest {
 
   @Test
   void wrapped() throws Throwable {
-    Invocation.Build<String> call = new Invocation.Call<>(() -> this.doStuff(myArg))
+    Invocation.Base<String> call = new Invocation.Call<>(() -> this.doStuff(myArg))
       .with(this, doStuffMethod, myArg)
       .wrap(new Inter0());
 
@@ -65,7 +65,7 @@ class InvocationCallTest {
 
   @Test
   void wrapped_wrapped() throws Throwable {
-    Invocation.Build<String> call = new Invocation.Call<>(() -> this.doStuff(myArg))
+    Invocation.Base<String> call = new Invocation.Call<>(() -> this.doStuff(myArg))
       .with(this, doStuffMethod, myArg)
       .wrap(new Inter0())
       .wrap(new Inter1());

--- a/inject/src/test/java/io/avaje/inject/aop/InvocationFallbackRawTest.java
+++ b/inject/src/test/java/io/avaje/inject/aop/InvocationFallbackRawTest.java
@@ -48,7 +48,7 @@ class InvocationFallbackRawTest {
 
   @Test
   void invokeFallback() throws Throwable {
-    Invocation.Build<String> call = new Invocation.Call<>(() -> this.doStuff(myArg))
+    Invocation.Base<String> call = new Invocation.Call<>(() -> this.doStuff(myArg))
       .with(this, doStuffMethod, myArg);
 
     MyInterceptor myInterceptor = new MyInterceptor();

--- a/inject/src/test/java/io/avaje/inject/aop/InvocationFallbackTest.java
+++ b/inject/src/test/java/io/avaje/inject/aop/InvocationFallbackTest.java
@@ -51,7 +51,7 @@ class InvocationFallbackTest {
   void invokeWithFallback() throws Throwable {
     throwOnDoStuff = true;
 
-    Invocation.Build<String> call = new Invocation.Call<>(() -> this.doStuff(myArg))
+    Invocation.Base<String> call = new Invocation.Call<>(() -> this.doStuff(myArg))
       .with(this, doStuffMethod, myArg);
 
     Fallback fallback = Fallback.find("fallbackDoStuff", doStuffMethod);
@@ -70,7 +70,7 @@ class InvocationFallbackTest {
   void invokeWithNoFallback() throws Throwable {
     throwOnDoStuff = false;
 
-    Invocation.Build<String> call = new Invocation.Call<>(() -> this.doStuff(myArg))
+    Invocation.Base<String> call = new Invocation.Call<>(() -> this.doStuff(myArg))
       .with(this, doStuffMethod, myArg);
 
     Fallback fallback = Fallback.find("fallbackDoStuff", doStuffMethod);

--- a/inject/src/test/java/io/avaje/inject/aop/InvocationRunTest.java
+++ b/inject/src/test/java/io/avaje/inject/aop/InvocationRunTest.java
@@ -34,7 +34,7 @@ class InvocationRunTest {
 
   @Test
   void single() throws Throwable {
-    Invocation.Build<Void> call = new Invocation.Run(() -> this.doStuff(myArg))
+    Invocation.Base<Void> call = new Invocation.Run(() -> this.doStuff(myArg))
       .with(this, doStuffMethod, myArg);
 
     new Inter0().invoke(call);
@@ -47,7 +47,7 @@ class InvocationRunTest {
 
   @Test
   void wrapped() throws Throwable {
-    Invocation.Build<Void> call = new Invocation.Run(() -> this.doStuff(myArg))
+    Invocation.Base<Void> call = new Invocation.Run(() -> this.doStuff(myArg))
       .with(this, doStuffMethod, myArg)
       .wrap(new Inter0());
 
@@ -61,7 +61,7 @@ class InvocationRunTest {
 
   @Test
   void wrapped_wrapped() throws Throwable {
-    Invocation.Build<Void> call = new Invocation.Run(() -> this.doStuff(myArg))
+    Invocation.Base<Void> call = new Invocation.Run(() -> this.doStuff(myArg))
       .with(this, doStuffMethod, myArg)
       .wrap(new Inter0())
       .wrap(new Inter1());


### PR DESCRIPTION
I think Base is a better name, its a base abstract type for both Invocation.Call and Invocation.Run