### PR TITLE
Add support for PreDestroy priority to control ordering

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/ExampleService.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/ExampleService.java
@@ -1,5 +1,6 @@
 package org.example.myapp;
 
+import io.avaje.inject.PreDestroy;
 import jakarta.inject.Singleton;
 import org.example.myapp.aspect.MyTimed;
 
@@ -35,5 +36,10 @@ public class ExampleService {
 
   public void withListString(List<String> param0) {
     System.out.println("withListString " + param0);
+  }
+
+  @PreDestroy(priority = 1001)
+  public void close() {
+    MyDestroyOrder.add("ExampleService");
   }
 }

--- a/blackbox-test-inject/src/main/java/org/example/myapp/HelloData.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/HelloData.java
@@ -3,4 +3,7 @@ package org.example.myapp;
 public interface HelloData {
 
   String helloData();
+
+  default void shutdown() {
+  }
 }

--- a/blackbox-test-inject/src/main/java/org/example/myapp/HelloService.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/HelloService.java
@@ -91,8 +91,8 @@ public class HelloService {
 
   }
 
-  @PreDestroy
+  @PreDestroy(priority = 100)
   void preDest() {
-
+    MyDestroyOrder.add("HelloService");
   }
 }

--- a/blackbox-test-inject/src/main/java/org/example/myapp/MyDestroyOrder.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/MyDestroyOrder.java
@@ -1,0 +1,18 @@
+package org.example.myapp;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class MyDestroyOrder {
+
+  private static final List<String> ordering = Collections.synchronizedList(new ArrayList<>());
+
+  public static void add(String val){
+    ordering.add(val);
+  }
+
+  public static List<String> ordering() {
+    return ordering;
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/AppConfig.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/AppConfig.java
@@ -4,6 +4,7 @@ import io.avaje.inject.*;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import org.example.myapp.HelloData;
+import org.example.myapp.MyDestroyOrder;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -13,12 +14,17 @@ public class AppConfig {
 
   public static AtomicBoolean BEAN_AUTO_CLOSED = new AtomicBoolean();
 
+  @PreDestroy
+  void close() {
+    MyDestroyOrder.add("AppConfig");
+  }
+
   @Bean(autoCloseable = true)
   SomeInterface someInterface() {
     return new SomeInterfaceWithClose();
   }
 
-  @Bean
+  @Bean(destroyMethod = "shutdown", destroyPriority = 1500)
   HelloData data() {
     return new AppHelloData();
   }
@@ -28,6 +34,11 @@ public class AppConfig {
     @Override
     public String helloData() {
       return "AppHelloData";
+    }
+
+    @Override
+    public void shutdown() {
+      MyDestroyOrder.add("AppHelloData");
     }
   }
 

--- a/blackbox-test-inject/src/main/java/org/example/myapp/i347/MyMetaDataRepo.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/i347/MyMetaDataRepo.java
@@ -1,11 +1,18 @@
 package org.example.myapp.i347;
 
 import io.avaje.inject.Component;
+import io.avaje.inject.PreDestroy;
+import org.example.myapp.MyDestroyOrder;
 
 @Component
 public class MyMetaDataRepo extends MyMongoRepo<MyMetaData> {
   @Override
   public MyMetaData doThings(MoDocument moDocument) {
     return null;
+  }
+
+  @PreDestroy
+  void close() {
+    MyDestroyOrder.add("MyMetaDataRepo");
   }
 }

--- a/blackbox-test-inject/src/main/java/org/example/myapp/named/MyNamed.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/named/MyNamed.java
@@ -1,10 +1,16 @@
 package org.example.myapp.named;
 
 import io.avaje.inject.Component;
+import io.avaje.inject.PreDestroy;
 import jakarta.inject.Named;
+import org.example.myapp.MyDestroyOrder;
 
 @Named("my-name-with-hyphens")
 @Component
 public class MyNamed {
 
+  @PreDestroy
+  public void close() {
+    MyDestroyOrder.add("MyNamed");
+  }
 }

--- a/blackbox-test-inject/src/test/java/org/example/myapp/MyDestroyOrderTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/MyDestroyOrderTest.java
@@ -1,0 +1,21 @@
+package org.example.myapp;
+
+import io.avaje.inject.BeanScope;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MyDestroyOrderTest {
+
+  @Test
+  void ordering() {
+    MyDestroyOrder.ordering().clear();
+    try (BeanScope beanScope = BeanScope.builder().build()) {
+      beanScope.get(HelloService.class);
+    }
+    List<String> ordering = MyDestroyOrder.ordering();
+    assertThat(ordering).containsExactly("HelloService", "AppConfig", "MyNamed", "MyMetaDataRepo", "ExampleService", "AppHelloData");
+  }
+}

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -31,6 +31,7 @@ final class BeanReader {
   private final BeanAspects aspects;
   private final BeanConditions conditions = new BeanConditions();
   private final boolean importedComponent;
+  private final Integer preDestroyPriority;
   private boolean writtenToFile;
   private boolean suppressBuilderImport;
   private boolean suppressGeneratedImport;
@@ -57,6 +58,7 @@ final class BeanReader {
     this.factoryMethods = typeReader.factoryMethods();
     this.postConstructMethod = typeReader.postConstructMethod();
     this.preDestroyMethod = typeReader.preDestroyMethod();
+    this.preDestroyPriority = typeReader.preDestroyPriority();
     this.constructor = typeReader.constructor();
     this.importedComponent = importedComponent && (constructor != null && constructor.isPublic());
   }
@@ -247,7 +249,8 @@ final class BeanReader {
     }
     if (preDestroyMethod != null) {
       prototypeNotSupported("@PreDestroy");
-      writer.append("%s builder.addPreDestroy($bean::%s);", indent, preDestroyMethod.getSimpleName()).eol();
+      var priority = preDestroyPriority == null || preDestroyPriority == 1000 ? "" : ", " + preDestroyPriority;
+      writer.append("%s builder.addPreDestroy($bean::%s%s);", indent, preDestroyMethod.getSimpleName(), priority).eol();
     } else if (typeReader.isClosable() && !prototype) {
       writer.append("%s builder.addPreDestroy($bean);", indent).eol();
     }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -29,6 +29,7 @@ final class MethodReader {
   private final boolean isFactory;
   private final String initMethod;
   private final String destroyMethod;
+  private final Integer destroyPriority;
   private final boolean beanCloseable;
   private final String name;
   private final TypeReader typeReader;
@@ -72,6 +73,7 @@ final class MethodReader {
     this.isVoid = Util.isVoid(topType);
     String initMethod = (bean == null) ? null : bean.initMethod();
     String destroyMethod = (bean == null) ? null : bean.destroyMethod();
+    this.destroyPriority = (bean == null) ? null : bean.destroyPriority();
     this.beanCloseable = (bean != null) && bean.autoCloseable();
     this.name = qualifierName;
     TypeElement returnElement = asElement(returnMirror);
@@ -227,10 +229,11 @@ final class MethodReader {
       if (notEmpty(initMethod)) {
         writer.append(indent).append("builder.addPostConstruct($bean::%s);", initMethod).eol();
       }
+      var priority = destroyPriority == null || destroyPriority == 1000 ? "" : ", " + destroyPriority;
       if (notEmpty(destroyMethod)) {
-        writer.append(indent).append("builder.addPreDestroy($bean::%s);", destroyMethod).eol();
+        writer.append(indent).append("builder.addPreDestroy($bean::%s%s);", destroyMethod, priority).eol();
       } else if (typeReader != null && typeReader.isClosable()) {
-        writer.append(indent).append("builder.addPreDestroy($bean::close);").eol();
+        writer.append(indent).append("builder.addPreDestroy($bean::close%s);", priority).eol();
       } else if (beanCloseable) {
         writer.append(indent).append("builder.addAutoClosable($bean);").eol();
       }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsInjection.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsInjection.java
@@ -30,6 +30,7 @@ final class TypeExtendsInjection {
   private final List<AspectPair> typeAspects;
   private Element postConstructMethod;
   private Element preDestroyMethod;
+  private Integer preDestroyPriority;
 
   TypeExtendsInjection(TypeElement baseType, boolean factory, ImportTypeMap importTypes) {
     this.importTypes = importTypes;
@@ -124,6 +125,7 @@ final class TypeExtendsInjection {
     if (AnnotationUtil.hasAnnotationWithName(element, "PreDestroy")) {
       preDestroyMethod = element;
       checkAspect = false;
+      PreDestroyPrism.getOptionalOn(element).ifPresent(preDestroy -> preDestroyPriority = preDestroy.priority());
     }
     if (checkAspect) {
       checkForAspect(methodElement);
@@ -200,6 +202,10 @@ final class TypeExtendsInjection {
 
   Element preDestroyMethod() {
     return preDestroyMethod;
+  }
+
+  Integer preDestroyPriority() {
+    return preDestroyPriority;
   }
 
   MethodReader constructor() {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -101,6 +101,10 @@ final class TypeExtendsReader {
     return extendsInjection.preDestroyMethod();
   }
 
+  Integer preDestroyPriority() {
+    return extendsInjection.preDestroyPriority();
+  }
+
   MethodReader constructor() {
     return extendsInjection.constructor();
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeReader.java
@@ -77,6 +77,10 @@ final class TypeReader {
     return extendsReader.preDestroyMethod();
   }
 
+  Integer preDestroyPriority() {
+    return extendsReader.preDestroyPriority();
+  }
+
   MethodReader constructor() {
     return extendsReader.constructor();
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/package-info.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/package-info.java
@@ -13,6 +13,7 @@
 @GeneratePrism(Primary.class)
 @GeneratePrism(Secondary.class)
 @GeneratePrism(Proxy.class)
+@GeneratePrism(PreDestroy.class)
 @GeneratePrism(DependencyMeta.class)
 @GeneratePrism(Bean.class)
 @GeneratePrism(QualifiedMap.class)

--- a/inject/src/main/java/io/avaje/inject/Bean.java
+++ b/inject/src/main/java/io/avaje/inject/Bean.java
@@ -52,6 +52,15 @@ public @interface Bean {
   String destroyMethod() default "";
 
   /**
+   * Specify the priority of the destroy method to control its execution
+   * order relative to other destroy methods.
+   * <p>
+   * Low values execute earlier than high values. All destroy methods without
+   * any explicit priority are given a value of 1000.
+   */
+  int destroyPriority() default 0;
+
+  /**
    * Specify that the concrete instance of the bean is an AutoCloseable. Use if your bean interface
    * doesn't extend AutoCloseable but the concrete class implements it.
    */

--- a/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
@@ -236,6 +236,17 @@ public interface BeanScopeBuilder {
   BeanScopeBuilder addPreDestroy(AutoCloseable preDestroyHook);
 
   /**
+   * Add hook with a priority that will execute before this scope is destroyed.
+   * <p>
+   * Specify the priority of the destroy method to control its execution
+   * order relative to other destroy methods.
+   * <p>
+   * Low values for priority execute earlier than high values. All destroy methods
+   * without any explicit priority are given a value of 1000.
+   */
+  BeanScopeBuilder addPreDestroy(AutoCloseable preDestroyHook, int priority);
+
+  /**
    * Set the ClassLoader to use when loading modules.
    *
    * @param classLoader The ClassLoader to use

--- a/inject/src/main/java/io/avaje/inject/PreDestroy.java
+++ b/inject/src/main/java/io/avaje/inject/PreDestroy.java
@@ -29,4 +29,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Target(METHOD)
 public @interface PreDestroy {
+
+  /**
+   * Specify the priority of the destroy method to control its execution
+   * order relative to other destroy methods.
+   * <p>
+   * Low values execute earlier than high values. All destroy methods without
+   * any explicit priority are given a value of 1000.
+   */
+  int priority() default 1000;
 }

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -107,6 +107,11 @@ public interface Builder {
   void addPreDestroy(AutoCloseable closeable);
 
   /**
+   * Add lifecycle PreDestroy method with a given priority.
+   */
+  void addPreDestroy(AutoCloseable closeable, int priority);
+
+  /**
    * Check if the instance is AutoCloseable and if so register it with PreDestroy.
    *
    * @param maybeAutoCloseable An instance that might be AutoCloseable

--- a/inject/src/main/java/io/avaje/inject/spi/ClosePair.java
+++ b/inject/src/main/java/io/avaje/inject/spi/ClosePair.java
@@ -1,0 +1,25 @@
+package io.avaje.inject.spi;
+
+public final class ClosePair implements Comparable<ClosePair> {
+
+  private final int priority;
+  private final AutoCloseable closeable;
+
+  public ClosePair(int priority, AutoCloseable closeable) {
+    this.priority = priority;
+    this.closeable = closeable;
+  }
+
+  public int priority() {
+    return priority;
+  }
+
+  public AutoCloseable closeable() {
+    return closeable;
+  }
+
+  @Override
+  public int compareTo(ClosePair o) {
+    return Integer.compare(priority, o.priority);
+  }
+}


### PR DESCRIPTION
This allows control of the ordering of the PreDestroy methods. It does this using a int priority value. The default/baseline value is 1000. Setting values less than that means those methods run earlier and values over than means those methods run later.

e.g. using `io.avaje.inject.PreDestroy` `priority` attribute:

```java

// Run before all the normal pre-destroy methods
@PreDestroy(priority = 100)
void close() {... }


// Run after all the normal pre-destroy methods
@PreDestroy(priority = 2000)
void close() {... }
```

e.g. using `@Factory @Bean` ... added the `destroyPriority` attribute. 

```java
@Factory
class MyFactory {

  @Bean(destroyMethod = "shutdown", destroyPriority = 1500)
  Hello data() {
    ...
  }
}
```