### PR TITLE
BeanScopeBuilder - change addPostConstruct() and addPreDestroy() methods

### DIFF
--- a/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
@@ -215,24 +215,18 @@ public interface BeanScopeBuilder {
 
   /**
    * Adds hooks that will execute after this scope is built.
-   *
-   * @param runnables the PostConstruct hooks to add to the bean scope
    */
-  BeanScopeBuilder addPostConstructHooks(Runnable... runnables);
+  BeanScopeBuilder addPostConstruct(Runnable postConstructHook);
 
   /**
    * Adds hook that will execute after this scope is built.
-   *
-   * @param consumer the PostConstruct hook to add to the bean scope
    */
-  BeanScopeBuilder addPostConstructConsumerHook(Consumer<BeanScope> consumer);
+  BeanScopeBuilder addPostConstruct(Consumer<BeanScope> postConstructHook);
 
   /**
-   * Adds hooks that will execute before this scope is destroyed.
-   *
-   * @param closables the PreDestroy hooks to add to the bean scope
+   * Add hook that will execute before this scope is destroyed.
    */
-  BeanScopeBuilder addPreDestroyHooks(AutoCloseable... closables);
+  BeanScopeBuilder addPreDestroy(AutoCloseable preDestroyHook);
 
   /**
    * Set the ClassLoader to use when loading modules.

--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -110,20 +110,20 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
   }
 
   @Override
-  public BeanScopeBuilder addPostConstructHooks(Runnable... postConstructRunnable) {
-    Collections.addAll(this.postConstructList, postConstructRunnable);
+  public BeanScopeBuilder addPostConstruct(Runnable postConstructHook) {
+    postConstructList.add(postConstructHook);
     return this;
   }
 
   @Override
-  public BeanScopeBuilder addPostConstructConsumerHook(Consumer<BeanScope> postConstructConsumer) {
+  public BeanScopeBuilder addPostConstruct(Consumer<BeanScope> postConstructConsumer) {
     this.postConstructConsumerList.add(postConstructConsumer);
     return this;
   }
 
   @Override
-  public BeanScopeBuilder addPreDestroyHooks(AutoCloseable... closables) {
-    Collections.addAll(this.preDestroyList, closables);
+  public BeanScopeBuilder addPreDestroy(AutoCloseable preDestroyHook) {
+    preDestroyList.add(preDestroyHook);
     return this;
   }
 


### PR DESCRIPTION
Improve consistency and remove use of varargs. This is breaking API change for plugins using 9.3 (currently limited to avaje plugins?)