### PR TITLE
lock inject plugin version

### DIFF
--- a/inject-maven-plugin/pom.xml
+++ b/inject-maven-plugin/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
-      <version>9.4-RC3</version>
+      <version>9.4-RC2</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
We're getting build errors because we keep bumping the plugin version