### PR TITLE
Support RequestScope with Helidon 4.0.0 (Nima)

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/RequestScope.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/RequestScope.java
@@ -13,8 +13,8 @@ final class RequestScope {
   private static final String HELIDON_REQ = "io.helidon.webserver.ServerRequest";
   private static final String HELIDON_RES = "io.helidon.webserver.ServerResponse";
 
-  private static final String NIMA_REQ = "io.helidon.nima.webserver.http.ServerRequest";
-  private static final String NIMA_RES = "io.helidon.nima.webserver.http.ServerResponse";
+  private static final String NIMA_REQ = "io.helidon.webserver.http.ServerRequest";
+  private static final String NIMA_RES = "io.helidon.webserver.http.ServerResponse";
   private static final String HELIDON_REACTIVE_REQ = "io.helidon.reactive.webserver.ServerRequest";
   private static final String HELIDON_REACTIVE_RES = "io.helidon.reactive.webserver.ServerResponse";
 

--- a/inject-test/pom.xml
+++ b/inject-test/pom.xml
@@ -96,13 +96,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.helidon.webserver</groupId>
-      <artifactId>helidon-webserver</artifactId>
-      <version>2.5.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.18.30</version>

--- a/inject-test/src/test/java/io/helidon/webserver/http/ServerRequest.java
+++ b/inject-test/src/test/java/io/helidon/webserver/http/ServerRequest.java
@@ -1,0 +1,7 @@
+package io.helidon.webserver.http;
+
+/**
+ * Placeholder for Helidon 4.x ServerRequest (without requiring Java 21).
+ */
+public class ServerRequest {
+}

--- a/inject-test/src/test/java/io/helidon/webserver/http/ServerResponse.java
+++ b/inject-test/src/test/java/io/helidon/webserver/http/ServerResponse.java
@@ -1,0 +1,7 @@
+package io.helidon.webserver.http;
+
+/**
+ * Placeholder for Helidon 4.x ServerResponse (without requiring Java 21).
+ */
+public class ServerResponse {
+}

--- a/inject-test/src/test/java/org/example/request/BController.java
+++ b/inject-test/src/test/java/org/example/request/BController.java
@@ -1,8 +1,8 @@
 package org.example.request;
 
 import io.avaje.http.api.Controller;
-import io.helidon.webserver.ServerRequest;
-import io.helidon.webserver.ServerResponse;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
 
 /**
  * Controller with request scoped dependencies (request and response).

--- a/inject-test/src/test/java/org/example/request/BControllerReqOnly.java
+++ b/inject-test/src/test/java/org/example/request/BControllerReqOnly.java
@@ -1,7 +1,7 @@
 package org.example.request;
 
 import io.avaje.http.api.Controller;
-import io.helidon.webserver.ServerRequest;
+import io.helidon.webserver.http.ServerRequest;
 
 /**
  * Controller with request scoped dependencies (request and response).

--- a/inject-test/src/test/java/org/example/request/BControllerResOnly.java
+++ b/inject-test/src/test/java/org/example/request/BControllerResOnly.java
@@ -1,7 +1,7 @@
 package org.example.request;
 
 import io.avaje.http.api.Controller;
-import io.helidon.webserver.ServerResponse;
+import io.helidon.webserver.http.ServerResponse;
 
 /**
  * Controller with request scoped dependencies (request and response).

--- a/inject-test/src/test/java/org/example/request/BWebRoute.java
+++ b/inject-test/src/test/java/org/example/request/BWebRoute.java
@@ -1,8 +1,8 @@
 package org.example.request;
 
 import io.avaje.inject.spi.BeanFactory2;
-import io.helidon.webserver.ServerRequest;
-import io.helidon.webserver.ServerResponse;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
 
 import jakarta.inject.Singleton;
 

--- a/inject-test/src/test/java/org/example/request/BWebRouteTest.java
+++ b/inject-test/src/test/java/org/example/request/BWebRouteTest.java
@@ -2,8 +2,8 @@ package org.example.request;
 
 
 import io.avaje.inject.xtra.ApplicationScope;
-import io.helidon.webserver.ServerRequest;
-import io.helidon.webserver.ServerResponse;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 

--- a/inject-test/src/test/java/org/example/request/CController.java
+++ b/inject-test/src/test/java/org/example/request/CController.java
@@ -1,8 +1,8 @@
 package org.example.request;
 
 import io.avaje.http.api.Controller;
-import io.helidon.webserver.ServerRequest;
-import io.helidon.webserver.ServerResponse;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
 import org.example.generic.MyObj;
 import org.example.generic.ReadService;
 


### PR DESCRIPTION
Simulate Helidon request response without requiring Java 21+