### PR TITLE
Check if Generic Type Exists Before Writing

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -149,11 +149,11 @@ final class ProcessingContext {
     }
   }
 
-  static Element asElement(TypeMirror returnType) {
+  static TypeElement asElement(TypeMirror returnType) {
 
     final var wrapper = PrimitiveUtil.wrap(returnType.toString());
 
-    return wrapper == null ? CTX.get().typeUtils.asElement(returnType) : element(wrapper);
+    return wrapper == null ? (TypeElement) CTX.get().typeUtils.asElement(returnType) : element(wrapper);
   }
 
   static boolean isUncheckedException(TypeMirror returnType) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -143,7 +143,7 @@ final class TypeExtendsReader {
           qualifierName = baseName.substring(0, baseName.length() - superName.length()).toLowerCase();
         }
       }
-      addSuperType(superElement,superMirror);
+      addSuperType(superElement, superMirror);
     }
 
     providesTypes.addAll(extendsTypes);

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -203,15 +203,15 @@ final class TypeExtendsReader {
     } else if (Constants.AUTO_CLOSEABLE.equals(rawType) || Constants.IO_CLOSEABLE.equals(rawType)) {
       closeable = true;
     } else {
+      final var genericType = GenericType.parse(rawType);
       if (qualifierName == null) {
-        final String mainType = GenericType.removeParameter(rawType);
+        final String mainType = genericType.topType();
         final String iShortName = Util.shortName(mainType);
         if (beanSimpleName.endsWith(iShortName)) {
           // derived qualifier name based on prefix to interface short name
           qualifierName = beanSimpleName.substring(0, beanSimpleName.length() - iShortName.length()).toLowerCase();
         }
       }
-      final var genericType = GenericType.parse(rawType);
       // check if any unknown generic types are in the parameters (T,T2, etc.)
       final var knownType =
           genericType.params().stream()

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -132,7 +132,9 @@ final class TypeExtendsReader {
       extendsInjection.read(baseType);
     }
     readInterfaces(baseType);
-    final TypeElement superElement = superOf(baseType);
+    final var superMirror = baseType.getSuperclass();
+    final TypeElement superElement = asElement(superMirror);
+
     if (superElement != null) {
       if (qualifierName == null) {
         final String baseName = baseType.getSimpleName().toString();
@@ -141,7 +143,7 @@ final class TypeExtendsReader {
           qualifierName = baseName.substring(0, baseName.length() - superName.length()).toLowerCase();
         }
       }
-      addSuperType(superElement);
+      addSuperType(superElement,superMirror);
     }
 
     providesTypes.addAll(extendsTypes);
@@ -161,21 +163,20 @@ final class TypeExtendsReader {
     return "";
   }
 
-  private void addSuperType(TypeElement element) {
+  private void addSuperType(TypeElement element, TypeMirror mirror) {
     readInterfaces(element);
-    final String fullName = element.getQualifiedName().toString();
+    final String fullName = mirror.toString();
     if (!JAVA_LANG_OBJECT.equals(fullName) && !JAVA_LANG_RECORD.equals(fullName)) {
       final String type = Util.unwrapProvider(fullName);
       if (isPublic(element)) {
         extendsTypes.add(type);
         extendsInjection.read(element);
       }
-      addSuperType(superOf(element));
-    }
-  }
 
-  private TypeElement superOf(TypeElement element) {
-    return (TypeElement) asElement(element.getSuperclass());
+      final var superMirror = element.getSuperclass();
+      final TypeElement superElement = asElement(superMirror);
+      addSuperType(superElement, superMirror);
+    }
   }
 
   private void readInterfaces(TypeElement type) {


### PR DESCRIPTION
It seems when using class -> generic class -> generic class/interface, the type information is lost when calling `getInterfaces`/`getSuperClass`, with no way to retrieve it. 

To solve this, I have made it so that if an unknown type is added to the list of super interfaces we will write the raw type without generic parameters.

This isn't a problem when using class -> generic interface -> generic interface.


fixes #347 
