### PR TITLE
Module Validation

### DIFF
--- a/blackbox-aspect/src/main/java/module-info.java
+++ b/blackbox-aspect/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module blackbox.aspect {
+
+  requires io.avaje.inject;
+
+  //remove this and compilation fails
+  provides io.avaje.inject.spi.Module with org.example.external.aspect.sub.ExampleExternalAspectModule;
+}

--- a/inject-generator/pom.xml
+++ b/inject-generator/pom.xml
@@ -13,7 +13,7 @@
   <name>avaje inject generator</name>
   <description>annotation processor generating di as source code</description>
   <properties>
-    <avaje.prisms.version>1.10</avaje.prisms.version>
+    <avaje.prisms.version>1.12</avaje.prisms.version>
   </properties>
   <dependencies>
 
@@ -44,24 +44,6 @@
 
   <build>
     <plugins>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
-        <configuration>
-          <source>11</source>
-          <target>11</target>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>io.avaje</groupId>
-              <artifactId>avaje-prisms</artifactId>
-              <version>${avaje.prisms.version}</version>
-            </path>
-          </annotationProcessorPaths>
-        </configuration>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/inject-generator/pom.xml
+++ b/inject-generator/pom.xml
@@ -13,7 +13,7 @@
   <name>avaje inject generator</name>
   <description>annotation processor generating di as source code</description>
   <properties>
-    <avaje.prisms.version>1.12</avaje.prisms.version>
+    <avaje.prisms.version>1.13</avaje.prisms.version>
   </properties>
   <dependencies>
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -214,7 +214,7 @@ final class ProcessingContext {
               .map(roundEnv::getElementsAnnotatedWith)
               .flatMap(Collection::stream)
               .findAny()
-              .map(ProcessingContext::search)
+              .map(ProcessingContext::getModuleElement)
               .orElse(null);
     }
   }
@@ -246,11 +246,11 @@ final class ProcessingContext {
     }
   }
 
