### PR TITLE
Fix Generic type Params showing up in generated requires

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -400,8 +400,10 @@ final class ScopeInfo {
     writer.append("  @Override").eol();
     writer.append("  public Class<?>[] %s() { return %s; }", fieldName, fieldName).eol();
     writer.append("  private final Class<?>[] %s = new Class<?>[]{", fieldName).eol();
-    for (String rawType : types) {
-      writer.append("    %s.class,", rawType).eol();
+    for (final String rawType : types) {
+      final var pos = rawType.indexOf("<");
+      final var type = pos == -1 ? rawType : rawType.substring(0, pos);
+      writer.append("    %s.class,", type).eol();
     }
     writer.append("  };").eol().eol();
   }


### PR DESCRIPTION
Got a request saying

>I have a constructor injecting a MongoCollection<Document> param and the module has a requires for org.MongoDB.client.MongoCollection<org.Bson.Document>.class but it should be ignoring generics
that didn’t happen in earlier versions, haven’t narrowed it down to which inject version breaks it though

didn't get more than that but I think this should resolve it.