### PR TITLE
Plugin Aspects

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -1,5 +1,8 @@
 package io.avaje.inject.generator;
 
+import static io.avaje.inject.generator.ProcessingContext.logDebug;
+import static io.avaje.inject.generator.ProcessingContext.logWarn;
+
 import java.util.Iterator;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
@@ -30,13 +33,17 @@ final class ExternalProvider {
 
   static void registerModuleProvidedTypes(Set<String> providedTypes) {
     if (!injectAvailable) {
+      logWarn(
+          "Unable to detect Avaje Inject in Annotation Processor Class Path, use the Avaje Inject Maven/Gradle plugin for detecting external dependencies");
       return;
     }
 
-    Iterator<Module> iterator = ServiceLoader.load(Module.class, ExternalProvider.class.getClassLoader()).iterator();
+    Iterator<Module> iterator =
+        ServiceLoader.load(Module.class, ExternalProvider.class.getClassLoader()).iterator();
     while (iterator.hasNext()) {
       try {
-        Module module = iterator.next();
+        var module = iterator.next();
+        logDebug("Loaded External Module %s", module.getClass().getCanonicalName());
         for (final Class<?> provide : module.provides()) {
           providedTypes.add(provide.getCanonicalName());
         }
@@ -61,6 +68,7 @@ final class ExternalProvider {
       return;
     }
     for (final Plugin plugin : ServiceLoader.load(Plugin.class, Processor.class.getClassLoader())) {
+      logDebug("Loaded Plugin %s", plugin.getClass().getCanonicalName());
       for (final Class<?> provide : plugin.provides()) {
         defaultScope.pluginProvided(provide.getCanonicalName());
       }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -1,5 +1,6 @@
 package io.avaje.inject.generator;
 
+import java.util.Iterator;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.Set;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -1,6 +1,5 @@
 package io.avaje.inject.generator;
 
-import java.util.Iterator;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -63,6 +62,9 @@ final class ExternalProvider {
     for (final Plugin plugin : ServiceLoader.load(Plugin.class, Processor.class.getClassLoader())) {
       for (final Class<?> provide : plugin.provides()) {
         defaultScope.pluginProvided(provide.getCanonicalName());
+      }
+      for (final Class<?> provide : plugin.providesAspects()) {
+        defaultScope.pluginProvided(Util.wrapAspect(provide.getCanonicalName()));
       }
     }
   }

--- a/inject-gradle-plugin/build.gradle
+++ b/inject-gradle-plugin/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'io.avaje:avaje-inject:9.0'
+  implementation 'io.avaje:avaje-inject:9.4-SNAPSHOT'
   implementation gradleApi()
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'

--- a/inject-gradle-plugin/src/main/java/io/avaje/inject/plugin/AvajeInjectPlugin.java
+++ b/inject-gradle-plugin/src/main/java/io/avaje/inject/plugin/AvajeInjectPlugin.java
@@ -2,6 +2,8 @@ package io.avaje.inject.plugin;
 
 import org.gradle.api.*;
 
+import io.avaje.inject.spi.Plugin;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -54,13 +56,22 @@ public class AvajeInjectPlugin implements Plugin<Project> {
   }
 
   private void writeProvidedPlugins(ClassLoader cl, FileWriter pluginWriter) throws IOException {
-    for (final io.avaje.inject.spi.Plugin plugin : ServiceLoader.load(io.avaje.inject.spi.Plugin.class, cl)) {
-      for (final Class<?> providedType : plugin.provides()) {
-        pluginWriter.write(providedType.getCanonicalName());
-        pluginWriter.write("\n");
-      }
-    }
-  }
+	    final Set<String> providedTypes = new HashSet<>();
+
+	    for (final var plugin : ServiceLoader.load(Plugin.class, newClassLoader)) {
+	      for (final Class<?> provide : plugin.provides()) {
+	        providedTypes.add(provide.getCanonicalName());
+	      }
+	      for (final Class<?> provide : plugin.providesAspects()) {
+	        providedTypes.add(wrapAspect(provide.getCanonicalName()));
+	      }
+	    }
+
+	    for (final var providedType : providedTypes) {
+	    	pluginWriter.write(providedType);
+	    	pluginWriter.write("\n");
+	    }
+	  }
 
   private void writeProvidedModules(ClassLoader classLoader, FileWriter moduleWriter) throws IOException {
     final Set<String> providedTypes = new HashSet<>();

--- a/inject-maven-plugin/pom.xml
+++ b/inject-maven-plugin/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
-      <version>8.12-RC4</version>
+      <version>9.4-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
+++ b/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
@@ -84,19 +84,28 @@ public class AutoProvidesMojo extends AbstractMojo {
 
   private void writeProvidedPlugins(URLClassLoader newClassLoader, FileWriter pluginWriter)
       throws IOException {
-    for (final var plugin : ServiceLoader.load(Plugin.class, newClassLoader)) {
-      for (final Class<?> providedType : plugin.provides()) {
-        pluginWriter.write(providedType.getCanonicalName());
-        pluginWriter.write("\n");
-      }
-    }
-  }
+	    final Set<String> providedTypes = new HashSet<>();
+
+	    for (final var plugin : ServiceLoader.load(Plugin.class, newClassLoader)) {
+	      for (final Class<?> provide : plugin.provides()) {
+	        providedTypes.add(provide.getCanonicalName());
+	      }
+	      for (final Class<?> provide : plugin.providesAspects()) {
+	        providedTypes.add(wrapAspect(provide.getCanonicalName()));
+	      }
+	    }
+
+	    for (final var providedType : providedTypes) {
+	    	pluginWriter.write(providedType);
+	    	pluginWriter.write("\n");
+	    }
+	  }
 
   private void writeProvidedModules(URLClassLoader newClassLoader, FileWriter moduleWriter)
       throws IOException {
     final Set<String> providedTypes = new HashSet<>();
 
-    for (final Module module : ServiceLoader.load(Module.class, newClassLoader)) {
+    for (final var module : ServiceLoader.load(Module.class, newClassLoader)) {
       for (final Class<?> provide : module.provides()) {
         providedTypes.add(provide.getCanonicalName());
       }

--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -12,7 +12,7 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.*;
 
 /**
  * Build a bean scope with options for shutdown hook and supplying test doubles.
@@ -236,7 +236,11 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
         " Review IntelliJ Settings / Build / Build tools / Gradle - 'Build and run using' value and set that to 'Gradle'. " +
         " Refer to https://avaje.io/inject#gradle");
     }
-    log.log(DEBUG, "building with modules {0}", moduleNames);
+    
+    log.log(
+        propertyRequiresPlugin.contains("printModules") ? INFO : DEBUG,
+        "building with modules {0}",
+        moduleNames);
 
     final Builder builder = Builder.newBuilder(propertyRequiresPlugin, suppliedBeans, enrichBeans, parent, parentOverride);
     for (final Module factory : factoryOrder.factories()) {

--- a/inject/src/main/java/io/avaje/inject/spi/GenericType.java
+++ b/inject/src/main/java/io/avaje/inject/spi/GenericType.java
@@ -5,7 +5,7 @@ import java.lang.reflect.Type;
 /**
  * Represents a full type including generics declaration, to avoid information loss due to type erasure.
  * <p>
- * This is a cut down version of Helidon GenericType Apache 2 licence.
+ * This is a cut down version of Helidon GenericType Apache 2 license.
  *
  * @param <T> the generic type parameter
  */

--- a/inject/src/main/java/io/avaje/inject/spi/Plugin.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Plugin.java
@@ -6,20 +6,25 @@ import java.lang.reflect.Type;
 
 /**
  * A Plugin that can be applied when creating a bean scope.
- * <p>
- * Typically, a plugin might provide a default dependency via {@link BeanScopeBuilder#provideDefault(Type, java.util.function.Supplier)}.
+ *
+ * <p>Typically, a plugin might provide a default dependency via {@link
+ * BeanScopeBuilder#provideDefault(Type, java.util.function.Supplier)}.
  */
 public interface Plugin {
 
-  /**
-   * Return the classes that the plugin provides.
-   */
+  /** Apply the plugin to the scope builder. */
+  void apply(BeanScopeBuilder builder);
+
+  /** Empty array of classes. */
+  Class<?>[] EMPTY_CLASSES = {};
+
+  /** Return the classes that the plugin provides. */
   default Class<?>[] provides() {
-    return new Class<?>[]{};
+    return EMPTY_CLASSES;
   }
 
-  /**
-   * Apply the plugin to the scope builder.
-   */
-  void apply(BeanScopeBuilder builder);
+  /** Return the aspect classes that the plugin provides. */
+  default Class<?>[] providesAspects() {
+    return EMPTY_CLASSES;
+  }
 }


### PR DESCRIPTION
Now Plugins can provide Aspect Provider classes. 

Works on my local, it fails on the pipeline since the inject plugins don't have the new version

- modify plugin interfaces to provide aspects as well
- modify inject plugins to use this new method
- enhance generator logging to show the detected modules
- now will log modules with INFO instead of DEBUG if `printModules` property is set (I really don't want to have to pull in an logging adapter just to set the log level for debugging)