### PR TITLE
README typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ public final class ExampleModule implements Module {
 
 - Specifically Aimed for server-side development (rather than Android)
 - Provides API to obtain all bean instances that implement an interface
-- Lifecycle methods with `@PostConstruct` and `@PreDestory`
+- Lifecycle methods with `@PostConstruct` and `@PreDestroy`
 - Spring-like factory classes with `@Factory` and `@Bean`
 - Conditional Wiring based on active profiles or existing beans/properties
 

--- a/inject/README.md
+++ b/inject/README.md
@@ -25,7 +25,7 @@ module org.example {
 ## Differences to Dagger
 
 - Aimed specifically for server side development (rather than Andriod)
-- Supports lifecycle methods with `@PostConstruct` and `@PreDestory`
+- Supports lifecycle methods with `@PostConstruct` and `@PreDestroy`
 - Supports `@Factory` and `@Bean`
 - Provides API to obtain all bean instances that implement an interface
 - Provides API to obtain all bean instances that have an annotation


### PR DESCRIPTION
`PreDestory` -> `PreDestroy`
