### PR TITLE
Make Generated `@DependencyMeta` annotations more readable

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
@@ -177,27 +177,48 @@ final class MetaData {
     if (usesExternalDependency) {
       append.append("  // uses external dependency ").append(externalDependency).append(NEWLINE);
     }
-    append.append("  @DependencyMeta(").eol().append("      type = \"").append(type).append("\"");
-    if (name != null) {
+
+    final var  hasName= name != null;
+
+    final var hasMethod = hasMethod();
+    final var hasProvidesAspect = !providesAspect.isEmpty();
+    final var hasDependsOn = !dependsOn.isEmpty();
+    final var hasProvides = !provides.isEmpty();
+    final var hasAutoProvides = autoProvides != null && !autoProvides.isEmpty();
+
+    append.append("  @DependencyMeta(");
+
+    if (hasName
+        || hasMethod
+        || hasProvidesAspect
+        || hasDependsOn
+        || hasProvides
+        || hasAutoProvides) {
+      append.eol().append("      ");
+    }
+
+    append
+    .append("type = \"").append(type).append("\"");
+    if (hasName) {
       append.append(",").eol().append("      name = \"").append(name).append("\"");
     }
-    if (hasMethod()) {
+    if (hasMethod) {
       append.append(",").eol().append("      method = \"").append(method).append("\"");
     }
-    if (!providesAspect.isEmpty()) {
+    if (hasProvidesAspect) {
       append
           .append(",")
           .eol()
           .append("      providesAspect = \"")
           .append(providesAspect)
           .append("\"");
-    } else if (!provides.isEmpty()) {
+    } else if (hasProvides) {
       appendProvides(append, "provides", provides);
     }
-    if (!dependsOn.isEmpty()) {
+    if (hasDependsOn) {
       appendProvides(append, "dependsOn", dependsOn.stream().map(Dependency::dependsOn).collect(Collectors.toList()));
     }
-    if (autoProvides != null && !autoProvides.isEmpty()) {
+    if (hasAutoProvides) {
       append.append(",").eol().append("      autoProvides = \"").append(autoProvides).append("\"");
     }
     append.append(")").append(NEWLINE);

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
@@ -178,8 +178,7 @@ final class MetaData {
       append.append("  // uses external dependency ").append(externalDependency).append(NEWLINE);
     }
 
-    final var  hasName= name != null;
-
+    final var hasName = name != null;
     final var hasMethod = hasMethod();
     final var hasProvidesAspect = !providesAspect.isEmpty();
     final var hasDependsOn = !dependsOn.isEmpty();
@@ -197,8 +196,7 @@ final class MetaData {
       append.eol().append("      ");
     }
 
-    append
-    .append("type = \"").append(type).append("\"");
+    append.append("type = \"").append(type).append("\"");
     if (hasName) {
       append.append(",").eol().append("      name = \"").append(name).append("\"");
     }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
@@ -1,4 +1,5 @@
 package io.avaje.inject.generator;
+
 import static io.avaje.inject.generator.ProcessingContext.*;
 
 import java.util.ArrayList;
@@ -35,6 +36,7 @@ final class MetaData {
    * Type deemed to be candidate for providing to another external module.
    */
   private String autoProvides;
+
   private boolean generateProxy;
   private boolean usesExternalDependency;
   private String externalDependency;
@@ -175,15 +177,20 @@ final class MetaData {
     if (usesExternalDependency) {
       append.append("  // uses external dependency ").append(externalDependency).append(NEWLINE);
     }
-    append.append("  @DependencyMeta(type=\"").append(type).append("\"");
+    append.append("  @DependencyMeta(").eol().append("      type = \"").append(type).append("\"");
     if (name != null) {
-      append.append(", name=\"").append(name).append("\"");
+      append.append(",").eol().append("      name = \"").append(name).append("\"");
     }
     if (hasMethod()) {
-      append.append(", method=\"").append(method).append("\"");
+      append.append(",").eol().append("      method = \"").append(method).append("\"");
     }
     if (!providesAspect.isEmpty()) {
-      append.append(", providesAspect=\"").append(providesAspect).append("\"");
+      append
+          .append(",")
+          .eol()
+          .append("      providesAspect = \"")
+          .append(providesAspect)
+          .append("\"");
     } else if (!provides.isEmpty()) {
       appendProvides(append, "provides", provides);
     }
@@ -191,7 +198,7 @@ final class MetaData {
       appendProvides(append, "dependsOn", dependsOn.stream().map(Dependency::dependsOn).collect(Collectors.toList()));
     }
     if (autoProvides != null && !autoProvides.isEmpty()) {
-      append.append(", autoProvides=\"").append(autoProvides).append("\"");
+      append.append(",").eol().append("      autoProvides = \"").append(autoProvides).append("\"");
     }
     append.append(")").append(NEWLINE);
     append.append("  private void build_").append(buildName()).append("() {").append(NEWLINE);
@@ -210,14 +217,21 @@ final class MetaData {
   }
 
   private void appendProvides(Append sb, String attribute, List<String> types) {
-    sb.append(", ").append(attribute).append("={");
+    sb.append(",").eol().append("      ").append(attribute).append(" = {");
+    final var size = types.size();
+    if (size > 1) {
+      sb.eol().append("        ");
+    }
     for (int i = 0; i < types.size(); i++) {
       if (i > 0) {
-        sb.append(",");
+        sb.append(",").eol().append("        ");
       }
       sb.append("\"");
       sb.append(types.get(i));
       sb.append("\"");
+    }
+    if (size > 1) {
+      sb.eol().append("      ");
     }
     sb.append("}");
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -439,11 +439,6 @@ final class ScopeInfo {
     }
   }
 
-
-    final String replacement = "$1_$2";
-    return str.replaceAll(regex, replacement).toUpperCase();
-  }
-
   void readModuleMetaData(TypeElement moduleType) {
     final InjectModulePrism module = InjectModulePrism.getInstanceOn(moduleType);
     details(module.name(), moduleType);

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -398,7 +398,7 @@ final class ScopeInfo {
 
   private void buildProvidesMethod(Append writer, String fieldName, Set<String> types) {
     writer.append("  @Override").eol();
-    writer.append("  public Class<?>[] %s() { return %s; }", fieldName, fieldName).eol();
+    writer.append("  public Class<?>[] %s() {\n    return %s;\n  }", fieldName, fieldName).eol();
     writer.append("  private final Class<?>[] %s = new Class<?>[]{", fieldName).eol();
     for (final String rawType : types) {
       writer.append("    %s.class,", trimGenerics(rawType)).eol();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -439,8 +439,13 @@ final class ScopeInfo {
     }
   }
 
+
+    final String replacement = "$1_$2";
+    return str.replaceAll(regex, replacement).toUpperCase();
+  }
+
   void readModuleMetaData(TypeElement moduleType) {
-    InjectModulePrism module = InjectModulePrism.getInstanceOn(moduleType);
+    final InjectModulePrism module = InjectModulePrism.getInstanceOn(moduleType);
     details(module.name(), moduleType);
     readFactoryMetaData(moduleType);
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
@@ -20,7 +20,7 @@ final class SimpleModuleWriter {
     "/**\n" +
       " * Generated source - avaje inject module for %s.\n" +
       " * \n" +
-      " * With Java module system this generated class should be explicitly\n" +
+      " * With the Java module system, this generated class should be explicitly\n" +
       " * registered in module-info via a <code>provides</code> clause like:\n" +
       " * \n" +
       " * <pre>{@code\n" +

--- a/inject/src/main/java/io/avaje/inject/spi/DependencyMeta.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DependencyMeta.java
@@ -38,7 +38,7 @@ public @interface DependencyMeta {
   String[] provides() default {};
 
   /**
-   * The list of dependencies.
+   * The list of dependencies this bean requires.
    */
   String[] dependsOn() default {};
 


### PR DESCRIPTION
Before:
```java
 @DependencyMeta(type="io.helidon.nima.webserver.WebServer", method="com.jojo.helidon.api.config.ServerFactory$DI.build_server", dependsOn={"com.jojo.helidon.api.config.ServerFactory","io.helidon.nima.webserver.http.HttpService"}, autoProvides="io.helidon.nima.webserver.WebServer")
  private void build_webserver_WebServer() {
    ServerFactory$DI.build_server(builder);
  }
```
After:
```java
  @DependencyMeta(
      type = "io.helidon.nima.webserver.WebServer",
      method = "com.jojo.helidon.api.config.ServerFactory$DI.build_server",
      dependsOn = {
        "com.jojo.helidon.api.config.ServerFactory",
        "io.helidon.nima.webserver.http.HttpService"
      },
      autoProvides = "io.helidon.nima.webserver.WebServer")
  private void build_webserver_WebServer() {
    ServerFactory$DI.build_server(builder);
  }
```

Also makes the provided class arrays static.