### PR TITLE
fix: compilation error with providers and `throws`

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/AppConfig.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/AppConfig.java
@@ -48,6 +48,12 @@ public class AppConfig {
     return new Builder();
   }
 
+  @Prototype
+  @Bean
+  public BuilderThrows newBuilderThrows() throws Exception {
+    return new BuilderThrows();
+  }
+
   @Bean
   Generated newGenerated() {
     return new Generated();
@@ -57,6 +63,12 @@ public class AppConfig {
   @Bean
   public MySecType generalSecondary() {
     return new MySecType();
+  }
+
+  @Secondary
+  @Bean
+  public MySecTypeThrows generalSecondaryThrows() throws Exception {
+    return new MySecTypeThrows();
   }
 
   @Secondary
@@ -100,10 +112,16 @@ public class AppConfig {
   public static class Builder {
   }
 
+  public static class BuilderThrows {
+  }
+
   public static class Generated {
   }
 
   public static class MySecType {
+  }
+
+  public static class MySecTypeThrows {
   }
 
   public static class MySecOptType {

--- a/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyFactory.java
@@ -20,4 +20,10 @@ public class LazyFactory {
     if (initialized != null) initialized.set(true);
     return new LazyBean();
   }
+
+  @Bean
+  @Named("factoryThrows")
+  LazyBean lazyIntThrows(@Nullable AtomicBoolean initialized) throws Exception {
+    return lazyInt(initialized);
+  }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -205,6 +205,7 @@ final class MethodReader {
 
     writer.indent(String.format(".%s(() -> {", lazy ? "registerLazy" : "registerProvider")).eol();
 
+    startTry(writer);
     writer.indent(indent).append("    return ");
     writer.append("factory.%s(", methodName);
     for (int i = 0; i < params.size(); i++) {
@@ -214,6 +215,7 @@ final class MethodReader {
       params.get(i).builderGetDependency(writer, "builder");
     }
     writer.append(");").eol();
+    endTry(writer);
     writer.indent(indent).append("  });").eol();
     writer.indent(indent).append("}").eol();
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
@@ -144,11 +144,10 @@ final class SimpleBeanWriter {
     method.buildConditional(writer);
     method.buildAddFor(writer);
     method.builderGetFactory(writer, beanReader.hasConditions());
-    method.startTry(writer);
     if (method.isLazy() || method.isProtoType() || method.isUseProviderForSecondary()) {
       method.builderAddBeanProvider(writer);
-      method.endTry(writer);
     } else {
+      method.startTry(writer);
       method.builderBuildBean(writer);
       method.builderBuildAddBean(writer);
       method.endTry(writer);


### PR DESCRIPTION
Hello, everyone! Thank you all for your work.

Avaje-Inject currently generates invalid code when a "provider" method (i.e. `@Prototype`, `@Lazy`, etc.) has a `throws` clause.

There are two problems:

1. a syntax error: `try { ... } } catch`.
2. the lambdas passed to `Builder::register(Lazy|Provider)` do not handle the declared `Throwable`s.

This fixes those problems by wrapping the _bodies_ of the lambdas passed to `Builder::register(Lazy|Provider)` in `try` blocks.

To demonstrate, here are the (relevant) differences in the generated code before and after applying the fix:

```diff
--- before-fix-fallible-providers/blackbox-test-inject/target/generated-sources/annotations/org/example/myapp/config/AppConfig$DI.java
+++ fix-fallible-providers/blackbox-test-inject/target/generated-sources/annotations/org/example/myapp/config/AppConfig$DI.java
@@ -71,15 +71,15 @@ public final class AppConfig$DI  {
   public static void build_newBuilderThrows(Builder builder) {
     if (builder.isAddBeanFor(AppConfig.BuilderThrows.class)) {
       var factory = builder.get(AppConfig.class);
+      builder.asPrototype()
+.registerProvider(() -> {
       try {
-        builder.asPrototype()
-  .registerProvider(() -> {
           return factory.newBuilderThrows();
-        });
-      }
       } catch (Throwable e) {
         throw new RuntimeException("Error during wiring", e);
       }
+      });
+    }
   }

   /**
@@ -112,15 +112,15 @@ public final class AppConfig$DI  {
   public static void build_generalSecondaryThrows(Builder builder) {
     if (builder.isAddBeanFor(AppConfig.MySecTypeThrows.class)) {
       var factory = builder.get(AppConfig.class);
+      builder.asSecondary()
+.registerProvider(() -> {
       try {
-        builder.asSecondary()
-  .registerProvider(() -> {
           return factory.generalSecondaryThrows();
-        });
-      }
       } catch (Throwable e) {
         throw new RuntimeException("Error during wiring", e);
       }
+      });
+    }
   }

   /**
```

```diff
--- before-fix-fallible-providers/blackbox-test-inject/target/generated-sources/annotations/org/example/myapp/lazy/LazyFactory$DI.java
+++ fix-fallible-providers/blackbox-test-inject/target/generated-sources/annotations/org/example/myapp/lazy/LazyFactory$DI.java
@@ -41,14 +41,14 @@ public final class LazyFactory$DI  {
   public static void build_lazyIntThrows(Builder builder) {
     if (builder.isAddBeanFor("factorythrows", LazyBean.class)) {
       var factory = builder.get(LazyFactory.class);
+      builder.registerLazy(() -> {
       try {
-        builder  .registerLazy(() -> {
           return factory.lazyIntThrows(builder.getNullable(AtomicBoolean.class,"!initialized"));
-        });
-      }
       } catch (Throwable e) {
         throw new RuntimeException("Error during wiring", e);
       }
+      });
+    }
   }

 }
```