-  static ModuleElement search(Element e) {
+  static ModuleElement getModuleElement(Element e) {
     if (e == null || e instanceof ModuleElement) {
       return (ModuleElement) e;
     }
-    return search(e.getEnclosingElement());
+    return getModuleElement(e.getEnclosingElement());
   }
 
   static Optional<AspectImportPrism> getImportedAspect(String type) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -1,7 +1,5 @@
 package io.avaje.inject.generator;
 
-import static io.avaje.inject.generator.ProcessingContext.logWarn;
-
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -18,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.FilerException;
@@ -31,7 +28,6 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
-import javax.tools.DocumentationTool.Location;
 import javax.tools.FileObject;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
@@ -90,10 +86,6 @@ final class ProcessingContext {
 
   static void logWarn(String msg, Object... args) {
     CTX.get().messager.printMessage(Diagnostic.Kind.WARNING, String.format(msg, args));
-  }
-
-  static void logWarn(Element e, String msg, Object... args) {
-    CTX.get().messager.printMessage(Diagnostic.Kind.WARNING, String.format(msg, args), e);
   }
 
   static void logDebug(String msg, Object... args) {
@@ -220,7 +212,6 @@ final class ProcessingContext {
   }
 
   static void validateModule(String injectFQN) {
-
     if (!CTX.get().validated) {
       CTX.get().validated = true;
       var module = CTX.get().module;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -237,7 +237,7 @@ final class ProcessingContext {
           var noProvides = reader.lines().noneMatch(s -> s.contains(injectFQN));
 
           if (noProvides) {
-            logError(module, "Missing \"provides io.avaje.inject.spi.Module with %s\"", injectFQN);
+            logError(module, "Missing \"provides io.avaje.inject.spi.Module with %s;\"", injectFQN);
           }
         }
       } catch (Exception e) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
@@ -3,7 +3,6 @@ package io.avaje.inject.generator;
 import static io.avaje.inject.generator.ProcessingContext.addImportedAspects;
 import static io.avaje.inject.generator.ProcessingContext.addImportedType;
 import static io.avaje.inject.generator.ProcessingContext.element;
-import static io.avaje.inject.generator.ProcessingContext.findModule;
 import static io.avaje.inject.generator.ProcessingContext.loadMetaInfCustom;
 import static io.avaje.inject.generator.ProcessingContext.loadMetaInfServices;
 
@@ -123,6 +122,8 @@ public final class Processor extends AbstractProcessor {
     defaultScope.write(roundEnv.processingOver());
     allScopes.write(roundEnv.processingOver());
 
+    ProcessingContext.findModule(annotations, roundEnv);
+
     if (roundEnv.processingOver()) {
       ProcessingContext.clear();
     }
@@ -190,7 +191,6 @@ public final class Processor extends AbstractProcessor {
    */
   private void readChangedBeans(Set<? extends Element> beans, boolean factory, boolean importedComponent) {
     for (final Element element : beans) {
-      findModule(element);
       // ignore methods (e.g. factory methods with @Prototype on them)
       if (element instanceof TypeElement) {
         if (element.getKind() == ElementKind.INTERFACE) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Processor.java
@@ -3,15 +3,20 @@ package io.avaje.inject.generator;
 import static io.avaje.inject.generator.ProcessingContext.addImportedAspects;
 import static io.avaje.inject.generator.ProcessingContext.addImportedType;
 import static io.avaje.inject.generator.ProcessingContext.element;
+import static io.avaje.inject.generator.ProcessingContext.findModule;
 import static io.avaje.inject.generator.ProcessingContext.loadMetaInfCustom;
-import static io.avaje.inject.generator.ProcessingContext.*;
 import static io.avaje.inject.generator.ProcessingContext.loadMetaInfServices;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.annotation.processing.AbstractProcessor;
@@ -23,12 +28,7 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.ModuleElement;
-import javax.lang.model.element.ModuleElement.DirectiveKind;
-import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
 import javax.tools.StandardLocation;
 
@@ -52,6 +52,7 @@ public final class Processor extends AbstractProcessor {
   private boolean readModuleInfo;
   private final Set<String> pluginFileProvided = new HashSet<>();
   private final Set<String> moduleFileProvided = new HashSet<>();
+
   @Override
   public SourceVersion getSupportedSourceVersion() {
     return SourceVersion.latest();
@@ -249,10 +250,9 @@ public final class Processor extends AbstractProcessor {
   /** Read InjectModule for things like package-info etc (not for custom scopes) */
   private void readInjectModule(RoundEnvironment roundEnv) {
 
-    var injectModuleElements = roundEnv.getElementsAnnotatedWith(element(Constants.INJECTMODULE));
-
     // read other that are annotated with InjectModule
-    for (final Element element : injectModuleElements) {
+    for (final Element element :
+        roundEnv.getElementsAnnotatedWith(element(Constants.INJECTMODULE))) {
 
       final var scope = ScopePrism.getInstanceOn(element);
       if (scope == null) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -145,6 +145,7 @@ final class ScopeInfo {
       moduleShortName = name + "Module";
       moduleFullName = modulePackage + "." + moduleShortName;
       moduleFile = createWriter(moduleFullName);
+      ProcessingContext.validateModule(moduleFullName);
     }
   }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -145,7 +145,6 @@ final class ScopeInfo {
       moduleShortName = name + "Module";
       moduleFullName = modulePackage + "." + moduleShortName;
       moduleFile = createWriter(moduleFullName);
-      ProcessingContext.validateModule(moduleFullName);
     }
   }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
@@ -56,7 +56,6 @@ final class SimpleModuleWriter {
     this.modulePackage = scopeInfo.modulePackage();
     this.shortName = scopeInfo.moduleShortName();
     this.fullName = scopeInfo.moduleFullName();
-    ProcessingContext.validateModule(fullName);
   }
 
   void write(ScopeInfo.Type scopeType) throws IOException {
@@ -71,6 +70,9 @@ final class SimpleModuleWriter {
     writer.close();
     if (scopeType != ScopeInfo.Type.CUSTOM) {
       writeServicesFile(scopeType);
+    }
+    if (!ordering.ordered().isEmpty()) {
+      ProcessingContext.validateModule(fullName);
     }
   }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
@@ -56,6 +56,7 @@ final class SimpleModuleWriter {
     this.modulePackage = scopeInfo.modulePackage();
     this.shortName = scopeInfo.moduleShortName();
     this.fullName = scopeInfo.moduleFullName();
+    ProcessingContext.validateModule(fullName);
   }
 
   void write(ScopeInfo.Type scopeType) throws IOException {

--- a/inject-generator/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/inject-generator/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,0 @@
-io.avaje.inject.generator.Processor


### PR DESCRIPTION
Now we can ensure module-info classes have the `provides` statement for the generated module classes.

Got around the `ModuleElement` limitations by using `Filer` to manually read the `module-info.java` file.

Fixes #389 