### PR TITLE
Enable provider calls during wiring

### DIFF
--- a/inject-test/src/test/java/org/example/coffee/provider/FactoryProvider.java
+++ b/inject-test/src/test/java/org/example/coffee/provider/FactoryProvider.java
@@ -19,7 +19,8 @@ public class FactoryProvider {
   }
 
   @Bean
-  Provider<Supplier<String>> supply() {
+  Provider<Supplier<String>> supply(@Named("second") Provider<String> second) {
+    second.get();
     return () -> () -> "Stand proud Provider, you were strong";
   }
 }

--- a/inject/src/main/java/io/avaje/inject/Lazy.java
+++ b/inject/src/main/java/io/avaje/inject/Lazy.java
@@ -6,10 +6,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a Singleton, Component or Factory method beans to be initialised lazily.
+ * Marks a Singleton, Component or Factory method beans to be initialized lazily.
  * <p>
  * When annotating a {@link Factory} as {@code @Lazy} it means that the factory
- * itself is not lazy but all beans that it provides will have lazy initialisation.
+ * itself is not lazy but all beans that it provides will have lazy initialization.
  */
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.METHOD, ElementType.TYPE})

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -289,10 +289,7 @@ class DBuilder implements Builder {
     if (runningPostConstruct) {
       return obtainProvider(type, name);
     }
-    // use injectors to delay obtaining the provider until end of build
-    final ProviderPromise<T> promise = new ProviderPromise<>(type, name, this);
-    injectors.add(promise);
-    return promise;
+    return new ProviderPromise<>(type, name, this);
   }
 
   <T> Provider<T> obtainProvider(Type type, String name) {

--- a/inject/src/main/java/io/avaje/inject/spi/ProviderPromise.java
+++ b/inject/src/main/java/io/avaje/inject/spi/ProviderPromise.java
@@ -1,14 +1,13 @@
 package io.avaje.inject.spi;
 
-import jakarta.inject.Provider;
-
 import java.lang.reflect.Type;
-import java.util.function.Consumer;
+
+import jakarta.inject.Provider;
 
 /**
  * Provides late binding of Provider (like field/setter injection).
  */
-final class ProviderPromise<T> implements Provider<T>, Consumer<Builder> {
+final class ProviderPromise<T> implements Provider<T> {
 
   private final Type type;
   private final String name;
@@ -22,13 +21,10 @@ final class ProviderPromise<T> implements Provider<T>, Consumer<Builder> {
   }
 
   @Override
-  public void accept(Builder _builder) {
-    this.provider = builder.obtainProvider(type, name);
-  }
-
-  @Override
   public T get() {
+    if (provider == null) {
+      this.provider = builder.obtainProvider(type, name);
+    }
     return provider.get();
   }
-
 }


### PR DESCRIPTION
Augments the `ProviderPromise` to retrieve the provider when `get` is called.