### PR TITLE
Fix Module Debug Logging

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -1,6 +1,7 @@
 package io.avaje.inject.generator;
 
-import static io.avaje.inject.generator.ProcessingContext.*;
+import static io.avaje.inject.generator.ProcessingContext.logDebug;
+import static io.avaje.inject.generator.ProcessingContext.logWarn;
 
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
@@ -36,24 +37,23 @@ final class ExternalProvider {
       return;
     }
 
-    for (final Module module :
-        ServiceLoader.load(Module.class, ExternalProvider.class.getClassLoader())) {
-      try {
-        logDebug("Loaded External Module %s", module.getClass().getCanonicalName());
+    for (final Module module:ServiceLoader.load(Module.class, ExternalProvider.class.getClassLoader())){
+    try {
+      logDebug("Loaded External Module %s", module.getClass().getCanonicalName());
 
-        for (final Class<?> provide : module.provides()) {
-          providedTypes.add(provide.getCanonicalName());
-        }
-        for (final Class<?> provide : module.autoProvides()) {
-          providedTypes.add(provide.getCanonicalName());
-        }
-        for (final Class<?> provide : module.autoProvidesAspects()) {
-          providedTypes.add(Util.wrapAspect(provide.getCanonicalName()));
-        }
-      } catch (final ServiceConfigurationError expected) {
-        // ignore expected error reading the module that we are also writing
+      for (final Class<?> provide : module.provides()) {
+        providedTypes.add(provide.getCanonicalName());
       }
+      for (final Class<?> provide : module.autoProvides()) {
+        providedTypes.add(provide.getCanonicalName());
+      }
+      for (final Class<?> provide : module.autoProvidesAspects()) {
+        providedTypes.add(Util.wrapAspect(provide.getCanonicalName()));
+      }
+    } catch (final ServiceConfigurationError expected) {
+      // ignore expected error reading the module that we are also writing
     }
+  }
   }
 
   /**
@@ -65,6 +65,7 @@ final class ExternalProvider {
       return;
     }
     for (final Plugin plugin : ServiceLoader.load(Plugin.class, Processor.class.getClassLoader())) {
+      logDebug("Loaded Plugin %s", plugin.getClass().getCanonicalName());
       for (final Class<?> provide : plugin.provides()) {
         defaultScope.pluginProvided(provide.getCanonicalName());
       }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -1,6 +1,7 @@
 package io.avaje.inject.generator;
 
-import java.util.Iterator;
+import static io.avaje.inject.generator.ProcessingContext.*;
+
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -30,13 +31,16 @@ final class ExternalProvider {
 
   static void registerModuleProvidedTypes(Set<String> providedTypes) {
     if (!injectAvailable) {
+      logWarn(
+          "Running in Compiler Plugin/Modular Project, use the Avaje Inject Maven/Gradle plugin for automatic external module discovery");
       return;
     }
 
-    Iterator<Module> iterator = ServiceLoader.load(Module.class, ExternalProvider.class.getClassLoader()).iterator();
-    while (iterator.hasNext()) {
+    for (final Module module :
+        ServiceLoader.load(Module.class, ExternalProvider.class.getClassLoader())) {
       try {
-        Module module = iterator.next();
+        logDebug("Loaded External Module %s", module.getClass().getCanonicalName());
+
         for (final Class<?> provide : module.provides()) {
           providedTypes.add(provide.getCanonicalName());
         }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -34,7 +34,7 @@ final class ExternalProvider {
   static void registerModuleProvidedTypes(Set<String> providedTypes) {
     if (!injectAvailable) {
       logWarn(
-          "Running in Compiler Plugin/Modular Project, use the Avaje Inject Maven/Gradle plugin for automatic external module discovery");
+          "Unable to detect Avaje Inject in Annotation Processor Class Path, use the Avaje Inject Maven/Gradle plugin for detecting external dependencies");
       return;
     }
 

--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -12,7 +12,7 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.*;
 
 /**
  * Build a bean scope with options for shutdown hook and supplying test doubles.
@@ -236,7 +236,9 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
         " Review IntelliJ Settings / Build / Build tools / Gradle - 'Build and run using' value and set that to 'Gradle'. " +
         " Refer to https://avaje.io/inject#gradle");
     }
-    log.log(DEBUG, "building with modules " + moduleNames);
+    log.log(
+        propertyRequiresPlugin.contains("printModules") ? INFO : DEBUG,
+        "building with modules " + moduleNames);
 
     final Builder builder = Builder.newBuilder(propertyRequiresPlugin, suppliedBeans, enrichBeans, parent, parentOverride);
     for (final Module factory : factoryOrder.factories()) {

--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -236,7 +236,7 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
         " Review IntelliJ Settings / Build / Build tools / Gradle - 'Build and run using' value and set that to 'Gradle'. " +
         " Refer to https://avaje.io/inject#gradle");
     }
-    log.log(DEBUG, "building with modules {0}", moduleNames);
+    log.log(DEBUG, "building with modules " + moduleNames);
 
     final Builder builder = Builder.newBuilder(propertyRequiresPlugin, suppliedBeans, enrichBeans, parent, parentOverride);
     for (final Module factory : factoryOrder.factories()) {

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
@@ -242,7 +242,7 @@ final class DBeanScope implements BeanScope {
     } finally {
       lock.unlock();
     }
-    log.log(INFO, "Wired beans in {0}ms", (System.currentTimeMillis() - start));
+    log.log(INFO, String.format("Wired beans in %sms", System.currentTimeMillis() - start));
     return this;
   }
 

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
@@ -10,6 +10,7 @@ import io.avaje.lang.Nullable;
 import java.lang.System.Logger.Level;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.text.MessageFormat;
 import java.util.*;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
@@ -242,7 +243,7 @@ final class DBeanScope implements BeanScope {
     } finally {
       lock.unlock();
     }
-    log.log(INFO, String.format("Wired beans in %sms", System.currentTimeMillis() - start));
+    log.log(INFO, MessageFormat.format("Wired beans in {0}ms", System.currentTimeMillis() - start));
     return this;
   }
 


### PR DESCRIPTION
It seems that even when I add that swanky new adapter from slf4j:

```
		<dependency>
			<groupId>org.slf4j</groupId>
			<artifactId>slf4j-jdk-platform-logging</artifactId>
			<scope>runtime</scope>
		</dependency>
```

the debug log looks like this instead of showing the loaded modules: `22:20:44.627 [main] DEBUG io.avaje.inject - building with modules {0}`

Also adds logging for the detected modules from the generator.