### PR TITLE
Fix typeuse annotations not getting trimmed properly

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -49,14 +49,13 @@ final class Util {
     return type.substring(0, i);
   }
 
-
   /** Trim off annotations from the raw type if present. */
   public static String trimAnnotations(String type) {
-    final int pos = type.indexOf(".@");
+    final int pos = type.indexOf("@");
     if (pos == -1) {
       return type;
     }
-    return type.substring(0, pos + 1) + type.substring(type.lastIndexOf(' ') + 1);
+    return type.substring(0, pos) + type.substring(type.lastIndexOf(' ') + 1);
   }
 
   public static String sanitizeImports(String type) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -1,7 +1,10 @@
 package io.avaje.inject.generator;
 
-import java.util.Optional;
 import static io.avaje.inject.generator.ProcessingContext.isImportedType;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
@@ -9,6 +12,7 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
 final class Util {
+  static Pattern ANNOTATION_REGEX = Pattern.compile("(@.*?)(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)\\s");
 
   static final String ASPECT_PROVIDER_PREFIX = "io.avaje.inject.aop.AspectProvider<";
   static final String PROVIDER_PREFIX = "jakarta.inject.Provider<";
@@ -51,14 +55,16 @@ final class Util {
 
   /** Trim off annotations from the raw type if present. */
   public static String trimAnnotations(String input) {
-    // Regular expression pattern to match annotations
-    final String annotationPattern = "@[^\\s(]+(?:\\([^)]*\\))?";
 
-    // Replace annotations with an empty string
-    final String withoutAnnotations = input.replaceAll(annotationPattern, "");
+    // Use a pattern matcher to find the first occurrence of the pattern
+    final Matcher matcher = ANNOTATION_REGEX.matcher(input);
+    String result = input;
+    while (matcher.find()) {
+      final String matchedSubstring = matcher.group();
+      result = result.replace(matchedSubstring, "");
+    }
 
-    // Remove any remaining whitespace
-    return withoutAnnotations.replaceAll("\\s", "");
+    return result.toString().replace(" ", "");
   }
 
   public static String sanitizeImports(String type) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -12,7 +12,7 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
 final class Util {
-  static Pattern ANNOTATION_REGEX = Pattern.compile("(@.*?)(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)\\s");
+  private static final Pattern ANNOTATION_REGEX = Pattern.compile("(@.*?)(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)\\s");
 
   static final String ASPECT_PROVIDER_PREFIX = "io.avaje.inject.aop.AspectProvider<";
   static final String PROVIDER_PREFIX = "jakarta.inject.Provider<";

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -64,7 +64,7 @@ final class Util {
       result = result.replace(matchedSubstring, "");
     }
 
-    return result.toString().replace(" ", "");
+    return result.toString();
   }
 
   public static String sanitizeImports(String type) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -50,21 +50,24 @@ final class Util {
   }
 
   /** Trim off annotations from the raw type if present. */
-  public static String trimAnnotations(String type) {
-    final int pos = type.indexOf("@");
-    if (pos == -1) {
-      return type;
-    }
-    return type.substring(0, pos) + type.substring(type.lastIndexOf(' ') + 1);
+  public static String trimAnnotations(String input) {
+    // Regular expression pattern to match annotations
+    final String annotationPattern = "@[^\\s(]+(?:\\([^)]*\\))?";
+
+    // Replace annotations with an empty string
+    final String withoutAnnotations = input.replaceAll(annotationPattern, "");
+
+    // Remove any remaining whitespace
+    return withoutAnnotations.replaceAll("\\s", "");
   }
 
   public static String sanitizeImports(String type) {
     final int pos = type.indexOf("@");
     if (pos == -1) {
-      return type.replace("[]", "");
+      return type.replaceAll("[^\\n\\r\\t $;\\w.]", "");
     }
     final var start = pos == 0 ? type.substring(0, pos) : "";
-    return start + type.substring(type.lastIndexOf(' ') + 1).replace("[]", "");
+    return start + type.substring(type.lastIndexOf(' ') + 1).replaceAll("[^\\n\\r\\t $;\\w.]", "");
   }
 
   static String nestedPackageOf(String cls) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -12,8 +12,10 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
 final class Util {
+  // whitespace not in quotes
   private static final Pattern WHITE_SPACE_REGEX =
       Pattern.compile("\\s+(?=([^\"]*\"[^\"]*\")*[^\"]*$)");
+  // comma not in quotes
   private static final Pattern COMMA_PATTERN =
       Pattern.compile(", (?=(?:[^\\\"]*\\\"[^\\\"]*\\\")*[^\\\"]*$)");
   static final String ASPECT_PROVIDER_PREFIX = "io.avaje.inject.aop.AspectProvider<";
@@ -69,7 +71,7 @@ final class Util {
       return input;
     }
 
-     final Matcher matcher = WHITE_SPACE_REGEX.matcher(input);
+    final Matcher matcher = WHITE_SPACE_REGEX.matcher(input);
 
     int currentIndex = 0;
     if (matcher.find()) {

--- a/inject-generator/src/test/java/io/avaje/inject/generator/UtilTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/UtilTest.java
@@ -127,6 +127,10 @@ class UtilTest {
         "java.util.Map<String,String>",
         Util.trimAnnotations(
             "java.util.Map<@jakarta.validation.constraints.Positive String,String>"));
+    assertEquals(
+        "java.util.List<java.lang.String>",
+        Util.trimAnnotations(
+            "java.util.@jakarta.validation.constraints.NotEmpty List<java.lang.@jakarta.validation.constraints.NotNull String>"));
   }
 
   @Test
@@ -168,5 +172,6 @@ class UtilTest {
     assertEquals("my.Foo", Util.sanitizeImports("@annotationMcgee my.Foo"));
     assertEquals("my.Foo", Util.sanitizeImports("@org.bar.annotationMcgee my.Foo[]"));
     assertEquals("my.Foo", Util.sanitizeImports("@org.bar.annotationMcgee my.Foo"));
+    assertEquals("java.util.String", Util.sanitizeImports("java.util.String>"));
   }
 }

--- a/inject-generator/src/test/java/io/avaje/inject/generator/UtilTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/UtilTest.java
@@ -122,15 +122,15 @@ class UtilTest {
 
   @Test
   void trimmedAnnotation() {
+    assertEquals(
+        "java.util.List<java.lang.String>",
+        Util.trimAnnotations(
+            "java.util.@jakarta.validation.constraints.NotEmpty(\"message(); ,\") List<java.lang.@jakarta.validation.constraints.NotNull String>"));
     assertEquals("int", Util.trimAnnotations("@jakarta.validation.constraints.Positive int"));
     assertEquals(
         "java.util.Map<String,String>",
         Util.trimAnnotations(
             "java.util.Map<@jakarta.validation.constraints.Positive String,String>"));
-    assertEquals(
-        "java.util.List<java.lang.String>",
-        Util.trimAnnotations(
-            "java.util.@jakarta.validation.constraints.NotEmpty List<java.lang.@jakarta.validation.constraints.NotNull String>"));
   }
 
   @Test

--- a/inject-generator/src/test/java/io/avaje/inject/generator/UtilTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/UtilTest.java
@@ -122,16 +122,23 @@ class UtilTest {
 
   @Test
   void trimmedAnnotation() {
+
+  assertEquals(
+        "java.util.Map<java.lang.String,java.lang.String>",
+        Util.trimAnnotations(
+            "java.util.@io.avaje.validation.constraints.NotEmpty(message=\"sus \", groups={io.avaje.validation.generator.models.valid.Ship.class}) Map<java.lang.@io.avaje.validation.constraints.NotEmpty(groups={io.avaje.validation.generator.models.valid.Ship.class}),@io.avaje.validation.constraints.NotBlank String,java.lang.@io.avaje.validation.constraints.NotBlank(groups={io.avaje.validation.generator.models.valid.Ship.class}),@io.avaje.validation.Valid String>"));
+
     assertEquals(
         "java.util.List<java.lang.String>",
         Util.trimAnnotations(
             "java.util.@jakarta.validation.constraints.NotEmpty(\"message(); ,\") List<java.lang.@jakarta.validation.constraints.NotNull String>"));
     assertEquals("int", Util.trimAnnotations("@jakarta.validation.constraints.Positive int"));
     assertEquals(
-        "java.util.Map<String,String>",
+        "java.util.Map<java.lang.String,java.lang.String>",
         Util.trimAnnotations(
-            "java.util.Map<@jakarta.validation.constraints.Positive String,String>"));
-  }
+            "java.util.Map<@jakarta.validation.constraints.Positive(message=\"sus \", groups=1) java.lang.String,java.lang.String>"));
+
+    }
 
   @Test
   void validImportType_not() {

--- a/inject-generator/src/test/java/io/avaje/inject/generator/UtilTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/UtilTest.java
@@ -121,6 +121,15 @@ class UtilTest {
   }
 
   @Test
+  void trimmedAnnotation() {
+    assertEquals("int", Util.trimAnnotations("@jakarta.validation.constraints.Positive int"));
+    assertEquals(
+        "java.util.Map<String,String>",
+        Util.trimAnnotations(
+            "java.util.Map<@jakarta.validation.constraints.Positive String,String>"));
+  }
+
+  @Test
   void validImportType_not() {
     assertFalse(Util.validImportType("void"));
     assertFalse(Util.validImportType("Foo"));

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/MethodTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/MethodTest.java
@@ -1,0 +1,13 @@
+package io.avaje.inject.generator.models.valid.aspect;
+
+import java.util.Map;
+
+import io.avaje.inject.Component;
+import io.avaje.inject.generator.models.valid.Timed;
+
+@Component
+public class MethodTest {
+
+  @Timed
+  void test(@Param Map<@TypeUse String, String> str, @Param int inty, String regular) {}
+}

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/Param.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/Param.java
@@ -1,0 +1,3 @@
+package io.avaje.inject.generator.models.valid.aspect;
+
+public @interface Param {}

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/TypeUse.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/TypeUse.java
@@ -1,0 +1,11 @@
+package io.avaje.inject.generator.models.valid.aspect;
+
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target(TYPE_USE)
+@Retention(RUNTIME)
+public @interface TypeUse {}


### PR DESCRIPTION
It seems that our trim functions were not designed to handle type_use.

Use regex to trim annotations.
Use regex to sanitize imports.