### PR TITLE
Fix for @Component.Import for partial compile - Add @DependencyMeta importedComponent property

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/AllScopes.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/AllScopes.java
@@ -43,7 +43,7 @@ final class AllScopes {
     for (Data data : scopeAnnotations.values()) {
       for (Element customBean : roundEnv.getElementsAnnotatedWith(data.type)) {
         if (customBean instanceof TypeElement) {
-          data.scopeInfo.read((TypeElement) customBean, false);
+          data.scopeInfo.read((TypeElement) customBean, false, false);
         }
       }
     }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -198,7 +198,7 @@ final class BeanReader {
     if (beanType.getNestingKind().isNested()) {
       type = beanType.getEnclosingElement().toString() + "$" + beanType.getSimpleName();
     } else {
-      type = beanType.getQualifiedName().toString();
+      type = beanQualifiedName();
     }
     MetaData metaData = new MetaData(type, name);
     metaData.update(this);
@@ -411,11 +411,10 @@ final class BeanReader {
   }
 
   String shortName() {
-    final var originName = beanType.getQualifiedName().toString();
     if (beanType.getNestingKind().isNested()) {
-      return Util.nestedShortName(originName);
+      return Util.nestedShortName(beanQualifiedName());
     } else {
-      return Util.shortName(originName);
+      return Util.shortName(beanQualifiedName());
     }
   }
 
@@ -428,11 +427,14 @@ final class BeanReader {
   }
 
   private String beanPackageName() {
-    final var originName = beanType.getQualifiedName().toString();
     if (beanType.getNestingKind().isNested()) {
-      return Util.nestedPackageOf(originName);
+      return Util.nestedPackageOf(beanQualifiedName());
     } else {
-      return Util.packageOf(originName);
+      return Util.packageOf(beanQualifiedName());
     }
+  }
+
+  private String beanQualifiedName() {
+    return beanType.getQualifiedName().toString();
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -28,12 +28,14 @@ final class BeanReader {
   private final boolean proxy;
   private final BeanAspects aspects;
   private final BeanConditions conditions = new BeanConditions();
+  private final boolean importedComponent;
   private boolean writtenToFile;
   private boolean suppressBuilderImport;
   private boolean suppressGeneratedImport;
   private Set<GenericType> allGenericTypes;
 
-  BeanReader(TypeElement beanType, boolean factory) {
+  BeanReader(TypeElement beanType, boolean factory, boolean importedComponent) {
+    this.importedComponent = importedComponent;
     this.beanType = beanType;
     this.type = beanType.getQualifiedName().toString();
     this.shortName = shortName(beanType);
@@ -72,6 +74,10 @@ final class BeanReader {
 
   boolean prototype() {
     return prototype;
+  }
+
+  boolean importedComponent() {
+    return importedComponent;
   }
 
   BeanReader read() {
@@ -402,5 +408,31 @@ final class BeanReader {
 
   boolean hasConditions() {
     return !conditions.isEmpty();
+  }
+
+  String shortName() {
+    final var originName = beanType.getQualifiedName().toString();
+    if (beanType.getNestingKind().isNested()) {
+      return Util.nestedShortName(originName);
+    } else {
+      return Util.shortName(originName);
+    }
+  }
+
+  String packageName() {
+    if (importedComponent) {
+      return beanPackageName() + ".di";
+    } else {
+      return beanPackageName();
+    }
+  }
+
+  private String beanPackageName() {
+    final var originName = beanType.getQualifiedName().toString();
+    if (beanType.getNestingKind().isNested()) {
+      return Util.nestedPackageOf(originName);
+    } else {
+      return Util.packageOf(originName);
+    }
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
@@ -40,6 +40,7 @@ final class MetaData {
   private boolean generateProxy;
   private boolean usesExternalDependency;
   private String externalDependency;
+  private boolean importedComponent;
 
   MetaData(DependencyMetaPrism meta) {
     this.type = meta.type();
@@ -50,6 +51,7 @@ final class MetaData {
     this.provides = meta.provides();
     this.dependsOn = meta.dependsOn().stream().map(Dependency::new).collect(Collectors.toList());
     this.autoProvides = meta.autoProvides();
+    this.importedComponent = meta.importedComponent();
   }
 
   MetaData(String type, String name) {
@@ -119,6 +121,7 @@ final class MetaData {
     this.providesAspect = beanReader.providesAspect();
     this.autoProvides = beanReader.autoProvides();
     this.generateProxy = beanReader.isGenerateProxy();
+    this.importedComponent = beanReader.importedComponent();
   }
 
   String type() {
@@ -156,14 +159,14 @@ final class MetaData {
     if (hasMethod()) {
       importTypes.add(Util.classOfMethod(method));
     } else if (!generateProxy) {
-      if (isImportedType(type)) {
+      if (importedComponent) {
         String packageName;
         if (element(type).getNestingKind().isNested()) {
           packageName = Util.nestedPackageOf(type);
         } else {
           packageName = Util.packageOf(type);
         }
-        importTypes.add(packageName + "." + shortType + Constants.DI);
+        importTypes.add(packageName + ".di." + shortType + Constants.DI);
       } else {
         importTypes.add(type + Constants.DI);
       }
@@ -198,6 +201,9 @@ final class MetaData {
     append.append("type = \"").append(type).append("\"");
     if (hasName) {
       append.append(",").eol().append("      name = \"").append(name).append("\"");
+    }
+    if (importedComponent) {
+      append.append(",").eol().append("      importedComponent = true");
     }
     if (hasMethod) {
       append.append(",").eol().append("      method = \"").append(method).append("\"");

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
@@ -106,7 +106,7 @@ public final class Processor extends AbstractProcessor {
     readBeans(roundEnv.getElementsAnnotatedWith(element(Constants.COMPONENT)));
     readBeans(roundEnv.getElementsAnnotatedWith(element(Constants.PROTOTYPE)));
 
-    readBeans(importedElements(roundEnv));
+    readImported(importedElements(roundEnv));
     readBeans(roundEnv.getElementsAnnotatedWith(element(Constants.PROTOTYPE)));
     final var typeElement = elementUtils.getTypeElement(Constants.CONTROLLER);
     if (typeElement != null) {
@@ -168,17 +168,21 @@ public final class Processor extends AbstractProcessor {
   }
 
   private void readFactories(Set<? extends Element> beans) {
-    readChangedBeans(beans, true);
+    readChangedBeans(beans, true, false);
   }
 
   private void readBeans(Set<? extends Element> beans) {
-    readChangedBeans(beans, false);
+    readChangedBeans(beans, false, false);
+  }
+
+  private void readImported(Set<? extends Element> beans) {
+    readChangedBeans(beans, false, true);
   }
 
   /**
    * Read the beans that have changed.
    */
-  private void readChangedBeans(Set<? extends Element> beans, boolean factory) {
+  private void readChangedBeans(Set<? extends Element> beans, boolean factory, boolean importedComponent) {
     for (final Element element : beans) {
       // ignore methods (e.g. factory methods with @Prototype on them)
       if (element instanceof TypeElement) {
@@ -191,13 +195,13 @@ public final class Processor extends AbstractProcessor {
         if (!factory) {
           // will be found via custom scope so effectively ignore additional @Singleton
           if (scope == null) {
-            defaultScope.read(typeElement, false);
+            defaultScope.read(typeElement, false, importedComponent);
           }
         } else if (scope != null) {
           // logWarn("Adding factory to custom scope "+element+" scope: "+scope);
-          scope.read(typeElement, true);
+          scope.read(typeElement, true, false);
         } else {
-          defaultScope.read(typeElement, true);
+          defaultScope.read(typeElement, true, false);
         }
       }
     }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
@@ -99,20 +99,20 @@ public final class Processor extends AbstractProcessor {
     readModule(roundEnv);
     addImportedAspects(importedAspects(roundEnv));
     readScopes(roundEnv.getElementsAnnotatedWith(element(Constants.SCOPE)));
-    readChangedBeans(roundEnv.getElementsAnnotatedWith(element(Constants.FACTORY)), true);
+    readFactories(roundEnv.getElementsAnnotatedWith(element(Constants.FACTORY)));
     if (defaultScope.includeSingleton()) {
-      readChangedBeans(roundEnv.getElementsAnnotatedWith(element(Constants.SINGLETON)), false);
+      readBeans(roundEnv.getElementsAnnotatedWith(element(Constants.SINGLETON)));
     }
-    readChangedBeans(roundEnv.getElementsAnnotatedWith(element(Constants.COMPONENT)), false);
-    readChangedBeans(roundEnv.getElementsAnnotatedWith(element(Constants.PROTOTYPE)), false);
+    readBeans(roundEnv.getElementsAnnotatedWith(element(Constants.COMPONENT)));
+    readBeans(roundEnv.getElementsAnnotatedWith(element(Constants.PROTOTYPE)));
 
-    readChangedBeans(importedElements(roundEnv), false);
-    readChangedBeans(roundEnv.getElementsAnnotatedWith(element(Constants.PROTOTYPE)), false);
+    readBeans(importedElements(roundEnv));
+    readBeans(roundEnv.getElementsAnnotatedWith(element(Constants.PROTOTYPE)));
     final var typeElement = elementUtils.getTypeElement(Constants.CONTROLLER);
     if (typeElement != null) {
-      readChangedBeans(roundEnv.getElementsAnnotatedWith(typeElement), false);
+      readBeans(roundEnv.getElementsAnnotatedWith(typeElement));
     }
-    readChangedBeans(roundEnv.getElementsAnnotatedWith(element(Constants.PROXY)), false);
+    readBeans(roundEnv.getElementsAnnotatedWith(element(Constants.PROXY)));
     allScopes.readBeans(roundEnv);
     defaultScope.write(roundEnv.processingOver());
     allScopes.write(roundEnv.processingOver());
@@ -165,6 +165,14 @@ public final class Processor extends AbstractProcessor {
     if (testScopeType != null) {
       allScopes.addScopeAnnotation(testScopeType);
     }
+  }
+
+  private void readFactories(Set<? extends Element> beans) {
+    readChangedBeans(beans, true);
+  }
+
+  private void readBeans(Set<? extends Element> beans) {
+    readChangedBeans(beans, false);
   }
 
   /**

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -294,12 +294,12 @@ final class ScopeInfo {
   /**
    * Read the dependency injection meta data for the given bean.
    */
-  private void readBeanMeta(TypeElement typeElement, boolean factory) {
+  private void readBeanMeta(TypeElement typeElement, boolean factory, boolean importedComponent) {
     if (typeElement.getKind() == ElementKind.ANNOTATION_TYPE) {
       logDebug("skipping annotation type " + typeElement);
       return;
     }
-    beanReaders.add(new BeanReader(typeElement, factory).read());
+    beanReaders.add(new BeanReader(typeElement, factory, importedComponent).read());
   }
 
   void readBuildMethodDependencyMeta(Element element) {
@@ -316,9 +316,9 @@ final class ScopeInfo {
     }
   }
 
-  void read(TypeElement element, boolean factory) {
+  void read(TypeElement element, boolean factory, boolean importedComponent) {
     if (readBeans.add(element.toString())) {
-      readBeanMeta(element, factory);
+      readBeanMeta(element, factory, importedComponent);
     } else {
       logDebug("skipping already processed bean " + element);
     }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
@@ -31,15 +31,8 @@ final class SimpleBeanWriter {
 
   SimpleBeanWriter(BeanReader beanReader) {
     this.beanReader = beanReader;
-    final TypeElement origin = beanReader.beanType();
-    final var originName = origin.getQualifiedName().toString();
-    if (origin.getNestingKind().isNested()) {
-      this.packageName = Util.nestedPackageOf(originName);
-      this.shortName = Util.nestedShortName(originName);
-    } else {
-      this.packageName = Util.packageOf(originName);
-      this.shortName = Util.shortName(originName);
-    }
+    this.packageName = beanReader.packageName();
+    this.shortName = beanReader.shortName();
     this.suffix = beanReader.suffix();
     this.proxied = beanReader.isGenerateProxy();
     this.originName = packageName + "." + shortName;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -99,14 +99,12 @@ final class Util {
       return "";
     }
     pos = cls.lastIndexOf('.', pos - 1);
-    final var packageName = (pos == -1) ? "" : cls.substring(0, pos);
-    return isImportedType(cls) ? packageName + ".di" : packageName;
+    return (pos == -1) ? "" : cls.substring(0, pos);
   }
 
   static String packageOf(String cls) {
     final int pos = cls.lastIndexOf('.');
-    final var packageName = (pos == -1) ? "" : cls.substring(0, pos);
-    return isImportedType(cls) ? packageName + ".di" : packageName;
+    return (pos == -1) ? "" : cls.substring(0, pos);
   }
 
   static String unwrapProvider(String maybeProvider) {

--- a/inject-generator/src/test/java/io/avaje/inject/generator/UtilTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/UtilTest.java
@@ -24,29 +24,10 @@ class UtilTest {
   }
 
   @Test
-  void PackageOfImported() {
-    ProcessingContext.testInit();
-    ProcessingContext.addImportedType("com.example.Bar1");
-    ProcessingContext.addImportedType("com.example.other.Bar1");
-    assertEquals(Util.packageOf("com.example.Bar1"), "com.example.di");
-    assertEquals(Util.packageOf("com.example.other.Bar1"), "com.example.other.di");
-  }
-
-
-  @Test
   void nestedPackageOf() {
     ProcessingContext.testInit();
     assertEquals(Util.nestedPackageOf("com.example.Foo.Bar"), "com.example");
     assertEquals(Util.nestedPackageOf("com.example.other.foo.Bar"), "com.example.other");
-  }
-
-  @Test
-  void nestedPackageOfImported() {
-    ProcessingContext.testInit();
-    ProcessingContext.addImportedType("com.example.Foo.Bar1");
-    ProcessingContext.addImportedType("com.example.other.foo.Bar1");
-    assertEquals(Util.nestedPackageOf("com.example.Foo.Bar1"), "com.example.di");
-    assertEquals(Util.nestedPackageOf("com.example.other.foo.Bar1"), "com.example.other.di");
   }
 
   @Test

--- a/inject-test/src/test/java/org/example/custom4/GeneralScopeFactory.java
+++ b/inject-test/src/test/java/org/example/custom4/GeneralScopeFactory.java
@@ -1,0 +1,28 @@
+package org.example.custom4;
+
+import io.avaje.inject.Bean;
+import io.avaje.inject.Factory;
+
+@Factory
+public class GeneralScopeFactory {
+
+  @Bean
+  A genaralScope() {
+    return new A();
+  }
+
+  //@BuildScope
+  @Bean
+  B buildScope() {
+    return new B();
+  }
+
+
+  public static class A {
+
+  }
+
+  public static class B {
+
+  }
+}

--- a/inject/src/main/java/io/avaje/inject/spi/DependencyMeta.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DependencyMeta.java
@@ -23,6 +23,11 @@ public @interface DependencyMeta {
   String name() default "";
 
   /**
+   * True when the component has been imported.
+   */
+  boolean importedComponent() default false;
+
+  /**
    * The bean factory method (for <code>@Bean</code> annotated methods).
    */
   String method() default "";


### PR DESCRIPTION
For partial compile the meta data needs to be read from the @DependencyMeta to restore the state and for imported components we need to identify these as there $DI code is generated into a .di package to avoid split package issues with Java modules.

This change uses the explicit @DependencyMeta importedComponent property to identify those imported types (when a partial compile does not include them).