### PR TITLE
#555 No qualifier injection point prefers no qualifier bean (over named bean)

### DIFF
--- a/inject-test/src/test/java/org/example/coffee/qualifier/MegaStoreManager.java
+++ b/inject-test/src/test/java/org/example/coffee/qualifier/MegaStoreManager.java
@@ -1,0 +1,18 @@
+package org.example.coffee.qualifier;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class MegaStoreManager {
+
+  final SomeStore green;
+  final SomeStore blue;
+  final SomeStore noQualifier;
+
+  public MegaStoreManager(@Green SomeStore green, @Blue SomeStore blue, SomeStore noQualifier) {
+    this.green = green;
+    this.blue = blue;
+    this.noQualifier = noQualifier;
+  }
+
+}

--- a/inject-test/src/test/java/org/example/coffee/qualifier/MetaStoreManagerTest.java
+++ b/inject-test/src/test/java/org/example/coffee/qualifier/MetaStoreManagerTest.java
@@ -1,0 +1,20 @@
+package org.example.coffee.qualifier;
+
+import io.avaje.inject.BeanScope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MetaStoreManagerTest {
+
+  @Test
+  void test() {
+    try (BeanScope context = BeanScope.builder().build()) {
+      MegaStoreManager manager = context.get(MegaStoreManager.class);
+
+      assertThat(manager.green).isInstanceOf(GreenStore.class);
+      assertThat(manager.blue).isInstanceOf(BlueStore.class);
+      assertThat(manager.noQualifier).isInstanceOf(NoNameStore.class);
+    }
+  }
+}

--- a/inject-test/src/test/java/org/example/coffee/qualifier/NoNameStore.java
+++ b/inject-test/src/test/java/org/example/coffee/qualifier/NoNameStore.java
@@ -1,0 +1,14 @@
+package org.example.coffee.qualifier;
+
+import jakarta.inject.Singleton;
+
+// no qualifier on this one
+@Singleton
+public class NoNameStore implements SomeStore {
+
+  @Override
+  public String store() {
+    return "noName";
+  }
+
+}

--- a/inject-test/src/test/java/org/example/coffee/qualifier/StoreManagerWithNamedTest.java
+++ b/inject-test/src/test/java/org/example/coffee/qualifier/StoreManagerWithNamedTest.java
@@ -20,6 +20,14 @@ class StoreManagerWithNamedTest {
 
       SomeStore greenStore = beanScope.get(SomeStore.class, "green");
       SomeStore blueStore = beanScope.get(SomeStore.class, "blue");
+      SomeStore unNamedStore = beanScope.get(SomeStore.class);
+      assertThat(blueStore.store()).isEqualTo("blue");
+      assertThat(greenStore.store()).isEqualTo("green");
+      assertThat(unNamedStore.store()).isEqualTo("noName");
+      assertThat(greenStore).isInstanceOf(GreenStore.class);
+      assertThat(blueStore).isInstanceOf(BlueStore.class);
+      assertThat(unNamedStore).isInstanceOf(NoNameStore.class);
+
       Map<String, SomeStore> stores = beanScope.map(SomeStore.class);
 
       SomeStore green = stores.get("Green");
@@ -42,7 +50,7 @@ class StoreManagerWithNamedTest {
 
       try (BeanScope beanScope = BeanScope.builder().parent(parent).build()) {
         Map<String, SomeStore> stores = beanScope.map(SomeStore.class);
-        assertThat(stores).hasSize(3);
+        assertThat(stores).hasSize(4);
       }
     }
   }

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
@@ -123,12 +123,20 @@ final class DContextEntry {
 
     private DContextEntryBean findMatch(List<DContextEntryBean> entries) {
       for (DContextEntryBean entry : entries) {
-        if (entry.isNameMatch(name)) {
+        if (entry.isNameEqual(name)) {
           checkMatch(entry);
         }
       }
       if (match == null && impliedName) {
-        // search again as if the implied name wasn't there, name = null
+        // match without implied name, name = null to match against beans with no qualifier
+        for (DContextEntryBean entry : entries) {
+          if (entry.isNameEqual(null)) {
+            checkMatch(entry);
+          }
+        }
+      }
+      if (match == null && (name == null || impliedName)) {
+        // match no qualifier injection point to any beans
         for (DContextEntryBean entry : entries) {
           checkMatch(entry);
         }


### PR DESCRIPTION
In the case where we have 2 beans of the same type and one has no qualifier, then when injecting a bean with no qualifier specified then prefer to wire the bean with no qualifier.

Example: In the MegaStoreManager example we have NoNameStore as a bean with no name qualifier and that is preferred for the noQualifier injection point.