### PR TITLE
Fix Conditional Beans not working with AOP

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanProxyWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanProxyWriter.java
@@ -102,7 +102,7 @@ final class SimpleBeanProxyWriter {
   }
 
   private void writeClassStart() {
-    writer.append(Constants.AT_PROXY).eol();
+    writer.append(Constants.AT_PROXY).append("(%s.class)", shortName).eol();
     writer.append(Constants.AT_GENERATED).eol();
     writer.append("public final class %s%s extends %s {", shortName, suffix, shortName).eol().eol();
   }

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/MethodTestConditional.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/MethodTestConditional.java
@@ -1,0 +1,15 @@
+package io.avaje.inject.generator.models.valid.aspect;
+
+import java.util.Map;
+
+import io.avaje.inject.Component;
+import io.avaje.inject.Profile;
+import io.avaje.inject.generator.models.valid.Timed;
+
+@Component
+@Profile("sus")
+public class MethodTestConditional {
+
+  @Timed
+  void test(@Param Map<@TypeUse String, String> str, @Param int inty, String regular) {}
+}

--- a/inject/src/main/java/io/avaje/inject/spi/Proxy.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Proxy.java
@@ -5,10 +5,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Marks the type as being a Proxy.
- */
+/** Marks the type as being a Proxy. */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Proxy {
+  /** The class being proxied */
+  Class<?> value() default Void.class;
 }


### PR DESCRIPTION
- adds a new member to the `@Proxy` annotation to track the typemirror across rounds
- will now read the proxy annotation values and read the bean conditions 

fixes #432 