### PR TITLE
Remove Generated Array Instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ public final class Example$DI  {
     if (builder.isAddBeanFor(Example.class)) {
       var bean = new Example(builder.get(DependencyClass.class,"!d1"), builder.get(DependencyClass2.class,"!d2"));
       builder.register(bean);
+      // depending on the type of bean, callbacks for field/method injection, and lifecycle support will be generated here as well.
     }
   }
 }
@@ -133,7 +134,7 @@ public final class ExampleModule implements Module {
 
   /**
    * Creates all the beans in order based on constructor dependencies. The beans are registered
-   * into the builder along with callbacks for field injection, method injection, and lifecycle
+   * into the builder along with callbacks for field/method injection, and lifecycle
    * support.
    */
   @Override

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Discord](https://img.shields.io/discord/1074074312421683250?color=%237289da&label=discord)](https://discord.gg/Qcqf9R27BR)
 
 # [Avaje-Inject](https://avaje.io/inject)
-APT based dependency injection for server side developers - https://avaje.io/inject
+APT-based dependency injection for server-side developers - https://avaje.io/inject
 ## Quick Start
 #### 1. Add avaje-inject as a dependency.
 ```xml
@@ -31,7 +31,7 @@ public class Example {
 
  private DependencyClass d1;
  private DependencyClass2 d2;
-  
+
   // Dependencies must be annotated with singleton,
   // or else be provided from another class annotated with @Factory
   public Example(DependencyClass d1, DependencyClass2 d2) {
@@ -126,6 +126,7 @@ public final class ExampleModule implements Module {
   @Override
   public Class<?>[] classes() {
     return new Class<?>[] {
+      org.example.DependencyClass.class,
       org.example.DependencyClass2.class,
       org.example.Example.class,
       org.example.ExampleFactory.class,
@@ -143,6 +144,7 @@ public final class ExampleModule implements Module {
     // create beans in order based on constructor dependencies
     // i.e. "provides" followed by "dependsOn"
     build_example_ExampleFactory();
+    build_example_DependencyClass();
     build_example_DependencyClass2();
     build_example_Example();
   }
@@ -150,6 +152,12 @@ public final class ExampleModule implements Module {
   @DependencyMeta(type = "org.example.ExampleFactory")
   private void build_example_ExampleFactory() {
     ExampleFactory$DI.build(builder);
+  }
+
+  @DependencyMeta(
+      type = "org.example.DependencyClass")
+  private void build_example_DependencyClass() {
+    DependencyClass$DI.build(builder);
   }
 
   @DependencyMeta(

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ public final class Example$DI  {
 ### Generated Wiring Class
 The inject annotation processor determines the dependency wiring order and generates a `Module` class that calls all the generated DI classes.
 
-```
+```java
 @Generated("io.avaje.inject.generator")
 @InjectModule
 public final class ExampleModule implements Module {

--- a/README.md
+++ b/README.md
@@ -154,8 +154,7 @@ public final class ExampleModule implements Module {
     ExampleFactory$DI.build(builder);
   }
 
-  @DependencyMeta(
-      type = "org.example.DependencyClass")
+  @DependencyMeta(type = "org.example.DependencyClass")
   private void build_example_DependencyClass() {
     DependencyClass$DI.build(builder);
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
@@ -133,7 +133,10 @@ public final class Processor extends AbstractProcessor {
   }
 
   private static Map<String, AspectImportPrism> importedAspects(RoundEnvironment roundEnv) {
-    return roundEnv.getElementsAnnotatedWith(element(AspectImportPrism.PRISM_TYPE)).stream()
+    return Optional.ofNullable(element(AspectImportPrism.PRISM_TYPE))
+        .map(roundEnv::getElementsAnnotatedWith)
+        .stream()
+        .flatMap(Set::stream)
         .map(AspectImportPrism::getInstanceOn)
         .collect(Collectors.toMap(p -> p.value().toString(), p -> p));
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -234,8 +234,8 @@ final class ScopeInfo {
       }
       return;
     }
-    MetaDataOrdering ordering = new MetaDataOrdering(meta, this);
-    int remaining = ordering.processQueue();
+    final MetaDataOrdering ordering = new MetaDataOrdering(meta, this);
+    final int remaining = ordering.processQueue();
     if (remaining > 0) {
       ordering.logWarnings();
     }
@@ -399,7 +399,7 @@ final class ScopeInfo {
   private void buildProvidesMethod(Append writer, String fieldName, Set<String> types) {
     writer.append("  @Override").eol();
     writer.append("  public Class<?>[] %s() {\n    return %s;\n  }", fieldName, fieldName).eol();
-    writer.append("  private final Class<?>[] %s = new Class<?>[]{", fieldName).eol();
+    writer.append("  private final Class<?>[] %s = {", fieldName).eol();
     for (final String rawType : types) {
       writer.append("    %s.class,", trimGenerics(rawType)).eol();
     }
@@ -446,7 +446,7 @@ final class ScopeInfo {
   }
 
   private void readFactoryMetaData(TypeElement moduleType) {
-    List<? extends Element> elements = moduleType.getEnclosedElements();
+    final List<? extends Element> elements = moduleType.getEnclosedElements();
     if (elements != null) {
       for (Element element : elements) {
         if (ElementKind.METHOD == element.getKind()) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -364,7 +364,7 @@ final class ScopeInfo {
       if (leadingComma) {
         writer.append(", ");
       }
-      writer.append("customScopeType=\"%s\"", annotationType.getQualifiedName().toString());
+      writer.append("customScopeType = \"%s\"", annotationType.getQualifiedName().toString());
     }
     writer.append(")").eol();
   }
@@ -373,9 +373,9 @@ final class ScopeInfo {
     if (leadingComma) {
       writer.append(", ");
     }
-    writer.append("%s={", prefix);
+    writer.append("%s = {", prefix);
     int c = 0;
-    for (String value : classNames) {
+    for (final String value : classNames) {
       if (c++ > 0) {
         writer.append(",");
       }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
@@ -18,9 +18,9 @@ final class SimpleModuleWriter {
 
   private static final String CODE_COMMENT_FACTORY =
     "/**\n" +
-      " * Generated source - avaje inject module for %s.\n" +
+      " * Avaje Inject module for %s.\n" +
       " * \n" +
-      " * With the Java module system, this generated class should be explicitly\n" +
+      " * When using the Java module system, this generated class should be explicitly\n" +
       " * registered in module-info via a <code>provides</code> clause like:\n" +
       " * \n" +
       " * <pre>{@code\n" +
@@ -39,7 +39,7 @@ final class SimpleModuleWriter {
     "  /**\n" +
       "   * Creates all the beans in order based on constructor dependencies.\n" +
       "   * The beans are registered into the builder along with callbacks for\n" +
-      "   * field injection, method injection and lifecycle support.\n" +
+      "   * field injection, method injection, and lifecycle support.\n" +
       "   */";
 
   private final String modulePackage;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
@@ -39,7 +39,7 @@ final class SimpleModuleWriter {
     "  /**\n" +
       "   * Creates all the beans in order based on constructor dependencies.\n" +
       "   * The beans are registered into the builder along with callbacks for\n" +
-      "   * field injection, method injection, and lifecycle support.\n" +
+      "   * field/method injection, and lifecycle support.\n" +
       "   */";
 
   private final String modulePackage;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
@@ -37,8 +37,6 @@ final class SimpleModuleWriter {
 
   private static final String CODE_COMMENT_CREATE_CONTEXT =
     "  /**\n" +
-      "   * Create the beans.\n" +
-      "   * <p>\n" +
       "   * Creates all the beans in order based on constructor dependencies.\n" +
       "   * The beans are registered into the builder along with callbacks for\n" +
       "   * field injection, method injection and lifecycle support.\n" +

--- a/inject/src/main/java/io/avaje/inject/spi/Module.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Module.java
@@ -63,6 +63,7 @@ public interface Module {
   default Class<?>[] autoRequires() {
     return EMPTY_CLASSES;
   }
+
   /**
    * These are the apects that this module requires whose implementations are provided by other external
    * modules (that are in the classpath at compile time).


### PR DESCRIPTION
Before:

```
  private final Class<?>[] autoProvides =
      new Class<?>[] {
        com.jojo.helidon.api.client.ApiClient.class,
        com.jojo.helidon.api.service.ServiceClass.class,
        io.avaje.http.client.HttpClient.class,
        io.helidon.nima.webserver.WebServer.class,
        io.helidon.nima.webserver.http.HttpService.class,
      };
```

After:
```
  private final Class<?>[] autoProvides = {
        com.jojo.helidon.api.client.ApiClient.class,
        com.jojo.helidon.api.service.ServiceClass.class,
        io.avaje.http.client.HttpClient.class,
        io.helidon.nima.webserver.WebServer.class,
        io.helidon.nima.webserver.http.HttpService.class,
      };
```

Also fixes a weird situation with Intellij where Aspects.Import doesn't exist on the cp.

In addition, adds Generated code to README.