### PR TITLE
Fix support for @Prototype with Provider<T>

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -235,6 +235,8 @@ final class MethodReader {
         writer.append(".asPrimary()");
       } else if (secondary) {
         writer.append(".asSecondary()");
+      } else if (prototype) {
+        writer.append(".asPrototype()");
       }
       if (Util.isProvider(returnTypeRaw)) {
         writer.append(".registerProvider(bean);").eol();
@@ -360,7 +362,7 @@ final class MethodReader {
   }
 
   boolean isProtoType() {
-    return prototype;
+    return prototype && !Util.isProvider(returnTypeRaw);
   }
 
   boolean isLazy() {

--- a/inject-test/src/test/java/org/example/coffee/provider/FactoryProvider.java
+++ b/inject-test/src/test/java/org/example/coffee/provider/FactoryProvider.java
@@ -1,9 +1,11 @@
 package org.example.coffee.provider;
 
+import java.util.Random;
 import java.util.function.Supplier;
 
 import io.avaje.inject.Bean;
 import io.avaje.inject.Factory;
+import io.avaje.inject.Prototype;
 import io.avaje.inject.Secondary;
 import jakarta.inject.Named;
 import jakarta.inject.Provider;
@@ -21,5 +23,11 @@ public class FactoryProvider {
   @Bean
   Provider<Supplier<String>> supply() {
     return () -> () -> "Stand proud Provider, you were strong";
+  }
+
+  @Bean
+  @Prototype
+  Provider<Long> random() {
+    return new Random()::nextLong;
   }
 }

--- a/inject-test/src/test/java/org/example/coffee/provider/FactoryProviderTest.java
+++ b/inject-test/src/test/java/org/example/coffee/provider/FactoryProviderTest.java
@@ -19,4 +19,12 @@ class FactoryProviderTest {
       assertThat(scope.get(String.class, "second")).isEqualTo("Nah, I'd win");
     }
   }
+
+  @Test
+  void testProtoType() {
+    try (var scope = BeanScope.builder().build()) {
+      var numberGetter = scope.get(ProtoTypeNumberGetter.class);
+      assertThat(numberGetter.number()).isNotEqualTo(numberGetter.number());
+    }
+  }
 }

--- a/inject-test/src/test/java/org/example/coffee/provider/ProtoTypeNumberGetter.java
+++ b/inject-test/src/test/java/org/example/coffee/provider/ProtoTypeNumberGetter.java
@@ -1,0 +1,18 @@
+package org.example.coffee.provider;
+
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+
+@Singleton
+class ProtoTypeNumberGetter {
+
+  private final Provider<Long> nProv;
+
+  ProtoTypeNumberGetter(Provider<Long> nProv) {
+    this.nProv = nProv;
+  }
+
+  Long number() {
+    return nProv.get();
+  }
+}


### PR DESCRIPTION
Extracted this fix from #540

@Prototype with Provider<T> currently produces code that registers Provider<Provider<T>> instead of Provider<T> and this fixes that.