### PR TITLE
With Component.Import check for public constructor

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/ConfigPropertiesPlugin.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/ConfigPropertiesPlugin.java
@@ -1,14 +1,13 @@
 package org.example.myapp;
 
-import java.util.Optional;
-
-import org.other.one.OtherComponent2;
-
 import io.avaje.config.Config;
 import io.avaje.inject.Component;
 import io.avaje.inject.spi.PropertyRequiresPlugin;
+import org.other.one.OtherComponent2;
 
-@Component.Import(value = OtherComponent2.class, packagePrivate = true)
+import java.util.Optional;
+
+@Component.Import(value = OtherComponent2.class)
 public class ConfigPropertiesPlugin implements PropertyRequiresPlugin {
 
   @Override

--- a/blackbox-test-inject/src/main/java/org/example/myapp/Main.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/Main.java
@@ -1,10 +1,16 @@
 package org.example.myapp;
 
+import io.avaje.inject.Component;
 import org.example.external.aspect.MyExternalAspect;
 
 import io.avaje.inject.BeanScope;
 import io.avaje.inject.aop.Aspect.Import;
+import org.example.myapp.other.SimulateExternal;
+import org.example.myapp.other.SimulateExternal2;
+import org.example.myapp.other.SimulateExternalPub;
+import org.example.myapp.other.SimulateExternalPub2;
 
+@Component.Import(value = {SimulateExternal.class, SimulateExternal2.class, SimulateExternalPub.class, SimulateExternalPub2.class}) //, packagePrivate = true)
 @Import(MyExternalAspect.class)
 public class Main {
 

--- a/blackbox-test-inject/src/main/java/org/example/myapp/other/SimulateExternal.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/other/SimulateExternal.java
@@ -1,0 +1,14 @@
+package org.example.myapp.other;
+
+public class SimulateExternal {
+
+  private final SimulateExternal2 external2;
+
+  SimulateExternal(SimulateExternal2 external2) {
+    this.external2 = external2;
+  }
+
+  public String doStuff() {
+    return "asd Ex1|" + external2.doStuff();
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/other/SimulateExternal2.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/other/SimulateExternal2.java
@@ -1,0 +1,12 @@
+package org.example.myapp.other;
+
+public class SimulateExternal2 {
+
+  SimulateExternal2() {
+
+  }
+
+  public String doStuff() {
+    return "Ex2";
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/other/SimulateExternalPub.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/other/SimulateExternalPub.java
@@ -1,0 +1,14 @@
+package org.example.myapp.other;
+
+public class SimulateExternalPub {
+
+  private final SimulateExternalPub2 external2;
+
+  public SimulateExternalPub(SimulateExternalPub2 external2) {
+    this.external2 = external2;
+  }
+
+  public String doStuff() {
+    return "asd Ex1|" + external2.doStuff();
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/other/SimulateExternalPub2.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/other/SimulateExternalPub2.java
@@ -1,0 +1,12 @@
+package org.example.myapp.other;
+
+public class SimulateExternalPub2 {
+
+  public SimulateExternalPub2() {
+
+  }
+
+  public String doStuff() {
+    return "Ex2";
+  }
+}

--- a/blackbox-test-inject/src/test/java/org/example/myapp/other/SimulateExternalTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/other/SimulateExternalTest.java
@@ -1,0 +1,24 @@
+package org.example.myapp.other;
+
+import io.avaje.inject.BeanScope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SimulateExternalTest {
+
+  @Test
+  void doStuff() {
+    try (BeanScope beanScope = BeanScope.builder().build()) {
+      var simulateExternal = beanScope.get(SimulateExternal.class);
+      var simulateExternal2 = beanScope.get(SimulateExternal2.class);
+      var simulateExternalPub = beanScope.get(SimulateExternalPub.class);
+      var simulateExternalPub2 = beanScope.get(SimulateExternalPub2.class);
+
+      assertThat(simulateExternal).isNotNull();
+      assertThat(simulateExternal2).isNotNull();
+      assertThat(simulateExternalPub).isNotNull();
+      assertThat(simulateExternalPub2).isNotNull();
+    }
+  }
+}

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -37,7 +37,6 @@ final class BeanReader {
   private Set<GenericType> allGenericTypes;
 
   BeanReader(TypeElement beanType, boolean factory, boolean importedComponent) {
-    this.importedComponent = importedComponent;
     this.beanType = beanType;
     this.type = beanType.getQualifiedName().toString();
     this.shortName = shortName(beanType);
@@ -59,6 +58,7 @@ final class BeanReader {
     this.postConstructMethod = typeReader.postConstructMethod();
     this.preDestroyMethod = typeReader.preDestroyMethod();
     this.constructor = typeReader.constructor();
+    this.importedComponent = importedComponent && (constructor != null && constructor.isPublic());
   }
 
   @Override

--- a/inject/src/main/java/io/avaje/inject/Component.java
+++ b/inject/src/main/java/io/avaje/inject/Component.java
@@ -72,11 +72,5 @@ public @interface Component {
 
     /** Specify types to generate DI classes for. */
     Class<?>[] value();
-
-    /**
-     * When true, avaje will write generated classes to the same package as the imported class.
-     * (this will cause package splitting and will not work on JPMS so by default this is disabled)
-     */
-    boolean packagePrivate() default false;
   }
 }

--- a/inject/src/main/java/io/avaje/inject/Component.java
+++ b/inject/src/main/java/io/avaje/inject/Component.java
@@ -61,7 +61,7 @@ public @interface Component {
    * <p>Typically, we put this annotation on a package/module-info.
    *
    * <pre>{@code
-   * Component.Import({Customer.class, Product.class, ...})
+   * Component.Import({CustomerService.class, ProductService.class, ...})
    * package org.example.processor;
    *
    * }</pre>


### PR DESCRIPTION
So the DI class to wire the imported component will be in the same package as the component unless it has a public constructor, and then it can be put into a
di subpackage.