### PR TITLE
Default implementations for redundant PropertyRequiresPlugin methods

### DIFF
--- a/inject/src/main/java/io/avaje/inject/spi/PropertyRequiresPlugin.java
+++ b/inject/src/main/java/io/avaje/inject/spi/PropertyRequiresPlugin.java
@@ -19,7 +19,9 @@ public interface PropertyRequiresPlugin {
   /**
    * Return true if the property is not defined.
    */
-  boolean missing(String property);
+  default boolean missing(String property) {
+    return !contains(property);
+  }
 
   /**
    * Return true if the property is equal to the given value.
@@ -29,5 +31,7 @@ public interface PropertyRequiresPlugin {
   /**
    * Return true if the property is not defined or not equal to the given value.
    */
-  boolean notEqualTo(String property, String value);
+  default boolean notEqualTo(String property, String value) {
+    return !equalTo(property, value);
+  }
 }


### PR DESCRIPTION
Creates some default implementations returning the opposite of contains and equalTo for their opposing redundant methods.
I don't know why these are here, and perhaps they don't serve a purpose and their usages can be migrated to, well, the opposite of contains and equalTo.