### PR TITLE
Simplify Proxy Generation

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -60,13 +60,9 @@ final class BeanReader {
     this.constructor = typeReader.constructor();
     this.importedComponent = importedComponent && (constructor != null && constructor.isPublic());
 
-    var proxyPrism = ProxyPrism.getInstanceOn(beanType);
-    if (proxyPrism != null) {
+    if (ProxyPrism.isPresent(beanType)) {
       this.proxy = true;
-      var proxyMirror = proxyPrism.value();
-      if (!"Void".equals(proxyMirror.toString())) {
-        conditions.readAll(APContext.asTypeElement(proxyMirror));
-      }
+      conditions.readAll(APContext.asTypeElement(beanType.getSuperclass()));
     } else {
       conditions.readAll(beanType);
       this.proxy = false;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanProxyWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanProxyWriter.java
@@ -102,7 +102,7 @@ final class SimpleBeanProxyWriter {
   }
 
   private void writeClassStart() {
-    writer.append(Constants.AT_PROXY).append("(%s.class)", shortName).eol();
+    writer.append(Constants.AT_PROXY).eol();
     writer.append(Constants.AT_GENERATED).eol();
     writer.append("public final class %s%s extends %s {", shortName, suffix, shortName).eol().eol();
   }

--- a/inject/src/main/java/io/avaje/inject/spi/Proxy.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Proxy.java
@@ -8,7 +8,4 @@ import java.lang.annotation.Target;
 /** Marks the type as being a Proxy. */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Proxy {
-  /** The class being proxied */
-  Class<?> value() default Void.class;
-}
+public @interface Proxy {}


### PR DESCRIPTION
There's no need for the proxy annotation to have an attribute, when we can simply check the superclass