### PR TITLE
For @InjectTest only build new BeanScope when test has mocks or spies

### DIFF
--- a/inject-test/src/main/java/io/avaje/inject/test/GlobalTestScope.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/GlobalTestScope.java
@@ -18,9 +18,9 @@ final class GlobalTestScope implements ExtensionContext.Store.CloseableResource 
 
   private final ReentrantLock lock = new ReentrantLock();
   private boolean started;
-  private BeanScope globalBeanScope;
+  private Pair globalBeanScope;
 
-  BeanScope obtain(ExtensionContext context) {
+  Pair obtain(ExtensionContext context) {
     lock.lock();
     try {
       if (!started) {
@@ -34,11 +34,9 @@ final class GlobalTestScope implements ExtensionContext.Store.CloseableResource 
   }
 
   private void initialise(ExtensionContext context) {
-    globalBeanScope = TestBeanScope.init(false);
-    if (globalBeanScope != null) {
-      log.log(TRACE, "register global test BeanScope with beans {0}", globalBeanScope);
-      context.getRoot().getStore(ExtensionContext.Namespace.GLOBAL).put(InjectExtension.class.getCanonicalName(), this);
-    }
+    globalBeanScope = TSBuild.initialise();
+    log.log(TRACE, "register global test BeanScope with beans {0}", globalBeanScope);
+    context.getRoot().getStore(ExtensionContext.Namespace.GLOBAL).put(InjectExtension.class.getCanonicalName(), this);
   }
 
   /**
@@ -55,6 +53,57 @@ final class GlobalTestScope implements ExtensionContext.Store.CloseableResource 
     } finally {
       lock.unlock();
     }
+  }
+
+  /**
+   * The pair of BeanScopes that can be used for InjectTests.
+   */
+  static final class Pair {
+
+    /**
+     * Entire application wired (with testScope as parent replacing those beans).
+     * This can be used when a test only injects beans and there are no mocks,
+     * spies, or setup methods.
+     */
+    private final BeanScope allScope;
+
+    /**
+     * The TestScope beans, used as the parent scope when a new BeanScope
+     * needs to be wired for a test (due to mocks, spies or setup methods).
+     */
+    private final BeanScope baseScope;
+
+    Pair(BeanScope allScope, BeanScope baseScope) {
+      this.allScope = allScope;
+      this.baseScope = baseScope;
+    }
+
+    void close() {
+      if (allScope != null) {
+        allScope.close();
+      }
+      if (baseScope != null) {
+        baseScope.close();
+      }
+    }
+
+    BeanScope allScope() {
+      return allScope;
+    }
+
+    BeanScope baseScope() {
+      return baseScope;
+    }
+
+    Pair newPair(BeanScope newAllScope) {
+      return new Pair(newAllScope, baseScope);
+    }
+
+    @Override
+    public String toString() {
+      return "All[" + allScope + "] Test[" + baseScope + "]";
+    }
+
   }
 
 }

--- a/inject-test/src/main/java/io/avaje/inject/test/InjectExtension.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/InjectExtension.java
@@ -21,7 +21,7 @@ public final class InjectExtension implements BeforeAllCallback, AfterAllCallbac
   private static final String META = "META";
   private static final GlobalTestScope GLOBAL = new GlobalTestScope();
 
-  private BeanScope globalBeanScope;
+  private GlobalTestScope.Pair globalBeanScope;
 
   @Override
   public void beforeAll(ExtensionContext context) {
@@ -64,9 +64,8 @@ public final class InjectExtension implements BeforeAllCallback, AfterAllCallbac
     if (metaInfo.hasInstanceInjection()) {
 
       // if (static fields) then (class scope) else (globalTestScope)
-      final BeanScope parent = metaInfo.hasStaticInjection() ? getClassScope(context) : globalBeanScope;
-
-      AutoCloseable beanScope = metaInfo.buildForInstance(parent, context.getRequiredTestInstance());
+      final GlobalTestScope.Pair pair = metaInfo.hasStaticInjection() ? globalBeanScope.newPair(getClassScope(context)) : globalBeanScope;
+      AutoCloseable beanScope = metaInfo.buildForInstance(pair, context.getRequiredTestInstance());
 
       // put method level test scope
       Method testMethod = context.getRequiredTestMethod();

--- a/inject-test/src/main/java/io/avaje/inject/test/MetaReader.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/MetaReader.java
@@ -48,6 +48,33 @@ final class MetaReader {
     }
   }
 
+  boolean hasMocksOrSpies(Object testInstance) {
+    if (testInstance == null) {
+      return hasStaticMocksOrSpies() || methodFinder.hasStaticMethods();
+    } else {
+      return hasInstanceMocksOrSpies(testInstance) || methodFinder.hasInstanceMethods();
+    }
+  }
+
+  private boolean hasInstanceMocksOrSpies(Object testInstance) {
+    return !mocks.isEmpty() || !spies.isEmpty() || hasInjectMock(injection, testInstance);
+  }
+
+  private boolean hasStaticMocksOrSpies() {
+    return !staticMocks.isEmpty() || !staticSpies.isEmpty() || hasInjectMock(staticInjection, null);
+  }
+
+  private boolean hasInjectMock(List<FieldTarget> fields, Object testInstance) {
+    for (FieldTarget target : fields) {
+      Object existingValue = target.get(testInstance);
+      if (existingValue != null) {
+        // an assigned injection field is a mock
+        return true;
+      }
+    }
+    return false;
+  }
+
   private static LinkedList<Class<?>> typeHierarchy(Class<?> testClass) {
     var hierarchy = new LinkedList<Class<?>>();
     var analyzedClass = testClass;
@@ -142,15 +169,15 @@ final class MetaReader {
     return null;
   }
 
-  MetaInfo.Scope setFromScope(BeanScope beanScope, Object testInstance) {
+  MetaInfo.Scope setFromScope(BeanScope beanScope, Object testInstance, boolean newScope) {
     if (testInstance != null) {
-      return setForInstance(beanScope, testInstance);
+      return setForInstance(beanScope, testInstance, newScope);
     } else {
-      return setForStatics(beanScope);
+      return setForStatics(beanScope, newScope);
     }
   }
 
-  private MetaInfo.Scope setForInstance(BeanScope beanScope, Object testInstance) {
+  private MetaInfo.Scope setForInstance(BeanScope beanScope, Object testInstance, boolean newScope) {
     try {
       Plugin.Scope pluginScope = instancePlugin ? plugin.createScope(beanScope) : null;
 
@@ -171,14 +198,14 @@ final class MetaReader {
           target.setFromScope(beanScope, testInstance);
         }
       }
-      return new MetaInfo.Scope(beanScope, pluginScope);
+      return new MetaInfo.Scope(beanScope, pluginScope, newScope);
 
     } catch (IllegalAccessException e) {
       throw new RuntimeException(e);
     }
   }
 
-  private MetaInfo.Scope setForStatics(BeanScope beanScope) {
+  private MetaInfo.Scope setForStatics(BeanScope beanScope, boolean newScope) {
     try {
       Plugin.Scope pluginScope = staticPlugin ? plugin.createScope(beanScope) : null;
 
@@ -196,7 +223,7 @@ final class MetaReader {
           target.setFromScope(beanScope, null);
         }
       }
-      return new MetaInfo.Scope(beanScope, pluginScope);
+      return new MetaInfo.Scope(beanScope, pluginScope, newScope);
     } catch (IllegalAccessException e) {
       throw new RuntimeException(e);
     }

--- a/inject-test/src/main/java/io/avaje/inject/test/TSBuild.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/TSBuild.java
@@ -30,7 +30,7 @@ final class TSBuild {
    * time this method is called.
    */
   @Nullable
-  static BeanScope create(boolean shutdownHook) {
+  static BeanScope createTestBaseScope(boolean shutdownHook) {
     return new TSBuild(shutdownHook).build();
   }
 
@@ -42,7 +42,7 @@ final class TSBuild {
     lock.lock();
     try {
       if (SCOPE == null) {
-        SCOPE = create(shutdownHook);
+        SCOPE = createTestBaseScope(shutdownHook);
       }
       return SCOPE;
     } finally {
@@ -52,6 +52,18 @@ final class TSBuild {
 
   TSBuild(boolean shutdownHook) {
     this.shutdownHook = shutdownHook;
+  }
+
+  static GlobalTestScope.Pair initialise() {
+    BeanScope testBaseScope = createTestBaseScope(false);
+    BeanScope testAllScope = createTestAllScope(testBaseScope);
+    return new GlobalTestScope.Pair(testAllScope, testBaseScope);
+  }
+
+  private static BeanScope createTestAllScope(BeanScope testBaseScope) {
+      return BeanScope.builder()
+        .parent(testBaseScope, false)
+        .build();
   }
 
   @Nullable

--- a/inject-test/src/main/java/io/avaje/inject/test/TestBeanScope.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/TestBeanScope.java
@@ -74,7 +74,7 @@ public abstract class TestBeanScope {
    */
   @Nullable
   public static BeanScope create(boolean shutdownHook) {
-    return TSBuild.create(shutdownHook);
+    return TSBuild.createTestBaseScope(shutdownHook);
   }
 
   @Nullable

--- a/inject-test/src/test/java/io/avaje/inject/test/MetaReaderTest.java
+++ b/inject-test/src/test/java/io/avaje/inject/test/MetaReaderTest.java
@@ -39,7 +39,7 @@ class MetaReaderTest {
     assertThat(metaReader.instancePlugin).isTrue();
 
     HelloBean helloBean = new HelloBean();
-    metaReader.setFromScope(Mockito.mock(BeanScope.class), helloBean);
+    metaReader.setFromScope(Mockito.mock(BeanScope.class), helloBean, true);
 
     assertThat(helloBean.client).isNotNull();
   }


### PR DESCRIPTION
Currently, for each test using @InjectTest a new BeanScope is wired (and uses a parent scope with @TestScope beans in it).

This changes, such that the "global test scope" is a pair of BeanScope with
- "testBaseScope" as scope with all @TestScope beans in it
- "testAllScope" as all beans (with the testBaseScope as its parent).

Any test that just injects can reuse the "testAllScope" (and not write a new BeanScope).

Any test that uses mocks, spies, has a setup method, or uses profiles must work as before and wire a new BeanScope (and as before use the "testBaseScope" as its parent).

This change makes component testing faster