### PR TITLE
Fix when getting map of beans with parent scope

### DIFF
--- a/inject-test/src/test/java/org/example/coffee/BeanScopeBuilderAddTest.java
+++ b/inject-test/src/test/java/org/example/coffee/BeanScopeBuilderAddTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 
-class BeanScopeBuilderAddTest {
+public class BeanScopeBuilderAddTest {
 
   @Test
   void withModules_excludingThisOne() {
@@ -28,7 +28,7 @@ class BeanScopeBuilderAddTest {
     }
   }
 
-  static class SillyModule implements Module {
+  public static class SillyModule implements Module {
 
     @Override
     public Class<?>[] requires() {

--- a/inject-test/src/test/java/org/example/coffee/qualifier/StoreManagerWithNamedTest.java
+++ b/inject-test/src/test/java/org/example/coffee/qualifier/StoreManagerWithNamedTest.java
@@ -2,6 +2,7 @@ package org.example.coffee.qualifier;
 
 import io.avaje.inject.BeanScope;
 import org.example.autonamed.MyAutoB2;
+import org.example.coffee.BeanScopeBuilderAddTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -29,6 +30,27 @@ class StoreManagerWithNamedTest {
       // a map with unnamed component
       Map<String, MyAutoB2> mapWithUnnamed = beanScope.map(MyAutoB2.class);
       assertThat(mapWithUnnamed).hasSize(1);
+    }
+  }
+
+  @Test
+  void mapParent() {
+    try (BeanScope parent = BeanScope.builder()
+      .bean(SomeStore.class, new LocalStore())
+      .modules(new BeanScopeBuilderAddTest.SillyModule())
+      .build()) {
+
+      try (BeanScope beanScope = BeanScope.builder().parent(parent).build()) {
+        Map<String, SomeStore> stores = beanScope.map(SomeStore.class);
+        assertThat(stores).hasSize(3);
+      }
+    }
+  }
+
+  static final class LocalStore implements SomeStore {
+    @Override
+    public String store() {
+      return "foo";
     }
   }
 }

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
@@ -139,8 +139,15 @@ final class DBeanMap {
     if (parent == null) {
       return map(type);
     }
-    Map<String, Object> result = parent.map(type);
-    result.putAll(map(type));
+    Map<String, Object> parentMap = parent.map(type);
+    Map<String, Object> localMap = map(type);
+    if (parentMap.isEmpty()) {
+      return localMap;
+    } else if (localMap.isEmpty()) {
+      return parentMap;
+    }
+    Map<String, Object> result = new LinkedHashMap<>(parentMap);
+    result.putAll(localMap);
     return result;
   }
 


### PR DESCRIPTION
Prior to this fix if the parent returning an empty map it was unmodifiable and resulted in an error.