### PR TITLE
Fix for partial compile failing for external optional Dependency

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/Dependency.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Dependency.java
@@ -3,7 +3,7 @@ package io.avaje.inject.generator;
 final class Dependency {
 
   private final String name;
-  private final boolean softDependency;
+  private boolean softDependency;
   private final boolean conditionalDependency;
 
   Dependency(String name) {
@@ -57,5 +57,10 @@ final class Dependency {
 
   String dependsOn() {
     return toString();
+  }
+
+  /** External dependency */
+  void markExternal() {
+    softDependency = true;
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
@@ -2,9 +2,7 @@ package io.avaje.inject.generator;
 
 import static io.avaje.inject.generator.ProcessingContext.*;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 
@@ -39,7 +37,7 @@ final class MetaData {
 
   private boolean generateProxy;
   private boolean usesExternalDependency;
-  private String externalDependency;
+  private Set<String> externalDependencies = new HashSet<>();
   private boolean importedComponent;
 
   MetaData(DependencyMetaPrism meta) {
@@ -178,7 +176,7 @@ final class MetaData {
       return;
     }
     if (usesExternalDependency) {
-      append.append("  // uses external dependency ").append(externalDependency).append(NEWLINE);
+      append.append("  // uses external dependency " + externalDependencies + NEWLINE);
     }
 
     final var hasName = name != null;
@@ -280,6 +278,11 @@ final class MetaData {
    */
   void markWithExternalDependency(String name) {
     usesExternalDependency = true;
-    externalDependency = name;
+    externalDependencies.add(name);
+    for (Dependency dependency : dependsOn) {
+      if (name.equals(dependency.name())) {
+        dependency.markExternal();
+      }
+    }
   }
 }


### PR DESCRIPTION
In the tests this dependency is org.example.myapp.config.SomeOptionalDep. It gets added to autoRequires and in a full compile. For a partial compile this isn't restored from metadata and partial compile fails complaining that the dependency is not provided.

This fix is to mark this dependency as a soft: dependency. Partial compile reads the soft: dependency from metadata.

An alternative would be to add a mechanism (extra metadata annotation to save and restore the autoRequires types.