### PR TITLE
Support @Import Package-Private Constructors 

### DIFF
--- a/blackbox-other/src/main/java/org/other/one/OtherComponent.java
+++ b/blackbox-other/src/main/java/org/other/one/OtherComponent.java
@@ -3,6 +3,4 @@ package org.other.one;
 import io.avaje.inject.Component;
 
 @Component
-public class OtherComponent {
-
-}
+public class OtherComponent {}

--- a/blackbox-other/src/main/java/org/other/one/OtherComponent2.java
+++ b/blackbox-other/src/main/java/org/other/one/OtherComponent2.java
@@ -1,0 +1,3 @@
+package org.other.one;
+
+public class OtherComponent2 {}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/ConfigPropertiesPlugin.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/ConfigPropertiesPlugin.java
@@ -2,9 +2,13 @@ package org.example.myapp;
 
 import java.util.Optional;
 
+import org.other.one.OtherComponent2;
+
 import io.avaje.config.Config;
+import io.avaje.inject.Component;
 import io.avaje.inject.spi.PropertyRequiresPlugin;
 
+@Component.Import(value = OtherComponent2.class, packagePrivate = false)
 public class ConfigPropertiesPlugin implements PropertyRequiresPlugin {
 
   @Override

--- a/blackbox-test-inject/src/main/java/org/example/myapp/ConfigPropertiesPlugin.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/ConfigPropertiesPlugin.java
@@ -8,7 +8,7 @@ import io.avaje.config.Config;
 import io.avaje.inject.Component;
 import io.avaje.inject.spi.PropertyRequiresPlugin;
 
-@Component.Import(value = OtherComponent2.class, packagePrivate = false)
+@Component.Import(value = OtherComponent2.class, packagePrivate = true)
 public class ConfigPropertiesPlugin implements PropertyRequiresPlugin {
 
   @Override

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ImportTypeMap.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ImportTypeMap.java
@@ -1,7 +1,5 @@
 package io.avaje.inject.generator;
 
-import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -27,7 +27,6 @@ import java.util.Set;
 
 import javax.annotation.processing.FilerException;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.ModuleElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.FileObject;
@@ -43,7 +42,6 @@ final class ProcessingContext {
     private final Set<String> uniqueModuleNames = new HashSet<>();
     private final Set<String> providedTypes = new HashSet<>();
     private final Set<String> optionalTypes = new LinkedHashSet<>();
-    private final Set<String> importedTypes = new LinkedHashSet<>();
     private final Map<String, AspectImportPrism> aspectImportPrisms = new HashMap<>();
     private boolean validated;
 
@@ -154,14 +152,6 @@ final class ProcessingContext {
 
   static void addImportedAspects(Map<String, AspectImportPrism> importedMap) {
     CTX.get().aspectImportPrisms.putAll(importedMap);
-  }
-
-  static void addImportedType(String importedMap) {
-    CTX.get().importedTypes.add(importedMap);
-  }
-
-  static boolean isImportedType(String type) {
-    return CTX.get().importedTypes.contains(type);
   }
 
   static void validateModule(String injectFQN) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -1,7 +1,5 @@
 package io.avaje.inject.generator;
 
-import static io.avaje.inject.generator.ProcessingContext.isImportedType;
-
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/inject/src/main/java/io/avaje/inject/Component.java
+++ b/inject/src/main/java/io/avaje/inject/Component.java
@@ -53,12 +53,12 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 public @interface Component {
 
   /**
-   * Specify types to generate DI classes for.
+   * Specify types to generate DI classes for. To avoid package splitting, the imported DI classes
    *
    * <p>These types are typically in an external project / dependency or otherwise types that we
    * can't or don't want to explicitly annotate with {@code @Singleton}/{@code @Component}.
    *
-   * <p>Typically, we put this annotation on a package.
+   * <p>Typically, we put this annotation on a package/module-info.
    *
    * <pre>{@code
    * Component.Import({Customer.class, Product.class, ...})
@@ -70,9 +70,13 @@ public @interface Component {
   @Target({TYPE, PACKAGE, MODULE})
   @interface Import {
 
-    /**
-     * Specify types to generate DI classes for.
-     */
+    /** Specify types to generate DI classes for. */
     Class<?>[] value();
+
+    /**
+     * When true, avaje will write generated classes to the same package as the imported class.
+     * (this will cause package splitting and will not work on JPMS by default)
+     */
+    boolean packagePrivate() default false;
   }
 }

--- a/inject/src/main/java/io/avaje/inject/Component.java
+++ b/inject/src/main/java/io/avaje/inject/Component.java
@@ -75,7 +75,7 @@ public @interface Component {
 
     /**
      * When true, avaje will write generated classes to the same package as the imported class.
-     * (this will cause package splitting and will not work on JPMS by default)
+     * (this will cause package splitting and will not work on JPMS so by default this is disabled)
      */
     boolean packagePrivate() default false;
   }


### PR DESCRIPTION
For classpath-only applications, split packages are less of an issue.

Now can do this

```
@Component.Import(value = OtherComponent2.class, packagePrivate = true)
```
to make the generated DI classes for `OtherComponent2` reside in the same package.

fixes #396 