### PR TITLE
Add Invocation.invokeUnchecked() ... for ease of use when aspect isn't dealing wth checked exceptions

### DIFF
--- a/inject/src/main/java/io/avaje/inject/aop/Invocation.java
+++ b/inject/src/main/java/io/avaje/inject/aop/Invocation.java
@@ -13,10 +13,27 @@ public interface Invocation {
 
   /**
    * Invoke the underlying method returning the result.
-   * <p>
-   * This will return null for void methods.
+   *
+   * @return The result of the method call. This will return null for void methods.
+   * @throws Throwable Exception thrown by underlying method
    */
   Object invoke() throws Throwable;
+
+  /**
+   * Invoke the underlying method returning the result. Checked exceptions will be caught and
+   * rethrown as {@code InvocationException}s.
+   *
+   * @return The result of the method call. This will return null for void methods.
+   */
+  default Object invokeUnchecked() {
+    try {
+      return invoke();
+    } catch (final RuntimeException e) {
+      throw e;
+    } catch (final Throwable e) {
+      throw new InvocationException(e);
+    }
+  }
 
   /**
    * Set the result that will be returned to the caller.


### PR DESCRIPTION
for my aspects it's kinda annoying to deal with checked exceptions. 
```
 SVUtil.createScopedMDC(
          mdc,
          () -> {
            try {
              return invoke.invoke();
            } catch (final Throwable e) {
              if (e instanceof final RuntimeException ex) throw ex;
              throw new InvocationException(e);
            }
      });
```
Sure would be nice to have a method I could call when I know my aspect isn't dealing with checked exceptions.