### PR TITLE
Add option to disable automatic failure when no modules are found

### DIFF
--- a/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
@@ -230,10 +230,14 @@ public interface BeanScopeBuilder {
    */
   BeanScopeBuilder addPostConstruct(Consumer<BeanScope> postConstructHook);
 
-  /**
-   * Add hook that will execute before this scope is destroyed.
-   */
+  /** Add hook that will execute before this scope is destroyed. */
   BeanScopeBuilder addPreDestroy(AutoCloseable preDestroyHook);
+
+  /**
+   * Determine if an exception should be thrown if no modules can be discovered via ServiceLoader.
+   * By default, the value is true.
+   */
+  BeanScopeBuilder failOnEmpty(boolean failOnEmpty);
 
   /**
    * Set the ClassLoader to use when loading modules.
@@ -437,4 +441,5 @@ public interface BeanScopeBuilder {
      */
     <D> BeanScopeBuilder.ForTesting spy(Class<D> type, Consumer<D> consumer);
   }
+
 }

--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -266,11 +266,7 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
         " Refer to https://avaje.io/inject#gradle");
     }
     else if (moduleNames.isEmpty()) {
-    	  log.log(WARNING, "No modules found. When using java module system we need an explicit provides clause in module-info like:\n\n" +
-    	          " provides io.avaje.inject.spi.Module with org.example.ExampleModule;\n\n" +
-    	          " Otherwise perhaps using Gradle and IDEA but with a setup issue?" +
-    	          " Review IntelliJ Settings / Build / Build tools / Gradle - 'Build and run using' value and set that to 'Gradle'. " +
-    	          " Refer to https://avaje.io/inject#gradle");
+    	  log.log(INFO, "No inject modules found");
       }
 
     final var level = propertyRequiresPlugin.contains("printModules") ? INFO : DEBUG;


### PR DESCRIPTION
Now can do 
```java
BeanScope.builder().failOnEmpty(false).bean(someBean).build();
```
without an exception being thrown