### PR TITLE
Use CodeGen for AOP Fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ APT-based dependency injection for server-side developers - https://avaje.io/inj
 </dependency>
 ```
 
-**JDK 22+**
+**JDK 23+**
 
-In JDK 22+, annotation processors are disabled by default, you will need to add a flag in maven to re-enable the processor.
+In JDK 23+, annotation processors are disabled by default, you will need to add a flag in maven to re-enable the processor.
 ```xml
 <plugin>
   <groupId>org.apache.maven.plugins</groupId>

--- a/blackbox-test-inject/src/main/java/org/example/myapp/r4j/MyExample.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/r4j/MyExample.java
@@ -3,6 +3,7 @@ package org.example.myapp.r4j;
 import org.example.myapp.resilience4j.MyRetry;
 
 import io.avaje.inject.Component;
+import io.avaje.inject.aop.AOPFallback;
 
 @Component
 public class MyExample {
@@ -16,22 +17,24 @@ public class MyExample {
     throw new IllegalArgumentException("no");
   }
 
-  @MyRetry(fallbackMethod = "myFallback", maxAttempts = 5)
+  @MyRetry(maxAttempts = 5)
   public String retryWithFallback() {
     retryWithFallbackCounter++;
     throw new IllegalArgumentException("no");
   }
 
+  @AOPFallback("retryWithFallback")
   public String myFallback() {
     return "fallback-response";
   }
 
-  @MyRetry(fallbackMethod = "fallbackRetry2")
+  @MyRetry
   public String retry2(String param0, int param1) {
     retryWithFallbackCounter++;
     throw new IllegalArgumentException("Retry2Fail[" + param0 + "," + param1 + "]");
   }
 
+  @AOPFallback("retry2")
   public String fallbackRetry2(String param0, int param1, Throwable e) {
     return "fallbackRetry2-" + param0 + ":" + param1 + ":" + e.getMessage();
   }

--- a/blackbox-test-inject/src/main/java/org/example/myapp/resilience4j/MyRetry.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/resilience4j/MyRetry.java
@@ -9,8 +9,6 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MyRetry {
 
-  String fallbackMethod() default "";
-
   int maxAttempts() default -1;
 
   String waitDuration() default "";

--- a/blackbox-test-inject/src/main/java/org/example/myapp/resilience4j/RetryProvider.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/resilience4j/RetryProvider.java
@@ -1,18 +1,16 @@
 package org.example.myapp.resilience4j;
 
-import io.avaje.inject.Component;
-import io.avaje.inject.aop.AspectProvider;
-import io.avaje.inject.aop.Fallback;
-import io.avaje.inject.aop.Invocation;
-import io.avaje.inject.aop.MethodInterceptor;
-import io.github.resilience4j.retry.Retry;
-import io.github.resilience4j.retry.RetryConfig;
-
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
+
+import io.avaje.inject.Component;
+import io.avaje.inject.aop.AspectProvider;
+import io.avaje.inject.aop.Invocation;
+import io.avaje.inject.aop.MethodInterceptor;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
 
 @Component
 public class RetryProvider implements AspectProvider<MyRetry> {
@@ -32,64 +30,34 @@ public class RetryProvider implements AspectProvider<MyRetry> {
       } catch (DateTimeParseException e) {
         e.printStackTrace();
       }
-
     }
-    RetryConfig retryConfig = RetryConfig.ofDefaults();
     RetryConfig config = builder.build();
     io.github.resilience4j.retry.Retry retry = io.github.resilience4j.retry.Retry.of("id", config);
 
-    Fallback fallback = fallback(method, retryAnnotation);
-
-    return fallback == null ?  new RetryInterceptor(retry) : new RetryFallbackInterceptor(retry, fallback);
+    return new RetryFallbackInterceptor(retry);
   }
-
-  private Fallback fallback(Method method, MyRetry retryAnnotation) {
-    if (!retryAnnotation.fallbackMethod().isEmpty()) {
-      try {
-        return Fallback.find(retryAnnotation.fallbackMethod(), method);
-      } catch (NoSuchMethodException e) {
-        throw new IllegalStateException(e);
-      }
-    }
-    return null;
-  }
-
 
   public static AtomicInteger testCounter = new AtomicInteger();
-
-  static class RetryInterceptor implements MethodInterceptor {
-
-    private final io.github.resilience4j.retry.Retry retry;
-
-    public RetryInterceptor(Retry retry) {
-      this.retry = retry;
-    }
-
-    @Override
-    public void invoke(Invocation invocation) throws Throwable {
-      testCounter.incrementAndGet();
-      Retry.decorateCheckedSupplier(retry, invocation::invoke)
-        .apply();
-    }
-  }
 
   static class RetryFallbackInterceptor implements MethodInterceptor {
 
     private final io.github.resilience4j.retry.Retry retry;
-    private final Fallback fallback;
 
-    public RetryFallbackInterceptor(Retry retry, Fallback fallback) {
+    public RetryFallbackInterceptor(Retry retry) {
       this.retry = retry;
-      this.fallback = fallback;
     }
 
     @Override
     public void invoke(Invocation invocation) throws Throwable {
       testCounter.incrementAndGet();
-      Retry.decorateCheckedSupplier(retry, invocation::invoke)
-        .recover((throwable) -> (Supplier<Object>) () -> fallback.invoke(invocation, throwable))
-        .apply();
+      if (invocation.hasRecoveryMethod()) {
+
+        Retry.decorateCheckedSupplier(retry, invocation::invoke)
+            .recover(throwable -> () -> invocation.invokeRecoveryMethod(throwable))
+            .apply();
+      } else {
+        Retry.decorateCheckedSupplier(retry, invocation::invoke).apply();
+      }
     }
   }
-
 }

--- a/blackbox-test-inject/src/main/java/org/example/myapp/resilience4j/RetryProvider.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/resilience4j/RetryProvider.java
@@ -51,7 +51,6 @@ public class RetryProvider implements AspectProvider<MyRetry> {
     public void invoke(Invocation invocation) throws Throwable {
       testCounter.incrementAndGet();
       if (invocation.hasRecoveryMethod()) {
-
         Retry.decorateCheckedSupplier(retry, invocation::invoke)
             .recover(throwable -> () -> invocation.invokeRecoveryMethod(throwable))
             .apply();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/package-info.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/package-info.java
@@ -8,6 +8,7 @@
 @GeneratePrism(Qualifier.class)
 @GeneratePrism(Named.class)
 @GeneratePrism(Inject.class)
+@GeneratePrism(AOPFallback.class)
 @GeneratePrism(Aspect.class)
 @GeneratePrism(value = Aspect.Import.class, name = "AspectImportPrism")
 @GeneratePrism(Primary.class)
@@ -26,10 +27,8 @@
 package io.avaje.inject.generator;
 
 import io.avaje.inject.*;
-import io.avaje.inject.aop.Aspect;
-import io.avaje.inject.spi.DependencyMeta;
-import io.avaje.inject.spi.Generated;
-import io.avaje.inject.spi.Proxy;
+import io.avaje.inject.aop.*;
+import io.avaje.inject.spi.*;
 import io.avaje.prism.GeneratePrism;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/MethodTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/MethodTest.java
@@ -12,11 +12,21 @@ public class MethodTest {
   @Timed
   void test(@Param Map<@TypeUse String, String> str, @Param int inty, String regular) {}
 
-
-
-
+  @Timed
   @AOPFallback("test")
-  void retry() {}
+  void retry(@Param Map<@TypeUse String, String> str, @Param int inty, String regular) {}
 
+  @Timed
+  @AOPFallback("retry")
+  void retry2(Throwable ex) {}
 
+  @AOPFallback("retry2")
+  void retry3() {}
+
+  @Timed
+  void test2(@Param Map<@TypeUse String, String> str, @Param int inty, String regular) {}
+
+  @AOPFallback("test2")
+  void retry4(
+      @Param Map<@TypeUse String, String> str, @Param int inty, String regular, Throwable t) {}
 }

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/MethodTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/MethodTest.java
@@ -29,4 +29,10 @@ public class MethodTest {
   @AOPFallback("test2")
   void retry4(
       @Param Map<@TypeUse String, String> str, @Param int inty, String regular, Throwable t) {}
+
+  @Timed
+  void test2( @Param int inty, String regular) {}
+
+  @AOPFallback(value = "test2", place = 1)
+  void retry4(@Param int inty, String regular, Throwable t) {}
 }

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/MethodTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/MethodTest.java
@@ -3,6 +3,7 @@ package io.avaje.inject.generator.models.valid.aspect;
 import java.util.Map;
 
 import io.avaje.inject.Component;
+import io.avaje.inject.aop.AOPFallback;
 import io.avaje.inject.generator.models.valid.Timed;
 
 @Component
@@ -10,4 +11,12 @@ public class MethodTest {
 
   @Timed
   void test(@Param Map<@TypeUse String, String> str, @Param int inty, String regular) {}
+
+
+
+
+  @AOPFallback("test")
+  void retry() {}
+
+
 }

--- a/inject/src/main/java/io/avaje/inject/Component.java
+++ b/inject/src/main/java/io/avaje/inject/Component.java
@@ -70,7 +70,7 @@ public @interface Component {
   @Target({TYPE, PACKAGE, MODULE})
   @interface Import {
 
-    /** Specify types to generate DI classes for. */
+    /** Types to generate DI classes for. */
     Class<?>[] value();
   }
 }

--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -15,7 +15,6 @@ import java.util.function.Supplier;
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
 import static java.util.Collections.emptySet;
-import static java.util.stream.Collectors.toSet;
 
 /** Build a bean scope with options for shutdown hook and supplying test doubles. */
 @NonNullApi
@@ -230,14 +229,13 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
 
   private void initProfiles() {
     if (profiles == null) {
-      profiles = propertyRequiresPlugin.get("avaje.profiles").map(DBeanScopeBuilder::toProfiles).orElse(emptySet());
+      profiles =
+          propertyRequiresPlugin
+              .get("avaje.profiles")
+              .map(p -> Set.of(p.split(",")))
+              .orElse(emptySet());
     }
   }
-
-  private static Set<String> toProfiles(String profiles) {
-    return Arrays.stream(profiles.split(",")).collect(toSet());
-  }
-
 
   @Override
   public BeanScope build() {

--- a/inject/src/main/java/io/avaje/inject/aop/AOPFallback.java
+++ b/inject/src/main/java/io/avaje/inject/aop/AOPFallback.java
@@ -9,6 +9,6 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AOPFallback {
 
-  /** the name of the target method to recover for. */
+  /** the name of the target method to recover from. */
   String value();
 }

--- a/inject/src/main/java/io/avaje/inject/aop/AOPFallback.java
+++ b/inject/src/main/java/io/avaje/inject/aop/AOPFallback.java
@@ -11,4 +11,7 @@ public @interface AOPFallback {
 
   /** the name of the target method to recover from. */
   String value();
+
+  /** Distinguish what method to fallback when multiple methods share the same name. */
+  int place() default 0;
 }

--- a/inject/src/main/java/io/avaje/inject/aop/AOPFallback.java
+++ b/inject/src/main/java/io/avaje/inject/aop/AOPFallback.java
@@ -1,0 +1,14 @@
+package io.avaje.inject.aop;
+
+import static java.lang.annotation.ElementType.METHOD;
+
+import java.lang.annotation.*;
+
+/** Marks a method as a recovery method for an AOP operation. */
+@Target(METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AOPFallback {
+
+  /** the name of the target method to recover for. */
+  String value();
+}

--- a/inject/src/main/java/io/avaje/inject/aop/Aspect.java
+++ b/inject/src/main/java/io/avaje/inject/aop/Aspect.java
@@ -8,8 +8,6 @@ import java.lang.annotation.*;
  * <p>Create an annotation and annotate with {@code @Aspect} to define an aspect annotation. The
  * associated type that implements {@link AspectProvider} will be used as the target class. The
  * aspect provider should be a {@code @Singleton} bean registered with <em>avaje-inject</em>.
- *
- * <p>
  */
 @Target(ElementType.ANNOTATION_TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -32,18 +30,22 @@ public @interface Aspect {
    */
   int ordering() default 1000;
 
-  /** Marks an External Annotation as being used for aspects */
+  /**
+   * Marks an External Annotation as being used for aspects
+   */
   @Target({ElementType.PACKAGE, ElementType.TYPE})
   @Retention(RetentionPolicy.SOURCE)
-  public @interface Import {
+  @interface Import {
 
-    /** Annotation type to import */
+    /**
+     * Annotation type to import
+     */
     Class<? extends Annotation> value();
 
     /**
      * Specify the priority of the imported aspect.
      *
-     * @see {@link Aspect#ordering()}
+     * @see Aspect#ordering()
      */
     int ordering() default 1000;
   }

--- a/inject/src/main/java/io/avaje/inject/aop/Aspect.java
+++ b/inject/src/main/java/io/avaje/inject/aop/Aspect.java
@@ -7,7 +7,7 @@ import java.lang.annotation.*;
  *
  * <p>Create an annotation and annotate with {@code @Aspect} to define an aspect annotation. The
  * associated type that implements {@link AspectProvider} will be used as the target class. The
- * aspect provider should be a {@code @Singleton} such that registers with <em>avaje-inject</em>.
+ * aspect provider should be a {@code @Singleton} bean registered with <em>avaje-inject</em>.
  *
  * <p>
  */
@@ -32,29 +32,18 @@ public @interface Aspect {
    */
   int ordering() default 1000;
 
-  /**
-   * Marks an External Annotation as being used for aspects
-   */
+  /** Marks an External Annotation as being used for aspects */
   @Target({ElementType.PACKAGE, ElementType.TYPE})
   @Retention(RetentionPolicy.SOURCE)
   public @interface Import {
 
+    /** Annotation type to import */
     Class<? extends Annotation> value();
 
     /**
-     * Specify the priority ordering when multiple aspects are on a method.
+     * Specify the priority of the imported aspect.
      *
-     * <p>When multiple aspects are on a method they are nested. The highest ordering value will be
-     * the outer-most aspect, the lowest ordering will be the inner-most aspect.
-     *
-     * <p>The outer-most aspect will have it's <em>before</em> executed first, followed by the
-     * <em>before</em> of the inner nested aspects ultimately down the invocation of the target
-     * method.
-     *
-     * <p>The reverse ordering occurs for <em>after</em> with the outer-most aspect having it's
-     * <em>after</em> executed last.
-     *
-     * @return The ordering of this aspect. High value for outer-most aspect.
+     * @see {@link Aspect#ordering()}
      */
     int ordering() default 1000;
   }

--- a/inject/src/main/java/io/avaje/inject/aop/Fallback.java
+++ b/inject/src/main/java/io/avaje/inject/aop/Fallback.java
@@ -8,8 +8,10 @@ import java.lang.reflect.Method;
  * This isn't strictly required but more a helper to make it easier for aspects
  * that want to use a fallback or recovery method.
  */
+@Deprecated
 @FunctionalInterface
 public interface Fallback {
+
 
   /**
    * Find and return the fallback given the name and original method.

--- a/inject/src/main/java/io/avaje/inject/aop/Fallback.java
+++ b/inject/src/main/java/io/avaje/inject/aop/Fallback.java
@@ -3,12 +3,14 @@ package io.avaje.inject.aop;
 import java.lang.reflect.Method;
 
 /**
+ * @deprecated migrate to use {@link AOPFallback} to specify the fallback method.
+ * <p>
  * A fallback or recovery method used with Aspects.
  * <p>
  * This isn't strictly required but more a helper to make it easier for aspects
  * that want to use a fallback or recovery method.
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 @FunctionalInterface
 public interface Fallback {
 

--- a/inject/src/main/java/io/avaje/inject/aop/FallbackFinder.java
+++ b/inject/src/main/java/io/avaje/inject/aop/FallbackFinder.java
@@ -8,7 +8,6 @@ import java.lang.reflect.Parameter;
 final class FallbackFinder {
 
   static Fallback find(String name, Method method) throws NoSuchMethodException {
-
     final Class<?> type = method.getDeclaringClass();
     final Parameter[] parameters = method.getParameters();
     try {
@@ -46,7 +45,6 @@ final class FallbackFinder {
     @Override
     public Object invoke(Invocation call, Throwable e) {
        try {
-
         final Object result = fallbackMethod.invoke(call.instance(), call.arguments(e));
         call.result(result);
         return result;

--- a/inject/src/main/java/io/avaje/inject/aop/FallbackFinder.java
+++ b/inject/src/main/java/io/avaje/inject/aop/FallbackFinder.java
@@ -4,9 +4,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 
+@Deprecated
 final class FallbackFinder {
 
   static Fallback find(String name, Method method) throws NoSuchMethodException {
+
     final Class<?> type = method.getDeclaringClass();
     final Parameter[] parameters = method.getParameters();
     try {
@@ -43,7 +45,8 @@ final class FallbackFinder {
 
     @Override
     public Object invoke(Invocation call, Throwable e) {
-      try {
+       try {
+
         final Object result = fallbackMethod.invoke(call.instance(), call.arguments(e));
         call.result(result);
         return result;

--- a/inject/src/main/java/io/avaje/inject/aop/Invocation.java
+++ b/inject/src/main/java/io/avaje/inject/aop/Invocation.java
@@ -121,7 +121,7 @@ public interface Invocation {
     @Override
     public Object[] arguments(Throwable e) {
       if (args == null || args.length == 0) {
-        return new Object[]{e};
+        return new Object[] {e};
       } else {
         Object[] newArgs = Arrays.copyOf(args, args.length + 1);
         newArgs[args.length] = e;
@@ -186,8 +186,7 @@ public interface Invocation {
 
     @Override
     public Base<Void> wrap(MethodInterceptor methodInterceptor) {
-      return new Invocation.Run(() -> methodInterceptor.invoke(this))
-        .with(instance, method, args);
+      return new Invocation.Run(() -> methodInterceptor.invoke(this)).with(instance, method, args);
     }
 
     @Override
@@ -195,9 +194,10 @@ public interface Invocation {
 
       return fallback != null;
     }
+
     @Override
     public Object invokeRecoveryMethod(Throwable t) {
-    	noRecovery(fallback);
+      noRecovery(fallback);
       fallback.accept(t);
       return null;
     }
@@ -207,7 +207,6 @@ public interface Invocation {
       super.with(instance, method, args);
       return this;
     }
-
   }
 
   /**
@@ -253,11 +252,13 @@ public interface Invocation {
 
     @Override
     public Base<T> wrap(MethodInterceptor methodInterceptor) {
-      return new Invocation.Call<>(() -> {
-        final Call<T> delegate = this;
-        methodInterceptor.invoke(delegate);
-        return delegate.finalResult();
-      }).with(instance, method, args);
+      return new Invocation.Call<>(
+              () -> {
+                final Call<T> delegate = this;
+                methodInterceptor.invoke(delegate);
+                return delegate.finalResult();
+              })
+          .with(instance, method, args);
     }
 
     @Override
@@ -273,7 +274,6 @@ public interface Invocation {
       super.result(result);
       return result;
     }
-
   }
 
   /**

--- a/inject/src/main/java/io/avaje/inject/aop/Invocation.java
+++ b/inject/src/main/java/io/avaje/inject/aop/Invocation.java
@@ -151,8 +151,9 @@ public interface Invocation {
     public abstract Base<T> wrap(MethodInterceptor methodInterceptor);
 
     protected void noRecovery(Object recover) {
-      if (recover == null)
+      if (recover == null) {
         throw new IllegalStateException("No recovery method available for this invocation");
+      }
     }
   }
 
@@ -176,9 +177,10 @@ public interface Invocation {
       delegate.invoke();
       return null;
     }
+
     /**
-     * register a fallback method which can be used to recover from an exception while intercepting
-     * an invocation
+     * Register a fallback method which can be used to recover from an exception
+     * while intercepting an invocation
      */
     public Run fallback(Consumer<Throwable> fallback) {
       this.fallback = fallback;
@@ -192,7 +194,6 @@ public interface Invocation {
 
     @Override
     public boolean hasRecoveryMethod() {
-
       return fallback != null;
     }
 
@@ -253,18 +254,15 @@ public interface Invocation {
 
     @Override
     public Base<T> wrap(MethodInterceptor methodInterceptor) {
-      return new Invocation.Call<>(
-              () -> {
-                final Call<T> delegate = this;
-                methodInterceptor.invoke(delegate);
-                return delegate.finalResult();
-              })
-          .with(instance, method, args);
+      return new Invocation.Call<>(() -> {
+        final Call<T> delegate = this;
+        methodInterceptor.invoke(delegate);
+        return delegate.finalResult();
+      }).with(instance, method, args);
     }
 
     @Override
     public boolean hasRecoveryMethod() {
-
       return fallback != null;
     }
 

--- a/inject/src/main/java/io/avaje/inject/aop/Invocation.java
+++ b/inject/src/main/java/io/avaje/inject/aop/Invocation.java
@@ -52,8 +52,13 @@ public interface Invocation {
    */
   Object[] arguments();
 
-  /** Return the arguments additionally appending the throwable. */
-  @Deprecated
+  /**
+   * @deprecated migrate to using {@link AOPFallback} to specify fallback method.
+   * That then removes the need to use this method altogether.
+   * <p>
+   * Return the arguments additionally appending the throwable.
+   */
+  @Deprecated(forRemoval = true)
   Object[] arguments(Throwable e);
 
   /**
@@ -68,14 +73,16 @@ public interface Invocation {
    */
   Object instance();
 
-  /** Return whether this invocation has a registered recovery method */
+  /**
+   * Return whether this invocation has a registered recovery method
+   */
   boolean hasRecoveryMethod();
 
   /**
    * Invoke the recovery method associated for this invocation and return the result.
    *
-   * @throws IllegalStateException if no fallback method is configured with this invocation
    * @return The result of the method call. This will return null for void methods.
+   * @throws IllegalStateException if no fallback method is configured with this invocation
    */
   Object invokeRecoveryMethod(Throwable t);
 
@@ -122,7 +129,7 @@ public interface Invocation {
     @Override
     public Object[] arguments(Throwable e) {
       if (args == null || args.length == 0) {
-        return new Object[] {e};
+        return new Object[]{e};
       } else {
         Object[] newArgs = Arrays.copyOf(args, args.length + 1);
         newArgs[args.length] = e;

--- a/inject/src/main/java/io/avaje/inject/aop/Invocation.java
+++ b/inject/src/main/java/io/avaje/inject/aop/Invocation.java
@@ -2,6 +2,8 @@ package io.avaje.inject.aop;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Method invocation using in {@link MethodInterceptor#invoke(Invocation)} for Aspects.
@@ -50,9 +52,8 @@ public interface Invocation {
    */
   Object[] arguments();
 
-  /**
-   * Return the arguments additionally appending the throwable.
-   */
+  /** Return the arguments additionally appending the throwable. */
+  @Deprecated
   Object[] arguments(Throwable e);
 
   /**
@@ -66,6 +67,16 @@ public interface Invocation {
    * This is typically used when invoking fallback/recovery methods.
    */
   Object instance();
+
+  /** Return whether this invocation has a registered recovery method */
+  boolean hasRecoveryMethod();
+
+  /**
+   * Invoke the recovery method associated for this invocation and return the result.
+   *
+   * @return The result of the method call. This will return null for void methods.
+   */
+  Object invokeRecoveryMethod(Throwable t);
 
   /**
    * Invocation base type for both callable and runnable methods.
@@ -137,6 +148,11 @@ public interface Invocation {
      * @return The wrapped call
      */
     public abstract Base<T> wrap(MethodInterceptor methodInterceptor);
+
+    protected void noRecovery(Object recover) {
+      if (recover == null)
+        throw new IllegalStateException("No recovery method available for this invocation");
+    }
   }
 
   /**
@@ -145,6 +161,7 @@ public interface Invocation {
   final class Run extends Base<Void> {
 
     private final CheckedRunnable delegate;
+    private Consumer<Throwable> fallback;
 
     /**
      * Create with a given closure to run.
@@ -158,11 +175,37 @@ public interface Invocation {
       delegate.invoke();
       return null;
     }
+    /**
+     * register a fallback method which can be used to recover from an exception while intercepting
+     * an invocation
+     */
+    public Run fallback(Consumer<Throwable> fallback) {
+      this.fallback = fallback;
+      return this;
+    }
 
     @Override
     public Base<Void> wrap(MethodInterceptor methodInterceptor) {
       return new Invocation.Run(() -> methodInterceptor.invoke(this))
         .with(instance, method, args);
+    }
+
+    @Override
+    public boolean hasRecoveryMethod() {
+
+      return fallback != null;
+    }
+    @Override
+    public Object invokeRecoveryMethod(Throwable t) {
+    	noRecovery(fallback);
+      fallback.accept(t);
+      return null;
+    }
+
+    @Override
+    public Run with(Object instance, Method method, Object... args) {
+      super.with(instance, method, args);
+      return this;
     }
 
   }
@@ -173,6 +216,7 @@ public interface Invocation {
   final class Call<T> extends Base<T> {
 
     private final CheckedSupplier<T> delegate;
+    private Function<Throwable, T> fallback;
 
     /**
      * Create with a given supplier.
@@ -193,13 +237,43 @@ public interface Invocation {
     }
 
     @Override
+    public Call<T> with(Object instance, Method method, Object... args) {
+      super.with(instance, method, args);
+      return this;
+    }
+
+    /**
+     * register a fallback method which can be used to recover from an exception while intercepting
+     * an invocation
+     */
+    public Call<T> fallback(Function<Throwable, T> fallback) {
+      this.fallback = fallback;
+      return this;
+    }
+
+    @Override
     public Base<T> wrap(MethodInterceptor methodInterceptor) {
-      return new Invocation.Call<T>(() -> {
+      return new Invocation.Call<>(() -> {
         final Call<T> delegate = this;
         methodInterceptor.invoke(delegate);
         return delegate.finalResult();
       }).with(instance, method, args);
     }
+
+    @Override
+    public boolean hasRecoveryMethod() {
+
+      return fallback != null;
+    }
+
+    @Override
+    public Object invokeRecoveryMethod(Throwable t) {
+      noRecovery(fallback);
+      var result = fallback.apply(t);
+      super.result(result);
+      return result;
+    }
+
   }
 
   /**

--- a/inject/src/main/java/io/avaje/inject/aop/Invocation.java
+++ b/inject/src/main/java/io/avaje/inject/aop/Invocation.java
@@ -74,6 +74,7 @@ public interface Invocation {
   /**
    * Invoke the recovery method associated for this invocation and return the result.
    *
+   * @throws IllegalStateException if no fallback method is configured with this invocation
    * @return The result of the method call. This will return null for void methods.
    */
   Object invokeRecoveryMethod(Throwable t);

--- a/inject/src/main/java/io/avaje/inject/aop/InvocationException.java
+++ b/inject/src/main/java/io/avaje/inject/aop/InvocationException.java
@@ -4,7 +4,7 @@ package io.avaje.inject.aop;
  * Exception occurring during method interception.
  * <p>
  * When using aspects and {@link MethodInterceptor} any throwable that is undeclared on the
- * method is caught and re-throw as an InvocationException.
+ * method is caught and re-thrown as an InvocationException.
  */
 public class InvocationException extends RuntimeException {
 


### PR DESCRIPTION
The current way of using fallback methods is pretty obtuse, so this adds

- Adds a new annotation to mark a method as a fallback for AOP.
- will generate code to register a fallback method to an invocation
- Adds new method to `Invocation` to invoke a registered fallback method
- also will use method references in generated proxies if possible

Given stuff like this:
```java

  @MyRetry
  public String retry2(String param0, int param1) {
    retryWithFallbackCounter++;
    throw new IllegalArgumentException("Retry2Fail[" + param0 + "," + param1 + "]");
  }

  @AOPFallback("retry2")
  public String fallbackRetry2(String param0, int param1, Throwable e) {
    return "fallbackRetry2-" + param0 + ":" + param1 + ":" + e.getMessage();
  }
```
this will get generated
```java
  @Override
  public java.lang.String retry2(String param0, int param1) {
    var call = new Invocation.Call<>(() -> super.retry2(param0, param1))
      .with(this, retry20, param0, param1)
      .fallback(ex -> fallbackRetry2(param0, param1, ex));
    try {
      retry20MyRetry.invoke(call);
      return call.finalResult();
    } catch (RuntimeException ex) {
      ex.addSuppressed(new InvocationException("retry2 proxy threw exception"));
      throw ex;
    } catch (Throwable t) {
      throw new InvocationException("retry2 proxy threw exception", t);
    }
  }