### PR TITLE
Don't register beans about to be proxied

### DIFF
--- a/blackbox-test-inject/src/test/java/org/example/myapp/MyDestroyOrderTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/MyDestroyOrderTest.java
@@ -16,6 +16,6 @@ class MyDestroyOrderTest {
       beanScope.get(HelloService.class);
     }
     List<String> ordering = MyDestroyOrder.ordering();
-    assertThat(ordering).containsExactly("HelloService", "AppConfig", "MyNamed", "MyMetaDataRepo", "ExampleService", "AppHelloData");
+    assertThat(ordering).containsExactly("HelloService", "AppConfig", "MyMetaDataRepo", "MyNamed", "ExampleService", "AppHelloData");
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -274,12 +274,12 @@ final class ScopeInfo {
     }
   }
 
-  /**
-   * Add a new previously unknown bean.
-   */
+  /** Add a new previously unknown bean. */
   private void addMeta(BeanReader beanReader) {
     MetaData meta = beanReader.createMeta();
-    metaData.put(meta.key(), meta);
+    if (!meta.isGenerateProxy()) {
+      metaData.put(meta.key(), meta);
+    }
     for (MetaData methodMeta : beanReader.createFactoryMethodMeta()) {
       metaData.put(methodMeta.key(), methodMeta);
     }


### PR DESCRIPTION
This prevents cases where the proxy class is registered after it's needed.