### PR TITLE
Fix Throwable Aspects

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/r4j/MyExample.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/r4j/MyExample.java
@@ -1,7 +1,8 @@
 package org.example.myapp.r4j;
 
-import io.avaje.inject.Component;
 import org.example.myapp.resilience4j.MyRetry;
+
+import io.avaje.inject.Component;
 
 @Component
 public class MyExample {
@@ -10,7 +11,7 @@ public class MyExample {
   public int retryWithFallbackCounter;
 
   @MyRetry
-  public void doingItWithRetry() {
+  public void doingItWithRetry() throws Throwable, IllegalStateException{
     barfCounter++;
     throw new IllegalArgumentException("no");
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -156,6 +156,12 @@ final class ProcessingContext {
     return wrapper == null ? CTX.get().typeUtils.asElement(returnType) : element(wrapper);
   }
 
+  static boolean isUncheckedException(TypeMirror returnType) {
+    final var types = CTX.get().typeUtils;
+    final var runtime = element("java.lang.RuntimeException").asType();
+    return types.isSubtype(returnType, runtime);
+  }
+
   static void addModule(String moduleFullName) {
     if (moduleFullName != null) {
       CTX.get().uniqueModuleNames.add(moduleFullName);


### PR DESCRIPTION
Currently, proxying a method that `throws Throwable` causes a compilation error.

- if thrown types are unchecked, don't write a superfluous catch clause
- if method throws Throwable, rethrow it.