### PR TITLE
Fix for Factory with multiple "Builder" types - short names all exactly match Builder

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/A0.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/A0.java
@@ -1,0 +1,9 @@
+package org.example.myapp.config;
+
+public interface A0 {
+
+  /** Builder name clash in generated code, use the full type for this in generated code */
+  interface Builder {
+
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/A1.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/A1.java
@@ -1,0 +1,13 @@
+package org.example.myapp.config;
+
+public interface A1 {
+
+  /** Builder name clash in generated code, use the full type for this in generated code */
+  interface Builder {
+
+  }
+
+  interface DSS {
+
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/AFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/AFactory.java
@@ -1,0 +1,36 @@
+package org.example.myapp.config;
+
+import io.avaje.inject.Bean;
+import io.avaje.inject.Factory;
+
+@Factory
+class AFactory {
+
+  @Bean
+  A0.Builder build0() {
+    return new I0();
+  }
+
+  @Bean
+  A1.Builder build1() {
+    return new I1();
+  }
+
+  @Bean
+  void andUse(A1.Builder a1Build) {
+    a1Build.hashCode();
+  }
+
+  @Bean
+  void ad(A0.Builder b1, A1.Builder b2) {
+    b1.hashCode();
+    b2.hashCode();
+  }
+
+  static class I0 implements A0.Builder {
+
+  }
+  static class I1 implements A1.Builder {
+
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/BuilderFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/BuilderFactory.java
@@ -1,0 +1,18 @@
+package org.example.myapp.config;
+
+import io.avaje.inject.Bean;
+import io.avaje.inject.Factory;
+
+@Factory
+public class BuilderFactory {
+
+  @Bean
+  void consume0(A0.Builder aBuilder) {
+    aBuilder.hashCode();
+  }
+
+  @Bean
+  void consume1(A1.Builder aBuilder) {
+    aBuilder.hashCode();
+  }
+}

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
@@ -206,8 +206,8 @@ final class MetaDataOrdering {
             }
           }
         } else if (!providerList.isAllWired()) {
-        return false;
-      }
+          return false;
+        }
       }
     }
     return true;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -14,6 +14,8 @@ final class MethodReader {
 
   private static final String CODE_COMMENT_BUILD_FACTORYBEAN = "  /**\n   * Create and register %s via factory bean method %s#%s().\n   */";
 
+  private static final Set<String> UNSAFE_SHORT_NAME = Set.of("Builder", "Generated");
+
   private final ExecutableElement element;
   private final String factoryType;
   private final String methodName;
@@ -396,7 +398,7 @@ final class MethodReader {
     void builderGetDependency(Append writer, String builderName, boolean forFactory) {
       writer.append(builderName).append(".").append(utilType.getMethod(nullable, isBeanMap));
       if (!genericType.isGenericType()) {
-        writer.append(Util.shortName(genericType.topType())).append(".class");
+        writer.append(safeShortName(genericType.topType())).append(".class");
       } else if (isProvider()) {
         writer.append(providerParam()).append(".class");
       } else {
@@ -416,6 +418,14 @@ final class MethodReader {
         writer.append("\"");
       }
       writer.append(")");
+    }
+
+    private String safeShortName(String fullType) {
+      final String shortName = Util.shortName(fullType);
+      if (UNSAFE_SHORT_NAME.contains(shortName)) {
+        return fullType;
+      }
+      return shortName;
     }
 
     private String providerParam() {


### PR DESCRIPTION
When there are multiple Builders like A0.Builder and A1.Builder then we really need to use the full type name.

This change is to use the full type name when the short name matches Builder or Generated.