### PR TITLE
Prevent @Component.Import when type is already provided by external module

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
@@ -123,11 +123,15 @@ public final class Processor extends AbstractProcessor {
     return false;
   }
 
-  private static Set<TypeElement> importedElements(RoundEnvironment roundEnv) {
+  private Set<TypeElement> importedElements(RoundEnvironment roundEnv) {
     return roundEnv.getElementsAnnotatedWith(element(ImportPrism.PRISM_TYPE)).stream()
         .map(ImportPrism::getInstanceOn)
         .flatMap(p -> p.value().stream())
         .map(ProcessingContext::asElement)
+        .filter(
+            e ->
+                !moduleFileProvided.contains(e.getQualifiedName().toString())
+                    && !pluginFileProvided.contains(e.getQualifiedName().toString()))
         .peek(e -> addImportedType(e.getQualifiedName().toString()))
         .collect(Collectors.toSet());
   }


### PR DESCRIPTION
This prevents a situation where two maven projects A & B import the same class, and B depends on A, causing the same class to be wired twice and fail.