### PR TITLE
Sanitize DI class imports

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -303,7 +303,7 @@ final class BeanReader {
     }
     for (String importType : importTypes()) {
       if (Util.validImportType(importType)) {
-        writer.append("import %s;", importType).eol();
+        writer.append("import %s;", Util.sanitizeimports(importType)).eol();
       }
     }
     writer.eol();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -64,7 +64,7 @@ final class Util {
       return type.replace("[]", "");
     }
 
-    var start = pos == 0 ? type.substring(0, pos + 1) : "";
+    var start = pos == 0 ? type.substring(0, pos) : "";
 
     return start + type.substring(type.lastIndexOf(' ') + 1).replace("[]", "");
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -58,6 +58,17 @@ final class Util {
     return type.substring(0, pos + 1) + type.substring(type.lastIndexOf(' ') + 1);
   }
 
+  public static String sanitizeimports(String type) {
+    int pos = type.indexOf("@");
+    if (pos == -1) {
+      return type.replace("[]", "");
+    }
+
+    var start = pos == 0 ? type.substring(0, pos + 1) : "";
+
+    return start + type.substring(type.lastIndexOf(' ') + 1).replace("[]", "");
+  }
+
   static String nestedPackageOf(String cls) {
     int pos = cls.lastIndexOf('.');
     if (pos < 0) {

--- a/inject-generator/src/test/java/io/avaje/inject/generator/UtilTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/UtilTest.java
@@ -123,4 +123,10 @@ class UtilTest {
   void trimMethod_when_genericType() {
     assertThat(Util.trimMethod("foo.bar.ProcessMe<java.lang.String>")).isEqualTo("bar_ProcessMe");
   }
+
+  @Test
+  void sanitizedType() {
+    assertEquals("my.Foo", Util.sanitizeimports("my.Foo"));
+    assertEquals("my.Foo", Util.sanitizeimports("@annotationMcgee my.Foo[]"));
+  }
 }


### PR DESCRIPTION
On the discord, an issue was reported that something like this generates invalid adapters.

```
@Singleton
public class ServersService {
  ...
  public @Inject ServersService(final @NotNull JedisPool jedisPool, final @NotNull NatsConnection natsConnection) {
    this.jedisPool = jedisPool;
    this.natsConnection = natsConnection;
  }
  ...
```

the generated DI class has annotations in the imports causing compilation to fail.

I could not replicate the issue on my local, but I'm sure this'll fix it. (or else do absolutely nothing).