### PR TITLE
Prefer intra-module beans when resolving duplicate types

### DIFF
--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -285,6 +285,7 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
 
     final Builder builder = Builder.newBuilder(profiles, propertyRequiresPlugin, suppliedBeans, enrichBeans, parent, parentOverride);
     for (final Module factory : factoryOrder.factories()) {
+      builder.currentModule(factory.getClass());
       factory.build(builder);
     }
 

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -279,4 +279,5 @@ public interface Builder {
    */
   BeanScope build(boolean withShutdownHook, long start);
 
+  void currentModule(Class<? extends Module> class1);
 }

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -37,12 +37,19 @@ class DBuilder implements Builder {
   private boolean runningPostConstruct;
 
   private DBeanScopeProxy beanScopeProxy;
+  protected Class<? extends Module> currentModule;
 
   DBuilder(Set<String> profiles, PropertyRequiresPlugin propertyRequires, BeanScope parent, boolean parentOverride) {
     this.propertyRequires = propertyRequires;
     this.parent = parent;
     this.parentOverride = parentOverride;
     this.profiles = profiles;
+  }
+
+  @Override
+  public void currentModule(Class<? extends Module> currentModule) {
+
+    this.currentModule = currentModule;
   }
 
   @Override
@@ -156,7 +163,7 @@ class DBuilder implements Builder {
   @Override
   public final <T> T register(T bean) {
     bean = enrich(bean, beanMap.next());
-    beanMap.register(bean);
+    beanMap.register(bean, currentModule);
     return bean;
   }
 
@@ -181,20 +188,20 @@ class DBuilder implements Builder {
   @Override
   public final <T> void registerProvider(Provider<T> provider) {
     // no enrichment
-    beanMap.register(provider);
+    beanMap.register(provider, currentModule);
   }
 
   @Override
   public <T> void registerObserver(Type type, int priority, boolean sync, Consumer<T> observer, String qualifier) {
     get(ObserverManager.class)
-        .registerObserver(type, new Observer<T>(priority, sync, observer, qualifier));
+        .registerObserver(type, new Observer<>(priority, sync, observer, qualifier));
   }
 
   @Override
   public final <T> void withBean(Class<T> type, T bean) {
     next(null, type);
     beanMap.nextPriority(BeanEntry.SUPPLIED);
-    beanMap.register(bean);
+    beanMap.register(bean, currentModule);
   }
 
   @Override

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilderExtn.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilderExtn.java
@@ -54,7 +54,7 @@ final class DBuilderExtn extends DBuilder {
       final Object enrichedBean = enrich(parentMatch, beanMap.next());
       if (enrichedBean != parentMatch) {
         beanMap.nextPriority(BeanEntry.SUPPLIED);
-        beanMap.register(enrichedBean);
+        beanMap.register(enrichedBean, currentModule);
       }
     }
   }

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
@@ -186,8 +186,16 @@ final class DContextEntry {
         match = entry;
         return;
       }
-      throw new IllegalStateException("Expecting only 1 bean match but have multiple matching beans " + match.bean()
-        + " and " + entry.bean() + ". Maybe need a rebuild is required after adding a @Named qualifier?");
+      throw new IllegalStateException(
+          "Expecting only 1 bean match but have multiple matching beans "
+              + match.bean()
+              + " from avaje module: "
+              + match.sourceModule()
+              + " and "
+              + entry.bean()
+              + " from avaje module: "
+              + entry.sourceModule()
+              + ". Maybe need a rebuild is required after adding a @Named qualifier?");
     }
 
     private DContextEntryBean candidate() {

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
@@ -186,16 +186,8 @@ final class DContextEntry {
         match = entry;
         return;
       }
-      throw new IllegalStateException(
-          "Expecting only 1 bean match but have multiple matching beans "
-              + match.bean()
-              + " from avaje module: "
-              + match.sourceModule()
-              + " and "
-              + entry.bean()
-              + " from avaje module: "
-              + entry.sourceModule()
-              + ". Maybe need a rebuild is required after adding a @Named qualifier?");
+      throw new IllegalStateException("Expecting only 1 bean match but have multiple matching beans " + match.bean()
+        + " and " + entry.bean() + ". Maybe need a rebuild is required after adding a @Named qualifier?");
     }
 
     private DContextEntryBean candidate() {

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntryBean.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntryBean.java
@@ -53,7 +53,7 @@ class DContextEntryBean {
       "source=" + source +
       ", name='" + name + '\'' +
       ", flag=" + flag +
-      '}';
+      ", sourceModule=" + sourceModule + '}';
   }
 
   final DEntry entry() {

--- a/inject/src/test/java/io/avaje/inject/spi/DContextEntryTest.java
+++ b/inject/src/test/java/io/avaje/inject/spi/DContextEntryTest.java
@@ -13,86 +13,100 @@ class DContextEntryTest {
   void get_when_onePrimary() {
 
     DContextEntry entry = new DContextEntry();
-    entry.add(DContextEntryBean.of("P", null, BeanEntry.PRIMARY));
-    entry.add(DContextEntryBean.of("N", null, BeanEntry.NORMAL));
-    entry.add(DContextEntryBean.of("S", null, BeanEntry.SECONDARY));
+    entry.add(DContextEntryBean.of("P", null, BeanEntry.PRIMARY, null));
+    entry.add(DContextEntryBean.of("N", null, BeanEntry.NORMAL, null));
+    entry.add(DContextEntryBean.of("S", null, BeanEntry.SECONDARY, null));
 
-    assertEquals(entry.get(null), "P");
+    assertEquals(entry.get(null, null), "P");
   }
 
   @Test
   void get_when_twoPrimary() {
-    assertThrows(IllegalStateException.class, () -> {
-      DContextEntry entry = new DContextEntry();
-      entry.add(DContextEntryBean.of("P", null, BeanEntry.PRIMARY));
-      entry.add(DContextEntryBean.of("N", null, BeanEntry.NORMAL));
-      entry.add(DContextEntryBean.of("S", null, BeanEntry.PRIMARY));
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          DContextEntry entry = new DContextEntry();
+          entry.add(DContextEntryBean.of("P", null, BeanEntry.PRIMARY, null));
+          entry.add(DContextEntryBean.of("N", null, BeanEntry.NORMAL, null));
+          entry.add(DContextEntryBean.of("S", null, BeanEntry.PRIMARY, null));
 
-      entry.get(null);
-    });
+          entry.get(null, null);
+        });
   }
 
   @Test
   void get_when_oneNormal() {
 
     DContextEntry entry = new DContextEntry();
-    entry.add(DContextEntryBean.of("N", null, BeanEntry.NORMAL));
-    entry.add(DContextEntryBean.of("S", null, BeanEntry.SECONDARY));
+    entry.add(DContextEntryBean.of("N", null, BeanEntry.NORMAL, null));
+    entry.add(DContextEntryBean.of("S", null, BeanEntry.SECONDARY, null));
 
-    assertEquals(entry.get(null), "N");
+    assertEquals(entry.get(null, null), "N");
   }
 
+  @Test
+  void get_when_currentModule() {
+
+    DContextEntry entry = new DContextEntry();
+    entry.add(DContextEntryBean.of("N", "same", BeanEntry.NORMAL, Module.class));
+    entry.add(DContextEntryBean.of("N", "same", BeanEntry.NORMAL, null));
+
+    assertEquals(entry.get("same", Module.class), "N");
+    assertEquals(entry.get("same", null), "N");
+  }
 
   @Test
   void get_when_oneNormal2() {
 
     DContextEntry entry = new DContextEntry();
-    entry.add(DContextEntryBean.of("N", null, BeanEntry.NORMAL));
-    entry.add(DContextEntryBean.of("S1", null, BeanEntry.SECONDARY));
-    entry.add(DContextEntryBean.of("S2", null, BeanEntry.SECONDARY));
+    entry.add(DContextEntryBean.of("N", null, BeanEntry.NORMAL, null));
+    entry.add(DContextEntryBean.of("S1", null, BeanEntry.SECONDARY, null));
+    entry.add(DContextEntryBean.of("S2", null, BeanEntry.SECONDARY, null));
 
-    assertEquals(entry.get(null), "N");
+    assertEquals(entry.get(null, null), "N");
   }
 
   @Test
   void get_when_multiSecondaryOnly() {
 
-    assertThrows(IllegalStateException.class, () -> {
-      DContextEntry entry = new DContextEntry();
-      entry.add(DContextEntryBean.of("S1", null, BeanEntry.SECONDARY));
-      entry.add(DContextEntryBean.of("S2", null, BeanEntry.SECONDARY));
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          DContextEntry entry = new DContextEntry();
+          entry.add(DContextEntryBean.of("S1", null, BeanEntry.SECONDARY, null));
+          entry.add(DContextEntryBean.of("S2", null, BeanEntry.SECONDARY, null));
 
-      entry.get(null);
-    });
+          entry.get(null, null);
+        });
   }
 
   @Test
   void get_when_multiSecondary_butNamed() {
 
     DContextEntry entry = new DContextEntry();
-    entry.add(DContextEntryBean.of("S1", "a", BeanEntry.SECONDARY));
-    entry.add(DContextEntryBean.of("S2", "b", BeanEntry.SECONDARY));
+    entry.add(DContextEntryBean.of("S1", "a", BeanEntry.SECONDARY, null));
+    entry.add(DContextEntryBean.of("S2", "b", BeanEntry.SECONDARY, null));
 
-    assertEquals(entry.get("b"), "S2");
+    assertEquals(entry.get("b", null), "S2");
   }
 
   @Test
   void get_when_multiSecondary_butNamed2() {
 
     DContextEntry entry = new DContextEntry();
-    entry.add(DContextEntryBean.of("S1", null, BeanEntry.SECONDARY));
-    entry.add(DContextEntryBean.of("S2", "b", BeanEntry.SECONDARY));
+    entry.add(DContextEntryBean.of("S1", null, BeanEntry.SECONDARY, null));
+    entry.add(DContextEntryBean.of("S2", "b", BeanEntry.SECONDARY, null));
 
-    assertEquals(entry.get("b"), "S2");
+    assertEquals(entry.get("b", null), "S2");
   }
 
   @Test
   void get_when_secondary_butNamed() {
 
     DContextEntry entry = new DContextEntry();
-    entry.add(DContextEntryBean.of("S1", null, BeanEntry.PRIMARY));
-    entry.add(DContextEntryBean.of("S2", "b", BeanEntry.SECONDARY));
+    entry.add(DContextEntryBean.of("S1", null, BeanEntry.PRIMARY, null));
+    entry.add(DContextEntryBean.of("S2", "b", BeanEntry.SECONDARY, null));
 
-    assertEquals(entry.get("b"), "S2");
+    assertEquals(entry.get("b", null), "S2");
   }
 }


### PR DESCRIPTION
first pass at option 4 of #543 

- bean entries can now track the source module
- if all other resolutions fail prefer beans originating from the same module