### PR TITLE
Follow up to #503 for Plugin scope to match the test bean scope

### DIFF
--- a/inject-test/src/main/java/io/avaje/inject/test/GlobalInitialise.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/GlobalInitialise.java
@@ -18,10 +18,10 @@ import java.util.concurrent.locks.ReentrantLock;
  * Takes into when Service loading does not work such as when using module-path.
  * In that case loads the META-INF services resources and uses reflection.
  */
-final class TSBuild {
+final class GlobalInitialise {
 
   private static final ReentrantLock lock = new ReentrantLock();
-  private static GlobalTestScope.Pair SCOPE;
+  private static GlobalTestBeans.Beans SCOPE;
 
   private final boolean shutdownHook;
 
@@ -31,13 +31,13 @@ final class TSBuild {
    */
   @Nullable
   static BeanScope createTestBaseScope(boolean shutdownHook) {
-    return new TSBuild(shutdownHook).build();
+    return new GlobalInitialise(shutdownHook).build();
   }
 
   /**
    * Return the test BeanScope only creating once.
    */
-  static GlobalTestScope.Pair initialise(boolean shutdownHook) {
+  static GlobalTestBeans.Beans initialise(boolean shutdownHook) {
     lock.lock();
     try {
       if (SCOPE == null) {
@@ -49,14 +49,15 @@ final class TSBuild {
     }
   }
 
-  TSBuild(boolean shutdownHook) {
+  GlobalInitialise(boolean shutdownHook) {
     this.shutdownHook = shutdownHook;
   }
 
-  private static GlobalTestScope.Pair createScopes(boolean shutdownHook) {
+  private static GlobalTestBeans.Beans createScopes(boolean shutdownHook) {
     BeanScope testBaseScope = createTestBaseScope(shutdownHook);
     BeanScope testAllScope = createTestAllScope(testBaseScope);
-    return new GlobalTestScope.Pair(testAllScope, testBaseScope);
+    Plugin.Scope pluginAll = PluginMgr.scope(testAllScope);
+    return new GlobalTestBeans.Beans(pluginAll, testAllScope, testBaseScope);
   }
 
   private static BeanScope createTestAllScope(BeanScope testBaseScope) {

--- a/inject-test/src/main/java/io/avaje/inject/test/InjectExtension.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/InjectExtension.java
@@ -1,7 +1,6 @@
 package io.avaje.inject.test;
 
 import io.avaje.applog.AppLog;
-import io.avaje.inject.BeanScope;
 import org.junit.jupiter.api.extension.*;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 
@@ -19,18 +18,18 @@ public final class InjectExtension implements BeforeAllCallback, AfterAllCallbac
   private static final Namespace INJECT_NS = Namespace.create("io.avaje.inject.InjectTest");
   private static final String BEAN_SCOPE = "BEAN_SCOPE";
   private static final String META = "META";
-  private static final GlobalTestScope GLOBAL = new GlobalTestScope();
+  private static final GlobalTestBeans GLOBAL = new GlobalTestBeans();
 
-  private GlobalTestScope.Pair globalBeanScope;
+  private GlobalTestBeans.Beans globalTestBeans;
 
   @Override
   public void beforeAll(ExtensionContext context) {
-    globalBeanScope = GLOBAL.obtain(context);
+    globalTestBeans = GLOBAL.obtain(context);
 
     final MetaInfo metaInfo = createMetaInfo(context);
     putMetaInfo(context, metaInfo);
     if (metaInfo.hasStaticInjection()) {
-      putClassScope(context, metaInfo.buildForClass(globalBeanScope));
+      putClassScope(context, metaInfo.buildForClass(globalTestBeans));
     }
   }
 
@@ -44,15 +43,15 @@ public final class InjectExtension implements BeforeAllCallback, AfterAllCallbac
     return (MetaInfo) context.getStore(INJECT_NS).get(META + testClass);
   }
 
-  private void putClassScope(ExtensionContext context, MetaInfo.Scope testClassBeanScope) {
+  private void putClassScope(ExtensionContext context, TestBeans testClassBeanScope) {
     Class<?> testClass = context.getRequiredTestClass();
     context.getStore(INJECT_NS).put(BEAN_SCOPE + testClass, testClassBeanScope);
   }
 
-  private BeanScope getClassScope(ExtensionContext context) {
+  private GlobalTestBeans.Beans getClassScope(ExtensionContext context, GlobalTestBeans.Beans globalTestBeans) {
     Class<?> testClass = context.getRequiredTestClass();
-    MetaInfo.Scope pair = (MetaInfo.Scope) context.getStore(INJECT_NS).get(BEAN_SCOPE + testClass);
-    return pair.beanScope();
+    TestBeans testBeans =  (TestBeans) context.getStore(INJECT_NS).get(BEAN_SCOPE + testClass);
+    return globalTestBeans.withBeans(testBeans);
   }
 
   /**
@@ -62,14 +61,13 @@ public final class InjectExtension implements BeforeAllCallback, AfterAllCallbac
   public void beforeEach(final ExtensionContext context) {
     final MetaInfo metaInfo = getMetaInfo(context);
     if (metaInfo.hasInstanceInjection()) {
-
-      // if (static fields) then (class scope) else (globalTestScope)
-      final GlobalTestScope.Pair pair = metaInfo.hasStaticInjection() ? globalBeanScope.newPair(getClassScope(context)) : globalBeanScope;
-      AutoCloseable beanScope = metaInfo.buildForInstance(pair, context.getRequiredTestInstance());
+      // if (static fields) then (class scope) else (global scope)
+      final GlobalTestBeans.Beans parentBeans = metaInfo.hasStaticInjection() ? getClassScope(context, globalTestBeans) : globalTestBeans;
+      AutoCloseable metaScope = metaInfo.buildForInstance(parentBeans, context.getRequiredTestInstance());
 
       // put method level test scope
       Method testMethod = context.getRequiredTestMethod();
-      context.getStore(INJECT_NS).put(BEAN_SCOPE + testMethod, beanScope);
+      context.getStore(INJECT_NS).put(BEAN_SCOPE + testMethod, metaScope);
     }
   }
 
@@ -109,7 +107,7 @@ public final class InjectExtension implements BeforeAllCallback, AfterAllCallbac
    * Return the MetaInfo.
    */
   private MetaInfo createMetaInfo(ExtensionContext context) {
-    return new MetaInfo(context.getRequiredTestClass(), PluginInitialise.plugin());
+    return new MetaInfo(context.getRequiredTestClass(), PluginMgr.plugin());
   }
 
 }

--- a/inject-test/src/main/java/io/avaje/inject/test/MetaInfo.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/MetaInfo.java
@@ -1,9 +1,9 @@
 package io.avaje.inject.test;
 
-import java.util.Optional;
-
 import io.avaje.inject.BeanScope;
 import io.avaje.inject.BeanScopeBuilder;
+
+import java.util.Optional;
 
 /**
  * Wraps the underlying metadata (fields with annotations @Mock, @Spy, @Inject, @Captor).
@@ -27,18 +27,24 @@ final class MetaInfo {
   /**
    * Build for static fields class level scope.
    */
-  Scope buildForClass(GlobalTestScope.Pair globalTestScope) {
+  TestBeans buildForClass(GlobalTestBeans.Beans globalTestScope) {
     return buildSet(globalTestScope, null);
   }
 
   /**
    * Build test instance per test scope.
    */
-  Scope buildForInstance(GlobalTestScope.Pair globalTestScope, Object testInstance) {
+  TestBeans buildForInstance(GlobalTestBeans.Beans globalTestScope, Object testInstance) {
     return buildSet(globalTestScope, testInstance);
   }
 
-  private Scope buildSet(GlobalTestScope.Pair parent, Object testInstance) {
+  private TestBeans buildSet(GlobalTestBeans.Beans parent, Object testInstance) {
+    var testBeans = buildTestBeans(parent, testInstance);
+    // set inject, spy, mock fields from beanScope
+    return reader.setFromScope(testBeans, testInstance);
+  }
+
+  private TestBeans buildTestBeans(GlobalTestBeans.Beans parent, Object testInstance) {
     // wiring profiles
     String[] profiles = Optional.ofNullable(testInstance)
       .map(Object::getClass)
@@ -46,59 +52,26 @@ final class MetaInfo {
       .map(InjectTest::profiles)
       .orElse(new String[0]);
 
-    boolean newScope = false;
-    final BeanScope beanScope;
     if (profiles.length > 0 || reader.hasMocksOrSpies(testInstance)) {
-      // need to build a BeanScope for this using testScope() as the parent
+      // need to build a BeanScope for this using baseBeans() as the parent
       final BeanScopeBuilder builder = BeanScope.builder();
       if (parent != null) {
-        builder.parent(parent.baseScope(), false);
+        builder.parent(parent.baseBeans(), false);
         if (profiles.length > 0) {
           builder.profiles(profiles);
         }
       }
       // register mocks and spies local to this test
       reader.build(builder, testInstance);
-      // wire with local mocks, spies, and globalTestScope
-      beanScope = builder.build();
-      newScope = true;
+      // wire with local mocks, spies, and TestScope beans
+      var newBeanScope = builder.build();
+      var newPlugin = PluginMgr.scope(newBeanScope);
+      return new TestBeans(newBeanScope, newPlugin);
+
     } else {
-      // just use the all scope
-      beanScope = parent.allScope();
-    }
-
-    // set inject, spy, mock fields from beanScope
-    return reader.setFromScope(beanScope, testInstance, newScope);
-  }
-
-  /**
-   * Wraps both BeanScope and Plugin.Scope for either EACH or ALL
-   * (aka instance or class level).
-   */
-  static class Scope implements AutoCloseable {
-
-    private final BeanScope beanScope;
-    private final Plugin.Scope pluginScope;
-    private final boolean newScope;
-
-    Scope(BeanScope beanScope, Plugin.Scope pluginScope, boolean newScope) {
-      this.beanScope = beanScope;
-      this.pluginScope = pluginScope;
-      this.newScope = newScope;
-    }
-
-    BeanScope beanScope() {
-      return beanScope;
-    }
-
-    @Override
-    public void close() {
-      if (newScope) {
-        beanScope.close();
-      }
-      if (pluginScope != null) {
-        pluginScope.close();
-      }
+      // just use the existing beans and plugin from parent
+      return new TestBeans(parent);
     }
   }
+
 }

--- a/inject-test/src/main/java/io/avaje/inject/test/MetaReader.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/MetaReader.java
@@ -173,17 +173,18 @@ final class MetaReader {
     return null;
   }
 
-  MetaInfo.Scope setFromScope(BeanScope beanScope, Object testInstance, boolean newScope) {
+  TestBeans setFromScope(TestBeans metaScope, Object testInstance) {
     if (testInstance != null) {
-      return setForInstance(beanScope, testInstance, newScope);
+      return setForInstance(metaScope, testInstance);
     } else {
-      return setForStatics(beanScope, newScope);
+      return setForStatics(metaScope);
     }
   }
 
-  private MetaInfo.Scope setForInstance(BeanScope beanScope, Object testInstance, boolean newScope) {
+  private TestBeans setForInstance(TestBeans metaScope, Object testInstance) {
     try {
-      Plugin.Scope pluginScope = instancePlugin ? plugin.createScope(beanScope) : null;
+      Plugin.Scope pluginScope = metaScope.plugin();
+      BeanScope beanScope = metaScope.beanScope();
 
       for (Field field : captors) {
         set(field, captorFor(field), testInstance);
@@ -202,17 +203,17 @@ final class MetaReader {
           target.setFromScope(beanScope, testInstance);
         }
       }
-      return new MetaInfo.Scope(beanScope, pluginScope, newScope);
+      return metaScope;
 
     } catch (IllegalAccessException e) {
       throw new RuntimeException(e);
     }
   }
 
-  private MetaInfo.Scope setForStatics(BeanScope beanScope, boolean newScope) {
+  private TestBeans setForStatics(TestBeans metaScope) {
     try {
-      Plugin.Scope pluginScope = staticPlugin ? plugin.createScope(beanScope) : null;
-
+      Plugin.Scope pluginScope = metaScope.plugin();
+      BeanScope beanScope = metaScope.beanScope();
       for (FieldTarget target : staticMocks) {
         target.setFromScope(beanScope, null);
       }
@@ -227,7 +228,7 @@ final class MetaReader {
           target.setFromScope(beanScope, null);
         }
       }
-      return new MetaInfo.Scope(beanScope, pluginScope, newScope);
+      return metaScope;
     } catch (IllegalAccessException e) {
       throw new RuntimeException(e);
     }

--- a/inject-test/src/main/java/io/avaje/inject/test/PluginMgr.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/PluginMgr.java
@@ -1,10 +1,12 @@
 package io.avaje.inject.test;
 
+import io.avaje.inject.BeanScope;
 import io.avaje.lang.Nullable;
 
+import java.lang.reflect.Type;
 import java.util.ServiceLoader;
 
-final class PluginInitialise {
+final class PluginMgr {
 
   private static final Plugin plugin = init();
 
@@ -15,5 +17,13 @@ final class PluginInitialise {
   @Nullable
   static Plugin plugin() {
     return plugin;
+  }
+
+  /**
+   * Return a new plugin scope (if there is a plugin).
+   */
+   @Nullable
+  static Plugin.Scope scope(BeanScope beanScope) {
+    return plugin == null ? null : plugin.createScope(beanScope);
   }
 }

--- a/inject-test/src/main/java/io/avaje/inject/test/TestBeanScope.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/TestBeanScope.java
@@ -59,7 +59,7 @@ public abstract class TestBeanScope {
    */
   @Nullable
   public static BeanScope initialise() {
-    return TSBuild.initialise(true).baseScope();
+    return GlobalInitialise.initialise(true).baseBeans();
   }
 
   /**
@@ -73,7 +73,7 @@ public abstract class TestBeanScope {
    */
   @Nullable
   public static BeanScope create(boolean shutdownHook) {
-    return TSBuild.createTestBaseScope(shutdownHook);
+    return GlobalInitialise.createTestBaseScope(shutdownHook);
   }
 
 }

--- a/inject-test/src/main/java/io/avaje/inject/test/TestBeans.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/TestBeans.java
@@ -1,0 +1,50 @@
+package io.avaje.inject.test;
+
+import io.avaje.inject.BeanScope;
+
+/**
+ * Wraps both BeanScope and Plugin.Scope for either EACH or ALL
+ * (aka instance or class level).
+ */
+final class TestBeans implements AutoCloseable {
+
+  private final BeanScope beanScope;
+  private final Plugin.Scope pluginScope;
+  private final boolean closeAtEndOfTest;
+
+  /**
+   * Create with new beans and plugin which will be closed at the end of the test.
+   */
+  TestBeans(BeanScope beanScope, Plugin.Scope pluginScope) {
+    this.beanScope = beanScope;
+    this.pluginScope = pluginScope;
+    this.closeAtEndOfTest = true;
+  }
+
+  /**
+   * Create with existing beans - nothing closed at the end of the test.
+   */
+  TestBeans(GlobalTestBeans.Beans parent) {
+    this.beanScope = parent.allBeans();
+    this.pluginScope = parent.allPlugin();
+    this.closeAtEndOfTest = false;
+  }
+
+  BeanScope beanScope() {
+    return beanScope;
+  }
+
+  Plugin.Scope plugin() {
+    return pluginScope;
+  }
+
+  @Override
+  public void close() {
+    if (closeAtEndOfTest) {
+      if (pluginScope != null) {
+        pluginScope.close();
+      }
+      beanScope.close();
+    }
+  }
+}

--- a/inject-test/src/test/java/io/avaje/inject/test/MetaReaderTest.java
+++ b/inject-test/src/test/java/io/avaje/inject/test/MetaReaderTest.java
@@ -35,11 +35,15 @@ class MetaReaderTest {
 
   @Test
   void checkMetaReader_with_plugin() {
-    MetaReader metaReader = new MetaReader(HelloBean.class, new MyPlugin());
+    MyPlugin myPlugin = new MyPlugin();
+    MetaReader metaReader = new MetaReader(HelloBean.class, myPlugin);
     assertThat(metaReader.instancePlugin).isTrue();
 
     HelloBean helloBean = new HelloBean();
-    metaReader.setFromScope(Mockito.mock(BeanScope.class), helloBean, true);
+    BeanScope beanScope = Mockito.mock(BeanScope.class);
+    MyPlugin.Scope scope = myPlugin.createScope(beanScope);
+    TestBeans beans = new TestBeans(beanScope, scope);
+    metaReader.setFromScope(beans, helloBean);
 
     assertThat(helloBean.client).isNotNull();
   }


### PR DESCRIPTION
- Rename GlobalTestScope -> GlobalTestBeans
- Lift and rename GlobalTestScope.Pair to TestBeans
- The plugin scope lives in TestBeans and scoped with the associated test bean scope (created together, closed together)
- Rename PluginInitialise to PluginMgr
- Rename TSBuild to GlobalInitialise

Note the plugin for avaje-nima creates the nima http server, so now this will be started and stopped with the associated bean scope.