### PR TITLE
inject-maven-plugin: Add default lifecycle and goal support

### DIFF
--- a/inject-maven-plugin/pom.xml
+++ b/inject-maven-plugin/pom.xml
@@ -10,7 +10,7 @@
   <groupId>io.avaje</groupId>
   <artifactId>avaje-inject-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>10.0-RC1</version>
+  <version>10.0-RC2</version>
 
   <dependencies>
     <dependency>

--- a/inject-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/inject-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<component-set>
+  <components>
+    <component>
+      <role>org.apache.maven.lifecycle.Lifecycle</role>
+      <implementation>org.apache.maven.lifecycle.Lifecycle</implementation>
+      <role-hint>avaje-inject-maven-plugin</role-hint>
+      <configuration>
+        <id>avaje-inject-maven-pluginn</id>
+        <phases>
+          <phase>avaje-inject-maven-plugin-not-used-phase</phase>
+        </phases>
+        <default-phases>
+          <process-sources>
+            io.avaje:avaje-inject-maven-plugin:${project.version}:provides
+          </process-sources>
+        </default-phases>
+      </configuration>
+    </component>
+  </components>
+</component-set>


### PR DESCRIPTION
Add META-INF/plexus/components.xml with default lifecycle and goal such that the maven plugin can be used with extensions true like:

<plugin>
  <groupId>io.avaje</groupId>
  <artifactId>avaje-inject-maven-plugin</artifactId>
  <version>10.0-RC2</version>
  <extensions>true</extensions>
</plugin>