### PR TITLE
Make Generic Provides Changes Backwards Compatible

### DIFF
--- a/blackbox-aspect/src/main/java/module-info.java
+++ b/blackbox-aspect/src/main/java/module-info.java
@@ -3,6 +3,6 @@ module blackbox.aspect {
   requires io.avaje.inject;
 
   //remove this and compilation fails
-  provides io.avaje.inject.spi.Module with org.example.external.aspect.sub.ExampleExternalAspectModule;
+  provides io.avaje.inject.spi.InjectSPI with org.example.external.aspect.sub.ExampleExternalAspectModule;
 
 }

--- a/blackbox-test-inject/src/main/java/org/example/myapp/ConfigPropertiesPlugin.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/ConfigPropertiesPlugin.java
@@ -8,7 +8,7 @@ import org.other.one.OtherComponent2;
 import java.util.Optional;
 
 @Component.Import(value = OtherComponent2.class)
-public class ConfigPropertiesPlugin implements PropertyRequiresPlugin {
+public class ConfigPropertiesPlugin implements PropertyPlugin {
 
   @Override
   public Optional<String> get(String property) {

--- a/blackbox-test-inject/src/main/java/org/example/myapp/ConfigPropertiesPlugin.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/ConfigPropertiesPlugin.java
@@ -2,13 +2,13 @@ package org.example.myapp;
 
 import io.avaje.config.Config;
 import io.avaje.inject.Component;
-import io.avaje.inject.spi.PropertyRequiresPlugin;
+import io.avaje.inject.spi.ConfigPropertyPlugin;
 import org.other.one.OtherComponent2;
 
 import java.util.Optional;
 
 @Component.Import(value = OtherComponent2.class)
-public class ConfigPropertiesPlugin implements PropertyPlugin {
+public class ConfigPropertiesPlugin implements ConfigPropertyPlugin {
 
   @Override
   public Optional<String> get(String property) {

--- a/inject-generator/pom.xml
+++ b/inject-generator/pom.xml
@@ -30,6 +30,12 @@
       <optional>true</optional>
       <scope>provided</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-spi-service</artifactId>
+      <version>1.4</version>
+    </dependency>
 
     <!-- test dependencies -->
     <dependency>

--- a/inject-generator/src/main/java/io/avaje/inject/generator/AllScopes.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/AllScopes.java
@@ -63,7 +63,7 @@ final class AllScopes {
   void readModules(List<String> customScopeModules) {
     for (String customScopeModule : customScopeModules) {
       final TypeElement module = typeElement(customScopeModule);
-      if (module != null) {
+      if (module != null && module.getSuperclass().toString().contains("Module")) {
         InjectModulePrism injectModule = InjectModulePrism.getInstanceOn(module);
         if (injectModule != null) {
           final String customScopeType = injectModule.customScopeType();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/AvajeModuleData.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/AvajeModuleData.java
@@ -6,19 +6,19 @@ import static java.util.stream.Collectors.toList;
 import java.util.Arrays;
 import java.util.List;
 
-final class AvajeModule {
+final class AvajeModuleData {
 
   private final String fqn;
   private final List<String> provides;
   private final List<String> requires;
 
-  AvajeModule(String name, List<String> provides, List<String> requires) {
+  AvajeModuleData(String name, List<String> provides, List<String> requires) {
     this.fqn = name;
     this.provides = provides;
     this.requires = requires;
   }
 
-  AvajeModule(String[] moduleCsv) {
+  AvajeModuleData(String[] moduleCsv) {
     this.fqn = moduleCsv[0];
     this.provides = Arrays.stream(moduleCsv[1].split(",")).filter(not(String::isBlank)).collect(toList());
     this.requires = Arrays.stream(moduleCsv[2].split(",")).filter(not(String::isBlank)).collect(toList());
@@ -38,6 +38,6 @@ final class AvajeModule {
 
   @Override
   public String toString() {
-    return "AvajeModule [fqn=" + fqn + ", provides=" + provides + ", requires=" + requires + "]";
+    return "AvajeModule2 [fqn=" + fqn + ", provides=" + provides + ", requires=" + requires + "]";
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/AvajeModuleData.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/AvajeModuleData.java
@@ -38,6 +38,6 @@ final class AvajeModuleData {
 
   @Override
   public String toString() {
-    return "AvajeModule2 [fqn=" + fqn + ", provides=" + provides + ", requires=" + requires + "]";
+    return "AvajeModuleData [fqn=" + fqn + ", provides=" + provides + ", requires=" + requires + "]";
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
@@ -25,9 +25,9 @@ final class Constants {
   static final String AT_PROXY = "@Proxy";
   static final String AT_GENERATED = "@Generated(\"io.avaje.inject.generator\")";
   static final String AT_GENERATED_COMMENT = "(\"io.avaje.inject.generator\")";
-  static final String META_INF_MODULE = "META-INF/services/io.avaje.inject.spi.Module";
+  static final String META_INF_SPI = "META-INF/services/io.avaje.inject.spi.InjectSPI";
   static final String META_INF_TESTMODULE = "META-INF/services/io.avaje.inject.test.TestModule";
-  static final String META_INF_CUSTOM = "META-INF/services/io.avaje.inject.spi.Module.Custom";
+  static final String META_INF_CUSTOM = "META-INF/services/io.avaje.inject.spi.AvajeModule.Custom";
 
   static final String BEANSCOPE = "io.avaje.inject.BeanScope";
   static final String INJECTMODULE = "io.avaje.inject.InjectModule";
@@ -52,7 +52,7 @@ final class Constants {
   static final String BEAN_FACTORY2 = "io.avaje.inject.spi.BeanFactory2";
   static final String BUILDER = "io.avaje.inject.spi.Builder";
   static final String DEPENDENCYMETA = "io.avaje.inject.spi.DependencyMeta";
-  static final String MODULE = "io.avaje.inject.spi.Module";
+  static final String MODULE = "io.avaje.inject.spi.AvajeModule";
   static final String GENERICTYPE = "io.avaje.inject.spi.GenericType";
 
   static final String CONDITIONAL_DEPENDENCY = "con:";

--- a/inject-generator/src/main/java/io/avaje/inject/generator/FactoryOrder.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/FactoryOrder.java
@@ -13,7 +13,7 @@ import java.util.Set;
 class FactoryOrder {
 
   private final Set<String> moduleNames = new LinkedHashSet<>();
-  private final List<AvajeModule> factories = new ArrayList<>();
+  private final List<AvajeModuleData> factories = new ArrayList<>();
   private final List<FactoryState> queue = new ArrayList<>();
   private final List<FactoryState> queueNoDependencies = new ArrayList<>();
   private final Map<String, List<String>> unsatisfiedDependencies = new HashMap<>();
@@ -22,7 +22,7 @@ class FactoryOrder {
   private final Set<String> pluginProvided;
   private final List<String> loadedModules = new ArrayList<>();
 
-  FactoryOrder(Collection<AvajeModule> includeModules, Set<String> pluginProvided) {
+  FactoryOrder(Collection<AvajeModuleData> includeModules, Set<String> pluginProvided) {
     includeModules.forEach(m -> {
       add(m);
       loadedModules.add(m.name());
@@ -30,7 +30,7 @@ class FactoryOrder {
     this.pluginProvided = pluginProvided;
   }
 
-  void add(AvajeModule module) {
+  void add(AvajeModuleData module) {
     final FactoryState factoryState = new FactoryState(module);
     providesMap.computeIfAbsent(module.name(), s -> new FactoryList()).add(factoryState);
     addFactoryProvides(factoryState, module.provides());
@@ -96,7 +96,7 @@ class FactoryOrder {
     }
   }
 
-  private void unsatisfiedRequires(StringBuilder sb, AvajeModule module) {
+  private void unsatisfiedRequires(StringBuilder sb, AvajeModuleData module) {
     for (final var depModuleName : module.requires()) {
       if (notProvided(depModuleName)) {
         unsatisfiedDependencies
@@ -171,10 +171,10 @@ class FactoryOrder {
   /** Wrapper on Factory holding the pushed state. */
   static class FactoryState {
 
-    private final AvajeModule factory;
+    private final AvajeModuleData factory;
     private boolean pushed;
 
-    FactoryState(AvajeModule factory) {
+    FactoryState(AvajeModuleData factory) {
       this.factory = factory;
     }
 
@@ -187,7 +187,7 @@ class FactoryOrder {
       return pushed;
     }
 
-    AvajeModule factory() {
+    AvajeModuleData factory() {
       return factory;
     }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
@@ -95,7 +95,7 @@ public final class InjectProcessor extends AbstractProcessor {
       .filter(s -> !s.startsWith("External Module Type"))
       .distinct()
       .map(l -> l.split("\\|"))
-      .map(AvajeModule::new)
+      .map(AvajeModuleData::new)
       .peek(m -> APContext.logNote(m.toString()))
       .forEach(ProcessingContext::addAvajeModule);
   }
@@ -170,6 +170,7 @@ public final class InjectProcessor extends AbstractProcessor {
           logError("FilerException trying to write wiring order class " + e.getMessage());
         }
       }
+      ProcessingContext.writeSPIServicesFile();
       ProcessingContext.validateModule();
       ProcessingContext.clear();
     }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -11,7 +11,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 
 import javax.annotation.processing.FilerException;
 import javax.lang.model.element.Element;
@@ -27,11 +26,11 @@ final class ScopeInfo {
     /**
      * Default scope.
      */
-    DEFAULT("Module"),
+    DEFAULT("AvajeModule"),
     /**
      * Custom scope.
      */
-    CUSTOM("Module.Custom"),
+    CUSTOM("AvajeModule.Custom"),
     /**
      * Built-in Test scope.
      */

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
@@ -2,13 +2,12 @@ package io.avaje.inject.generator;
 
 import static io.avaje.inject.generator.APContext.logError;
 import static io.avaje.inject.generator.APContext.typeElement;
-import static io.avaje.inject.generator.ProcessingContext.createMetaInfWriter;
+import static io.avaje.inject.generator.ProcessingContext.createMetaInfWriterFor;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -34,7 +33,7 @@ final class SimpleModuleWriter {
       " *   module example {\n" +
       " *     requires io.avaje.inject;\n" +
       " *     \n" +
-      " *     provides io.avaje.inject.spi.Module with %s.%s;\n" +
+      " *     provides io.avaje.inject.spi.InjectSPI with %s.%s;\n" +
       " *     \n" +
       " *   }\n" +
       " * \n" +
@@ -84,7 +83,13 @@ final class SimpleModuleWriter {
 
   private void writeServicesFile(ScopeInfo.Type scopeType) {
     try {
-      FileObject jfo = createMetaInfWriter(scopeType);
+
+      if (scopeType == ScopeInfo.Type.DEFAULT) {
+        ProcessingContext.addInjectSPI(fullName);
+        return;
+      }
+
+      FileObject jfo = createMetaInfWriterFor(Constants.META_INF_TESTMODULE);
       if (jfo != null) {
         Writer writer = jfo.openWriter();
         writer.write(fullName);
@@ -132,7 +137,7 @@ final class SimpleModuleWriter {
     provides.addAll(autoProvides);
     autoProvidesAspects.stream().map(Util::wrapAspect).forEach(provides::add);
 
-    ProcessingContext.addAvajeModule(new AvajeModule(fullName, provides, requires));
+    ProcessingContext.addAvajeModule(new AvajeModuleData(fullName, provides, requires));
   }
 
   private void writeClassesMethod() {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleOrderWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleOrderWriter.java
@@ -37,17 +37,7 @@ final class SimpleOrderWriter {
   }
 
   private void writeServicesFile() {
-    try {
-      FileObject jfo = createMetaInfWriterFor("META-INF/services/io.avaje.inject.spi.ModuleOrdering");
-      if (jfo != null) {
-        Writer writer = jfo.openWriter();
-        writer.write(fullName);
-        writer.close();
-      }
-    } catch (IOException e) {
-      e.printStackTrace();
-      logError("Failed to write services file " + e.getMessage());
-    }
+    ProcessingContext.addInjectSPI(fullName);
   }
 
   private void writePackage() {
@@ -62,7 +52,7 @@ final class SimpleOrderWriter {
           + "import java.util.Set;\n"
           + "import io.avaje.inject.spi.Generated;\n"
           + "import io.avaje.inject.spi.ModuleOrdering;\n"
-          + "import io.avaje.inject.spi.Module;")
+          + "import io.avaje.inject.spi.AvajeModule;")
       .eol();
 
     writer.eol();
@@ -78,7 +68,7 @@ final class SimpleOrderWriter {
     writer.append(Constants.AT_GENERATED).eol();
     writer.append("public final class %s implements ModuleOrdering {", shortName).eol().eol();
 
-    writer.append("  private final Module[] sortedModules = new Module[%s];", ordering.size()).eol();
+    writer.append("  private final AvajeModule[] sortedModules = new AvajeModule[%s];", ordering.size()).eol();
     writer.append("  private static final Map<String, Integer> INDEXES = Map.ofEntries(").eol();
     var size = ordering.size();
     var count = 0;
@@ -96,7 +86,7 @@ final class SimpleOrderWriter {
     writer.append(
       "\n"
         + "  @Override\n"
-        + "  public List<Module> factories() {\n"
+        + "  public List<AvajeModule> factories() {\n"
         + "    return List.of(sortedModules);\n"
         + "  }\n"
         + "\n"
@@ -106,7 +96,7 @@ final class SimpleOrderWriter {
         + "  }\n"
         + "\n"
         + "  @Override\n"
-        + "  public void add(Module module) {\n"
+        + "  public void add(AvajeModule module) {\n"
         + "    final var index = INDEXES.get(module.getClass().getTypeName());\n"
         + "    if (index != null) {\n"
         + "      sortedModules[index] = module;\n"

--- a/inject-generator/src/main/java/module-info.java
+++ b/inject-generator/src/main/java/module-info.java
@@ -4,6 +4,7 @@ module io.avaje.inject.generator {
   requires io.avaje.inject;
   requires static io.avaje.prism;
 
+  uses io.avaje.inject.spi.InjectSPI;
   uses io.avaje.inject.spi.Plugin;
   uses io.avaje.inject.spi.Module;
 

--- a/inject-generator/src/test/java/io/avaje/inject/generator/InjectProcessorTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/InjectProcessorTest.java
@@ -37,8 +37,7 @@ class InjectProcessorTest {
           .sorted(Comparator.reverseOrder())
           .map(Path::toFile)
           .forEach(File::delete);
-      Paths.get("io.avaje.inject.spi.Module").toAbsolutePath().toFile().delete();
-      Paths.get("io.avaje.inject.spi.ModuleOrdering").toAbsolutePath().toFile().delete();
+      Paths.get("io.avaje.inject.spi.InjectSPI").toAbsolutePath().toFile().delete();
     } catch (final Exception e) {
     }
   }

--- a/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
+++ b/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
@@ -28,6 +29,9 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 
+import io.avaje.inject.spi.AvajeModule;
+import io.avaje.inject.spi.InjectPlugin;
+import io.avaje.inject.spi.InjectSPI;
 import io.avaje.inject.spi.Module;
 import io.avaje.inject.spi.Plugin;
 
@@ -48,7 +52,7 @@ public class AutoProvidesMojo extends AbstractMojo {
   @Parameter(defaultValue = "${project}", readonly = true, required = true)
   private MavenProject project;
 
-  private final List<AvajeModule> modules = new ArrayList<>();
+  private final List<AvajeModuleData> modules = new ArrayList<>();
 
   @Override
   public void execute() throws MojoExecutionException {
@@ -89,18 +93,29 @@ public class AutoProvidesMojo extends AbstractMojo {
   }
 
   private URLClassLoader createClassLoader(List<URL> listUrl) {
-    return new URLClassLoader(listUrl.toArray(new URL[listUrl.size()]), Thread.currentThread().getContextClassLoader());
+    return new URLClassLoader(
+        listUrl.toArray(new URL[listUrl.size()]), Thread.currentThread().getContextClassLoader());
   }
 
   private FileWriter createFileWriter(String string) throws IOException {
     return new FileWriter(new File(project.getBuild().getDirectory(), string), true);
   }
 
-  private void writeProvidedPlugins(URLClassLoader newClassLoader, FileWriter pluginWriter) throws IOException {
+  private void writeProvidedPlugins(URLClassLoader newClassLoader, FileWriter pluginWriter)
+      throws IOException {
     final Set<String> providedTypes = new HashSet<>();
 
     final Log log = getLog();
-    for (final var plugin : ServiceLoader.load(Plugin.class, newClassLoader)) {
+
+    final List<InjectPlugin> plugins = new ArrayList<>();
+    ServiceLoader.load(Plugin.class, newClassLoader).forEach(plugins::add);
+    ServiceLoader.load(InjectSPI.class, newClassLoader).stream()
+        .map(Provider::get)
+        .filter(InjectPlugin.class::isInstance)
+        .map(InjectPlugin.class::cast)
+        .forEach(plugins::add);
+
+    for (final var plugin : plugins) {
       log.info("Loaded Plugin: " + plugin.getClass().getTypeName());
       for (final var provide : plugin.provides()) {
         providedTypes.add(provide.getTypeName());
@@ -116,11 +131,19 @@ public class AutoProvidesMojo extends AbstractMojo {
     }
   }
 
-  private void writeProvidedModules(URLClassLoader newClassLoader, FileWriter moduleWriter) throws IOException {
+  private void writeProvidedModules(URLClassLoader newClassLoader, FileWriter moduleWriter)
+      throws IOException {
     final Set<String> providedTypes = new HashSet<>();
 
     final Log log = getLog();
-    for (final var module : ServiceLoader.load(Module.class, newClassLoader)) {
+    final List<AvajeModule> avajeModules = new ArrayList<>();
+    ServiceLoader.load(Module.class, newClassLoader).forEach(avajeModules::add);
+    ServiceLoader.load(InjectSPI.class, newClassLoader).stream()
+        .map(Provider::get)
+        .filter(AvajeModule.class::isInstance)
+        .map(AvajeModule.class::cast)
+        .forEach(avajeModules::add);
+    for (final var module : avajeModules) {
 
       final var name = module.getClass().getTypeName();
       log.info("Detected External Module: " + name);
@@ -142,15 +165,16 @@ public class AutoProvidesMojo extends AbstractMojo {
         provides.add(type);
       }
 
-      final var requires = Arrays.<Type>stream(module.requires()).map(Type::getTypeName).collect(toList());
+      final var requires =
+          Arrays.<Type>stream(module.requires()).map(Type::getTypeName).collect(toList());
 
       Arrays.<Type>stream(module.autoRequires()).map(Type::getTypeName).forEach(requires::add);
       Arrays.<Type>stream(module.requiresPackages()).map(Type::getTypeName).forEach(requires::add);
       Arrays.<Type>stream(module.autoRequiresAspects())
-        .map(Type::getTypeName)
-        .map(AutoProvidesMojo::wrapAspect)
-        .forEach(requires::add);
-      modules.add(new AvajeModule(name, provides, requires));
+          .map(Type::getTypeName)
+          .map(AutoProvidesMojo::wrapAspect)
+          .forEach(requires::add);
+      modules.add(new AvajeModuleData(name, provides, requires));
     }
 
     for (final String providedType : providedTypes) {
@@ -161,7 +185,7 @@ public class AutoProvidesMojo extends AbstractMojo {
 
   private void writeModuleCSV(FileWriter moduleWriter) throws IOException {
     moduleWriter.write("\nExternal Module Type|Provides|Requires");
-    for (AvajeModule avajeModule : modules) {
+    for (AvajeModuleData avajeModule : modules) {
       moduleWriter.write("\n");
       moduleWriter.write(avajeModule.name());
       moduleWriter.write("|");

--- a/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AvajeModuleData.java
+++ b/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AvajeModuleData.java
@@ -3,13 +3,13 @@ package io.avaje.inject.mojo;
 import java.util.ArrayList;
 import java.util.List;
 
-final class AvajeModule {
+public final class AvajeModuleData {
 
   private final String fqn;
   private final List<String> provides = new ArrayList<>();
   private final List<String> requires = new ArrayList<>();
 
-  AvajeModule(String name, List<String> provides, List<String> requires) {
+  AvajeModuleData(String name, List<String> provides, List<String> requires) {
     this.fqn = name;
     this.provides.addAll(provides);
     this.requires.addAll(requires);

--- a/inject-test/src/main/java/io/avaje/inject/test/GlobalInitialise.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/GlobalInitialise.java
@@ -1,7 +1,7 @@
 package io.avaje.inject.test;
 
 import io.avaje.inject.BeanScope;
-import io.avaje.inject.spi.Module;
+import io.avaje.inject.spi.AvajeModule;
 import io.avaje.lang.Nullable;
 
 import java.io.IOException;
@@ -81,7 +81,7 @@ final class GlobalInitialise {
 
   private BeanScope buildFromModules(List<TestModule> testModules) {
     return BeanScope.builder()
-      .modules(testModules.toArray(Module[]::new))
+      .modules(testModules.toArray(AvajeModule[]::new))
       .shutdownHook(shutdownHook)
       .build();
   }

--- a/inject-test/src/main/java/io/avaje/inject/test/TestModule.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/TestModule.java
@@ -1,9 +1,9 @@
 package io.avaje.inject.test;
 
-import io.avaje.inject.spi.Module;
+import io.avaje.inject.spi.AvajeModule;
 
 /**
  * Marker for Test scope module.
  */
-public interface TestModule extends Module.Custom {
+public interface TestModule extends AvajeModule.Custom {
 }

--- a/inject-test/src/test/java/org/example/coffee/BeanScopeBuilderAddTest.java
+++ b/inject-test/src/test/java/org/example/coffee/BeanScopeBuilderAddTest.java
@@ -2,7 +2,7 @@ package org.example.coffee;
 
 import io.avaje.inject.BeanScope;
 import io.avaje.inject.spi.Builder;
-import io.avaje.inject.spi.Module;
+import io.avaje.inject.spi.AvajeModule;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -28,7 +28,7 @@ public class BeanScopeBuilderAddTest {
     }
   }
 
-  public static class SillyModule implements Module {
+  public static class SillyModule implements AvajeModule {
 
     @Override
     public Class<?>[] requires() {

--- a/inject-test/src/test/java/org/example/custom2/ParentScopeSpyTest.java
+++ b/inject-test/src/test/java/org/example/custom2/ParentScopeSpyTest.java
@@ -2,7 +2,7 @@ package org.example.custom2;
 
 import io.avaje.inject.BeanScope;
 import io.avaje.inject.spi.Builder;
-import io.avaje.inject.spi.Module;
+import io.avaje.inject.spi.AvajeModule;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -64,7 +64,7 @@ class ParentScopeSpyTest {
     }
   }
 
-  static class MyTestModule implements Module.Custom {
+  static class MyTestModule implements AvajeModule.Custom {
 
     private final Class<?>[] provides = new Class<?>[]{};
     private final Class<?>[] requires = new Class<?>[]{};

--- a/inject/README.md
+++ b/inject/README.md
@@ -4,13 +4,13 @@ APT based dependency injection for server side developers - https://avaje.io/inj
 ### Example module use
 
 ```java
-import io.avaje.inject.spi.Module;
+import io.avaje.inject.spi.AvajeModule;
 
 module org.example {
 
     requires io.avaje.inject;
 
-    provides io.avaje.inject.spi.Module with org.example.ExampleModule;
+    provides io.avaje.inject.spi.AvajeModule with org.example.ExampleModule;
 }
 ```
 

--- a/inject/pom.xml
+++ b/inject/pom.xml
@@ -36,6 +36,13 @@
       <version>3.14</version>
       <optional>true</optional>
     </dependency>
+    
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-spi-service</artifactId>
+      <version>1.4</version>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>

--- a/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
@@ -1,7 +1,8 @@
 package io.avaje.inject;
 
 import io.avaje.inject.spi.AvajeModule;
-import io.avaje.inject.spi.PropertyPlugin;
+import io.avaje.inject.spi.ConfigPropertyPlugin;
+import io.avaje.inject.spi.PropertyRequiresPlugin;
 import io.avaje.lang.NonNullApi;
 import io.avaje.lang.Nullable;
 
@@ -80,17 +81,26 @@ public interface BeanScopeBuilder {
   BeanScopeBuilder modules(AvajeModule... modules);
 
   /**
-   * Set the PropertyPlugin used for this scope. This is serviceloaded automatically of not set
+   * Return the PropertyRequiresPlugin used for this scope. This is useful for plugins that want to
+   * use the scopes wiring properties.
+   *
+   * @deprecated use {@link #configPlugin()} instead
+   */
+  @Deprecated(forRemoval = true)
+  PropertyRequiresPlugin propertyPlugin();
+
+  /**
+   * Set the ConfigPropertyPlugin used for this scope. This is serviceloaded automatically of not set
    *
    * @param propertyRequiresPlugin The plugin for conditions based on properties
    */
-  void propertyPlugin(PropertyPlugin propertyRequiresPlugin);
+  void configPlugin(ConfigPropertyPlugin propertyPlugin);
 
   /**
-   * Return the PropertyPlugin used for this scope. This is useful for plugins that want to use
+   * Return the ConfigPropertyPlugin used for this scope. This is useful for plugins that want to use
    * the scopes wiring properties.
    */
-  PropertyPlugin propertyPlugin();
+  ConfigPropertyPlugin configPlugin();
 
   /**
    * Supply a bean to the scope that will be used instead of any similar bean in the scope.

--- a/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
@@ -1,7 +1,7 @@
 package io.avaje.inject;
 
-import io.avaje.inject.spi.Module;
-import io.avaje.inject.spi.PropertyRequiresPlugin;
+import io.avaje.inject.spi.AvajeModule;
+import io.avaje.inject.spi.PropertyPlugin;
 import io.avaje.lang.NonNullApi;
 import io.avaje.lang.Nullable;
 
@@ -77,20 +77,20 @@ public interface BeanScopeBuilder {
    * @param modules The modules that we want to include in dependency injection.
    * @return This BeanScopeBuilder
    */
-  BeanScopeBuilder modules(Module... modules);
+  BeanScopeBuilder modules(AvajeModule... modules);
 
   /**
    * Set the PropertyPlugin used for this scope. This is serviceloaded automatically of not set
    *
    * @param propertyRequiresPlugin The plugin for conditions based on properties
    */
-  void propertyPlugin(PropertyRequiresPlugin propertyRequiresPlugin);
+  void propertyPlugin(PropertyPlugin propertyRequiresPlugin);
 
   /**
    * Return the PropertyPlugin used for this scope. This is useful for plugins that want to use
    * the scopes wiring properties.
    */
-  PropertyRequiresPlugin propertyPlugin();
+  PropertyPlugin propertyPlugin();
 
   /**
    * Supply a bean to the scope that will be used instead of any similar bean in the scope.

--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -40,7 +40,7 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
   private boolean parentOverride = true;
   private boolean shutdownHook;
   private ClassLoader classLoader;
-  private PropertyPlugin propertyPlugin;
+  private ConfigPropertyPlugin propertyPlugin;
   private Set<String> profiles;
 
   /** Create a BeanScopeBuilder to ultimately load and return a new BeanScope. */
@@ -64,12 +64,20 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
   }
 
   @Override
-  public void propertyPlugin(PropertyPlugin propertyPlugin) {
+  public ConfigPropertyPlugin propertyPlugin() {
+    if (propertyPlugin == null) {
+      propertyPlugin = defaultPropertyPlugin();
+    }
+    return configPlugin();
+  }
+
+  @Override
+  public void configPlugin(ConfigPropertyPlugin propertyPlugin) {
     this.propertyPlugin = propertyPlugin;
   }
 
   @Override
-  public PropertyPlugin propertyPlugin() {
+  public ConfigPropertyPlugin configPlugin() {
     if (propertyPlugin == null) {
       propertyPlugin = defaultPropertyPlugin();
     }
@@ -212,7 +220,7 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
       classLoader = Thread.currentThread().getContextClassLoader();
     }
   }
-  private PropertyPlugin defaultPropertyPlugin() {
+  private ConfigPropertyPlugin defaultPropertyPlugin() {
     return detectAvajeConfig() ? new DConfigProps() : new DSystemProps();
   }
 
@@ -257,8 +265,8 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
         spiModules.add((AvajeModule) spi);
       } else if (spi instanceof ModuleOrdering) {
         spiOrdering = (ModuleOrdering) spi;
-      } else if (propertyPlugin == null && spi instanceof PropertyPlugin) {
-        propertyPlugin = (PropertyPlugin) spi;
+      } else if (propertyPlugin == null && spi instanceof ConfigPropertyPlugin) {
+        propertyPlugin = (ConfigPropertyPlugin) spi;
       }
     }
 

--- a/inject/src/main/java/io/avaje/inject/DConfigProps.java
+++ b/inject/src/main/java/io/avaje/inject/DConfigProps.java
@@ -1,14 +1,14 @@
 package io.avaje.inject;
 
 import io.avaje.config.Config;
-import io.avaje.inject.spi.PropertyRequiresPlugin;
+import io.avaje.inject.spi.PropertyPlugin;
 
 import java.util.Optional;
 
 /**
- * Avaje-Config based implementation of PropertyRequiresPlugin.
+ * Avaje-Config based implementation of PropertyPlugin.
  */
-final class DConfigProps implements PropertyRequiresPlugin {
+final class DConfigProps implements PropertyPlugin {
 
   @Override
   public Optional<String> get(String property) {

--- a/inject/src/main/java/io/avaje/inject/DConfigProps.java
+++ b/inject/src/main/java/io/avaje/inject/DConfigProps.java
@@ -1,14 +1,14 @@
 package io.avaje.inject;
 
 import io.avaje.config.Config;
-import io.avaje.inject.spi.PropertyPlugin;
+import io.avaje.inject.spi.ConfigPropertyPlugin;
 
 import java.util.Optional;
 
 /**
- * Avaje-Config based implementation of PropertyPlugin.
+ * Avaje-Config based implementation of ConfigPropertyPlugin.
  */
-final class DConfigProps implements PropertyPlugin {
+final class DConfigProps implements ConfigPropertyPlugin {
 
   @Override
   public Optional<String> get(String property) {

--- a/inject/src/main/java/io/avaje/inject/DSystemProps.java
+++ b/inject/src/main/java/io/avaje/inject/DSystemProps.java
@@ -2,7 +2,9 @@ package io.avaje.inject;
 
 import java.util.Optional;
 
-final class DSystemProps implements io.avaje.inject.spi.PropertyRequiresPlugin {
+import io.avaje.inject.spi.PropertyPlugin;
+
+final class DSystemProps implements PropertyPlugin {
 
   @Override
   public Optional<String> get(String property) {

--- a/inject/src/main/java/io/avaje/inject/DSystemProps.java
+++ b/inject/src/main/java/io/avaje/inject/DSystemProps.java
@@ -2,9 +2,9 @@ package io.avaje.inject;
 
 import java.util.Optional;
 
-import io.avaje.inject.spi.PropertyPlugin;
+import io.avaje.inject.spi.ConfigPropertyPlugin;
 
-final class DSystemProps implements PropertyPlugin {
+final class DSystemProps implements ConfigPropertyPlugin {
 
   @Override
   public Optional<String> get(String property) {

--- a/inject/src/main/java/io/avaje/inject/Profile.java
+++ b/inject/src/main/java/io/avaje/inject/Profile.java
@@ -24,12 +24,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * }</pre>
  *
  * <p>In the sample above, the MyService bean will get wired only if <code>avaje.profiles</code> is
- * set to "test" in the {@link io.avaje.inject.spi.PropertyRequiresPlugin}.
+ * set to "test" in the {@link io.avaje.inject.spi.PropertyPlugin}.
  *
  * <p>Avaje Config provides an implementation and if it is included in the classpath then Avaje
  * Config will be used to test the property conditions.
  *
- * <p>If no PropertyRequiresPlugin is found then the default implementation is used which uses
+ * <p>If no PropertyPlugin is found then the default implementation is used which uses
  * {@link System#getProperty(String)} and {@link System#getenv(String)}.
  */
 @Retention(RUNTIME)

--- a/inject/src/main/java/io/avaje/inject/Profile.java
+++ b/inject/src/main/java/io/avaje/inject/Profile.java
@@ -24,12 +24,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * }</pre>
  *
  * <p>In the sample above, the MyService bean will get wired only if <code>avaje.profiles</code> is
- * set to "test" in the {@link io.avaje.inject.spi.PropertyPlugin}.
+ * set to "test" in the {@link io.avaje.inject.spi.ConfigPropertyPlugin}.
  *
  * <p>Avaje Config provides an implementation and if it is included in the classpath then Avaje
  * Config will be used to test the property conditions.
  *
- * <p>If no PropertyPlugin is found then the default implementation is used which uses
+ * <p>If no ConfigPropertyPlugin is found then the default implementation is used which uses
  * {@link System#getProperty(String)} and {@link System#getenv(String)}.
  */
 @Retention(RUNTIME)

--- a/inject/src/main/java/io/avaje/inject/RequiresProperty.java
+++ b/inject/src/main/java/io/avaje/inject/RequiresProperty.java
@@ -29,12 +29,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * In the sample above the MyService bean will get wired only if <code>use.service</code>
  * is set in Java system properties / Avaje Config.
  * <p>
- * {@link io.avaje.inject.spi.PropertyRequiresPlugin} is used to test the property conditions and is loaded via {@link java.util.ServiceLoader}.
+ * {@link io.avaje.inject.spi.PropertyPlugin} is used to test the property conditions and is loaded via {@link java.util.ServiceLoader}.
  * <p>
  * Avaje Config provides an implementation and if it is included in the classpath then
  * Avaje Config will be used to test the property conditions.
  * <p>
- * If no PropertyRequiresPlugin is found then the default implementation is used which uses
+ * If no PropertyPlugin is found then the default implementation is used which uses
  * {@link System#getProperty(String)} and {@link System#getenv(String)}.
  */
 @Retention(RUNTIME)

--- a/inject/src/main/java/io/avaje/inject/RequiresProperty.java
+++ b/inject/src/main/java/io/avaje/inject/RequiresProperty.java
@@ -29,12 +29,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * In the sample above the MyService bean will get wired only if <code>use.service</code>
  * is set in Java system properties / Avaje Config.
  * <p>
- * {@link io.avaje.inject.spi.PropertyPlugin} is used to test the property conditions and is loaded via {@link java.util.ServiceLoader}.
+ * {@link io.avaje.inject.spi.ConfigPropertyPlugin} is used to test the property conditions and is loaded via {@link java.util.ServiceLoader}.
  * <p>
  * Avaje Config provides an implementation and if it is included in the classpath then
  * Avaje Config will be used to test the property conditions.
  * <p>
- * If no PropertyPlugin is found then the default implementation is used which uses
+ * If no ConfigPropertyPlugin is found then the default implementation is used which uses
  * {@link System#getProperty(String)} and {@link System#getenv(String)}.
  */
 @Retention(RUNTIME)

--- a/inject/src/main/java/io/avaje/inject/spi/AvajeModule.java
+++ b/inject/src/main/java/io/avaje/inject/spi/AvajeModule.java
@@ -1,28 +1,25 @@
 package io.avaje.inject.spi;
 
-/**
- * A Module that can be included in BeanScope.
- *
- * @deprecated use {@link io.avaje.inject.spi.AvajeModule AvajeModule}
- */
-@Deprecated(forRemoval = true)
-public interface Module extends AvajeModule {
+import java.lang.reflect.Type;
+
+/** A AvajeModule that can be included in BeanScope. */
+public interface AvajeModule extends InjectSPI {
+
+  /** Empty array of classes. */
+  Class<?>[] EMPTY_CLASSES = {};
 
   /** Return the set of types this module explicitly provides to other modules. */
-  @Override
-  default Class<?>[] provides() {
+  default Type[] provides() {
     return EMPTY_CLASSES;
   }
 
   /** Return the types this module needs to be provided externally or via other modules. */
-  @Override
-  default Class<?>[] requires() {
+  default Type[] requires() {
     return EMPTY_CLASSES;
   }
 
   /** Return the packages this module needs to be provided via other modules. */
-  @Override
-  default Class<?>[] requiresPackages() {
+  default Type[] requiresPackages() {
     return EMPTY_CLASSES;
   }
 
@@ -32,8 +29,7 @@ public interface Module extends AvajeModule {
    * <p>This is a convenience when using multiple modules that is otherwise controlled manually by
    * explicitly using {@link AvajeModule#provides()}.
    */
-  @Override
-  default Class<?>[] autoProvides() {
+  default Type[] autoProvides() {
     return EMPTY_CLASSES;
   }
 
@@ -43,7 +39,6 @@ public interface Module extends AvajeModule {
    * <p>This is a convenience when using multiple modules that we otherwise manually specify via
    * {@link AvajeModule#provides()}.
    */
-  @Override
   default Class<?>[] autoProvidesAspects() {
     return EMPTY_CLASSES;
   }
@@ -55,8 +50,7 @@ public interface Module extends AvajeModule {
    * <p>This is a convenience when using multiple modules that is otherwise controlled manually by
    * explicitly using {@link AvajeModule#requires()} or {@link AvajeModule#requiresPackages()}.
    */
-  @Override
-  default Class<?>[] autoRequires() {
+  default Type[] autoRequires() {
     return EMPTY_CLASSES;
   }
 
@@ -64,12 +58,21 @@ public interface Module extends AvajeModule {
    * These are the apects that this module requires whose implementations are provided by other
    * external modules (that are in the classpath at compile time).
    */
-  @Override
   default Class<?>[] autoRequiresAspects() {
     return EMPTY_CLASSES;
   }
 
+  /**
+   * Return public classes of the beans that would be registered by this module.
+   *
+   * <p>This method allows code to use reflection to inspect the modules classes before the module
+   * is wired. This method is not required for DI wiring.
+   */
+  Class<?>[] classes();
+
+  /** Build all the beans. */
+  void build(Builder builder);
 
   /** Marker for custom scoped modules. */
-  interface Custom extends Module {}
+  interface Custom extends AvajeModule {}
 }

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -25,7 +25,7 @@ public interface Builder {
    * @param parentOverride When false do not add beans that already exist on the parent
    */
   @SuppressWarnings("rawtypes")
-  static Builder newBuilder(Set<String> profiles, PropertyPlugin plugin, List<SuppliedBean> suppliedBeans, List<EnrichBean> enrichBeans, BeanScope parent, boolean parentOverride) {
+  static Builder newBuilder(Set<String> profiles, ConfigPropertyPlugin plugin, List<SuppliedBean> suppliedBeans, List<EnrichBean> enrichBeans, BeanScope parent, boolean parentOverride) {
     if (suppliedBeans.isEmpty() && enrichBeans.isEmpty()) {
       // simple case, no mocks or spies
       return new DBuilder(profiles, plugin, parent, parentOverride);
@@ -274,7 +274,7 @@ public interface Builder {
   /**
    * Return the plugin for required properties.
    */
-  PropertyPlugin property();
+  ConfigPropertyPlugin property();
 
   /**
    * Build and return the bean scope.

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -25,7 +25,7 @@ public interface Builder {
    * @param parentOverride When false do not add beans that already exist on the parent
    */
   @SuppressWarnings("rawtypes")
-  static Builder newBuilder(Set<String> profiles, PropertyRequiresPlugin plugin, List<SuppliedBean> suppliedBeans, List<EnrichBean> enrichBeans, BeanScope parent, boolean parentOverride) {
+  static Builder newBuilder(Set<String> profiles, PropertyPlugin plugin, List<SuppliedBean> suppliedBeans, List<EnrichBean> enrichBeans, BeanScope parent, boolean parentOverride) {
     if (suppliedBeans.isEmpty() && enrichBeans.isEmpty()) {
       // simple case, no mocks or spies
       return new DBuilder(profiles, plugin, parent, parentOverride);
@@ -274,7 +274,7 @@ public interface Builder {
   /**
    * Return the plugin for required properties.
    */
-  PropertyRequiresPlugin property();
+  PropertyPlugin property();
 
   /**
    * Build and return the bean scope.
@@ -284,5 +284,5 @@ public interface Builder {
   /**
    * Set the current module being wired.
    */
-  void currentModule(Class<? extends Module> currentModule);
+  void currentModule(Class<? extends AvajeModule> currentModule);
 }

--- a/inject/src/main/java/io/avaje/inject/spi/ConfigPropertyPlugin.java
+++ b/inject/src/main/java/io/avaje/inject/spi/ConfigPropertyPlugin.java
@@ -5,14 +5,14 @@ import java.util.Optional;
 import io.avaje.lang.NonNullApi;
 
 /**
- * InjectPlugin interface which contains the application properties used for wiring. Used with {@link
- * io.avaje.inject.RequiresProperty} and {@link io.avaje.inject.Profile}.
+ * InjectPlugin interface which contains the application properties used for wiring. Used with
+ * {@link io.avaje.inject.RequiresProperty} and {@link io.avaje.inject.Profile}.
  *
  * <p>The plugin is loaded via ServiceLoader and defaults to an implementation that uses {@link
  * System#getProperty(String)} and {@link System#getenv(String)}.
  */
 @NonNullApi
-public interface PropertyPlugin {
+public interface ConfigPropertyPlugin extends InjectSPI, PropertyRequiresPlugin {
 
   /**
    * Return a configuration value that might not exist.
@@ -36,5 +36,4 @@ public interface PropertyPlugin {
   default boolean notEqualTo(String property, String value) {
     return !equalTo(property, value);
   }
-
 }

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
@@ -24,12 +24,12 @@ final class DBeanMap {
   private final Set<String> qualifiers = new HashSet<>();
 
   private NextBean nextBean;
-  private Class<? extends Module> currentModule;
+  private Class<? extends AvajeModule> currentModule;
 
   DBeanMap() {
   }
 
-  void currentModule(Class<? extends Module> currentModule) {
+  void currentModule(Class<? extends AvajeModule> currentModule) {
     this.currentModule = currentModule;
   }
 

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -15,7 +15,7 @@ import static io.avaje.inject.spi.DBeanScope.combine;
 
 class DBuilder implements Builder {
 
-  private final PropertyPlugin propertyRequires;
+  private final ConfigPropertyPlugin propertyRequires;
   private final Set<String> profiles;
   /** List of Lifecycle methods. */
   private final List<Runnable> postConstruct = new ArrayList<>();
@@ -38,7 +38,7 @@ class DBuilder implements Builder {
 
   private DBeanScopeProxy beanScopeProxy;
 
-  DBuilder(Set<String> profiles, PropertyPlugin propertyRequires, BeanScope parent, boolean parentOverride) {
+  DBuilder(Set<String> profiles, ConfigPropertyPlugin propertyRequires, BeanScope parent, boolean parentOverride) {
     this.propertyRequires = propertyRequires;
     this.parent = parent;
     this.parentOverride = parentOverride;
@@ -386,7 +386,7 @@ class DBuilder implements Builder {
   }
 
   @Override
-  public PropertyPlugin property() {
+  public ConfigPropertyPlugin property() {
     return propertyRequires;
   }
 

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -15,7 +15,7 @@ import static io.avaje.inject.spi.DBeanScope.combine;
 
 class DBuilder implements Builder {
 
-  private final PropertyRequiresPlugin propertyRequires;
+  private final PropertyPlugin propertyRequires;
   private final Set<String> profiles;
   /** List of Lifecycle methods. */
   private final List<Runnable> postConstruct = new ArrayList<>();
@@ -38,7 +38,7 @@ class DBuilder implements Builder {
 
   private DBeanScopeProxy beanScopeProxy;
 
-  DBuilder(Set<String> profiles, PropertyRequiresPlugin propertyRequires, BeanScope parent, boolean parentOverride) {
+  DBuilder(Set<String> profiles, PropertyPlugin propertyRequires, BeanScope parent, boolean parentOverride) {
     this.propertyRequires = propertyRequires;
     this.parent = parent;
     this.parentOverride = parentOverride;
@@ -46,7 +46,7 @@ class DBuilder implements Builder {
   }
 
   @Override
-  public void currentModule(Class<? extends Module> currentModule) {
+  public void currentModule(Class<? extends AvajeModule> currentModule) {
     beanMap.currentModule(currentModule);
   }
 
@@ -386,7 +386,7 @@ class DBuilder implements Builder {
   }
 
   @Override
-  public PropertyRequiresPlugin property() {
+  public PropertyPlugin property() {
     return propertyRequires;
   }
 

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilderExtn.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilderExtn.java
@@ -20,7 +20,7 @@ final class DBuilderExtn extends DBuilder {
   private final boolean hasSuppliedBeans;
 
   @SuppressWarnings("rawtypes")
-  DBuilderExtn(Set<String> profiles, PropertyPlugin plugin, BeanScope parent, boolean parentOverride, List<SuppliedBean> suppliedBeans, List<EnrichBean> enrichBeans) {
+  DBuilderExtn(Set<String> profiles, ConfigPropertyPlugin plugin, BeanScope parent, boolean parentOverride, List<SuppliedBean> suppliedBeans, List<EnrichBean> enrichBeans) {
     super(profiles, plugin, parent, parentOverride);
     this.hasSuppliedBeans = (suppliedBeans != null && !suppliedBeans.isEmpty());
     if (hasSuppliedBeans) {

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilderExtn.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilderExtn.java
@@ -20,7 +20,7 @@ final class DBuilderExtn extends DBuilder {
   private final boolean hasSuppliedBeans;
 
   @SuppressWarnings("rawtypes")
-  DBuilderExtn(Set<String> profiles, PropertyRequiresPlugin plugin, BeanScope parent, boolean parentOverride, List<SuppliedBean> suppliedBeans, List<EnrichBean> enrichBeans) {
+  DBuilderExtn(Set<String> profiles, PropertyPlugin plugin, BeanScope parent, boolean parentOverride, List<SuppliedBean> suppliedBeans, List<EnrichBean> enrichBeans) {
     super(profiles, plugin, parent, parentOverride);
     this.hasSuppliedBeans = (suppliedBeans != null && !suppliedBeans.isEmpty());
     if (hasSuppliedBeans) {

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
@@ -29,7 +29,7 @@ final class DContextEntry {
     entries.add(entryBean);
   }
 
-  Provider<?> provider(String name, Class<? extends Module> currentModule) {
+  Provider<?> provider(String name, Class<? extends AvajeModule> currentModule) {
     if (entries.size() == 1) {
       return entries.get(0).provider();
     }
@@ -46,7 +46,7 @@ final class DContextEntry {
     return new EntryMatcher(name, null).match(entries);
   }
 
-  Object get(String name, Class<? extends Module> currentModule) {
+  Object get(String name, Class<? extends AvajeModule> currentModule) {
     if (entries.size() == 1) {
       return entries.get(0).bean();
     }
@@ -96,11 +96,11 @@ final class DContextEntry {
 
     private final String name;
     private final boolean impliedName;
-    private final Class<? extends Module> currentModule;
+    private final Class<? extends AvajeModule> currentModule;
     private DContextEntryBean match;
     private DContextEntryBean ignoredSecondaryMatch;
 
-    EntryMatcher(String name, Class<? extends Module> currentModule) {
+    EntryMatcher(String name, Class<? extends AvajeModule> currentModule) {
       this.currentModule = currentModule;
       if (name != null && name.startsWith("!")) {
         this.name = name.substring(1);

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntryBean.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntryBean.java
@@ -13,7 +13,7 @@ class DContextEntryBean {
   /**
    * Create taking into account if it is a Provider or the bean itself.
    */
-  static DContextEntryBean of(Object source, String name, int flag, Class<? extends Module> currentModule) {
+  static DContextEntryBean of(Object source, String name, int flag, Class<? extends AvajeModule> currentModule) {
     if (source instanceof Provider) {
       return new ProtoProvider((Provider<?>)source, name, flag, currentModule);
     } else {
@@ -32,16 +32,16 @@ class DContextEntryBean {
     }
   }
 
-  static DContextEntryBean provider(boolean prototype, Provider<?> provider, String name, int flag, Class<? extends Module> currentModule) {
+  static DContextEntryBean provider(boolean prototype, Provider<?> provider, String name, int flag, Class<? extends AvajeModule> currentModule) {
     return prototype ? new ProtoProvider(provider, name, flag, currentModule) : new OnceProvider(provider, name, flag, currentModule);
   }
 
   protected final Object source;
   protected final String name;
-  protected final Class<? extends Module> sourceModule;
+  protected final Class<? extends AvajeModule> sourceModule;
   private final int flag;
 
-  private DContextEntryBean(Object source, String name, int flag, Class<? extends Module> currentModule) {
+  private DContextEntryBean(Object source, String name, int flag, Class<? extends AvajeModule> currentModule) {
     this.source = source;
     this.name = name;
     this.flag = flag;
@@ -76,7 +76,7 @@ class DContextEntryBean {
     return qualifierName == null ? name == null : qualifierName.equalsIgnoreCase(name);
   }
 
-  final Class<? extends Module> sourceModule() {
+  final Class<? extends AvajeModule> sourceModule() {
     return sourceModule;
   }
 
@@ -122,7 +122,7 @@ class DContextEntryBean {
 
     private final Provider<?> provider;
 
-    private ProtoProvider(Provider<?> provider, String name, int flag, Class<? extends Module> currentModule) {
+    private ProtoProvider(Provider<?> provider, String name, int flag, Class<? extends AvajeModule> currentModule) {
       super(provider, name, flag, currentModule);
       this.provider = provider;
     }
@@ -147,7 +147,7 @@ class DContextEntryBean {
     private final Provider<?> provider;
     private Object bean;
 
-    private OnceProvider(Provider<?> provider, String name, int flag, Class<? extends Module> currentModule) {
+    private OnceProvider(Provider<?> provider, String name, int flag, Class<? extends AvajeModule> currentModule) {
       super(provider, name, flag, currentModule);
       this.provider = provider;
     }

--- a/inject/src/main/java/io/avaje/inject/spi/InjectPlugin.java
+++ b/inject/src/main/java/io/avaje/inject/spi/InjectPlugin.java
@@ -5,26 +5,33 @@ import io.avaje.inject.BeanScopeBuilder;
 import java.lang.reflect.Type;
 
 /**
- * A InjectPlugin that can be applied when creating a bean scope.
+ * A Plugin that can be applied when creating a bean scope.
  *
  * <p>Typically, a plugin might provide a default dependency via {@link
  * BeanScopeBuilder#provideDefault(Type, java.util.function.Supplier)}.
  */
-@Deprecated(forRemoval = true)
-public interface Plugin extends InjectPlugin {
+public interface InjectPlugin extends InjectSPI {
 
-  /** Apply the plugin to the scope builder. */
-  @Override
+  /**
+   * Empty array of classes.
+   */
+  Class<?>[] EMPTY_CLASSES = {};
+
+  /**
+   * Apply the plugin to the scope builder.
+   */
   void apply(BeanScopeBuilder builder);
 
-  /** Return the classes that the plugin provides. */
-  @Override
-  default Class<?>[] provides() {
+  /**
+   * Return the classes that the plugin provides.
+   */
+  default Type[] provides() {
     return EMPTY_CLASSES;
   }
 
-  /** Return the aspect classes that the plugin provides. */
-  @Override
+  /**
+   * Return the aspect classes that the plugin provides.
+   */
   default Class<?>[] providesAspects() {
     return EMPTY_CLASSES;
   }

--- a/inject/src/main/java/io/avaje/inject/spi/InjectSPI.java
+++ b/inject/src/main/java/io/avaje/inject/spi/InjectSPI.java
@@ -2,5 +2,6 @@ package io.avaje.inject.spi;
 
 import io.avaje.spi.Service;
 
+/** Superclass for all Inject SPI classes */
 @Service
 public interface InjectSPI {}

--- a/inject/src/main/java/io/avaje/inject/spi/InjectSPI.java
+++ b/inject/src/main/java/io/avaje/inject/spi/InjectSPI.java
@@ -1,0 +1,6 @@
+package io.avaje.inject.spi;
+
+import io.avaje.spi.Service;
+
+@Service
+public interface InjectSPI {}

--- a/inject/src/main/java/io/avaje/inject/spi/ModuleOrdering.java
+++ b/inject/src/main/java/io/avaje/inject/spi/ModuleOrdering.java
@@ -6,7 +6,7 @@ import java.util.Set;
 /**
  * Determines Wiring order.
  */
-public interface ModuleOrdering {
+public interface ModuleOrdering extends InjectSPI {
 
   /**
    * Order the factories, returning the ordered list of module names.
@@ -16,7 +16,7 @@ public interface ModuleOrdering {
   /**
    * The list of factories in the order they should be built.
    */
-  List<Module> factories();
+  List<AvajeModule> factories();
 
   /**
    * Whether no modules are available
@@ -26,5 +26,5 @@ public interface ModuleOrdering {
   /**
    * Accept a module for ordering
    */
-  void add(Module module);
+  void add(AvajeModule module);
 }

--- a/inject/src/main/java/io/avaje/inject/spi/Plugin.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Plugin.java
@@ -9,6 +9,8 @@ import java.lang.reflect.Type;
  *
  * <p>Typically, a plugin might provide a default dependency via {@link
  * BeanScopeBuilder#provideDefault(Type, java.util.function.Supplier)}.
+ *
+ * @deprecated use {@link io.avaje.inject.spi.InjectPlugin InjectPlugin}
  */
 @Deprecated(forRemoval = true)
 public interface Plugin extends InjectPlugin {

--- a/inject/src/main/java/io/avaje/inject/spi/PropertyPlugin.java
+++ b/inject/src/main/java/io/avaje/inject/spi/PropertyPlugin.java
@@ -5,14 +5,14 @@ import java.util.Optional;
 import io.avaje.lang.NonNullApi;
 
 /**
- * Plugin interface which contains the application properties used for wiring. Used with {@link
+ * InjectPlugin interface which contains the application properties used for wiring. Used with {@link
  * io.avaje.inject.RequiresProperty} and {@link io.avaje.inject.Profile}.
  *
  * <p>The plugin is loaded via ServiceLoader and defaults to an implementation that uses {@link
  * System#getProperty(String)} and {@link System#getenv(String)}.
  */
 @NonNullApi
-public interface PropertyRequiresPlugin {
+public interface PropertyPlugin {
 
   /**
    * Return a configuration value that might not exist.

--- a/inject/src/main/java/io/avaje/inject/spi/PropertyRequiresPlugin.java
+++ b/inject/src/main/java/io/avaje/inject/spi/PropertyRequiresPlugin.java
@@ -1,0 +1,44 @@
+package io.avaje.inject.spi;
+
+import java.util.Optional;
+
+import io.avaje.lang.NonNullApi;
+
+/**
+ * InjectPlugin interface which contains the application properties used for wiring. Used with {@link
+ * io.avaje.inject.RequiresProperty} and {@link io.avaje.inject.Profile}.
+ *
+ * <p>The plugin is loaded via ServiceLoader and defaults to an implementation that uses {@link
+ * System#getProperty(String)} and {@link System#getenv(String)}.
+ *
+ * @deprecated use ConfigPropertyPlugin Instead
+ *
+ */
+@NonNullApi
+@Deprecated(forRemoval = true)
+public interface PropertyRequiresPlugin {
+
+  /**
+   * Return a configuration value that might not exist.
+   */
+  Optional<String> get(String property);
+
+  /**
+   * Return true if the property is defined.
+   */
+  boolean contains(String property);
+
+  /** Return true if the property is not defined. */
+  default boolean missing(String property) {
+    return !contains(property);
+  }
+
+  /** Return true if the property is equal to the given value. */
+  boolean equalTo(String property, String value);
+
+  /** Return true if the property is not defined or not equal to the given value. */
+  default boolean notEqualTo(String property, String value) {
+    return !equalTo(property, value);
+  }
+
+}

--- a/inject/src/main/java/module-info.java
+++ b/inject/src/main/java/module-info.java
@@ -10,10 +10,10 @@ module io.avaje.inject {
   requires transitive jakarta.inject;
   requires static io.avaje.config;
   requires static org.mockito;
+  requires static transitive io.avaje.spi;
 
+  uses io.avaje.inject.spi.InjectSPI;
   uses io.avaje.inject.spi.Module;
-  uses io.avaje.inject.spi.ModuleOrdering;
   uses io.avaje.inject.spi.Plugin;
-  uses io.avaje.inject.spi.PropertyRequiresPlugin;
 
 }

--- a/inject/src/main/java/module-info.java
+++ b/inject/src/main/java/module-info.java
@@ -10,7 +10,7 @@ module io.avaje.inject {
   requires transitive jakarta.inject;
   requires static io.avaje.config;
   requires static org.mockito;
-  requires static transitive io.avaje.spi;
+  requires static io.avaje.spi;
 
   uses io.avaje.inject.spi.InjectSPI;
   uses io.avaje.inject.spi.Module;

--- a/inject/src/test/java/io/avaje/inject/LegacyBeanScopeBuilderTest.java
+++ b/inject/src/test/java/io/avaje/inject/LegacyBeanScopeBuilderTest.java
@@ -41,7 +41,7 @@ class LegacyBeanScopeBuilderTest {
     assertThatThrownBy(factoryOrder::orderModules)
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining(
-            "AvajeModule [io.avaje.inject.BeanScopeBuilderTest$TDModule] has unsatisfied requires [io.avaje.inject.BeanScopeBuilderTest$MyFeature]");
+            "Module [io.avaje.inject.LegacyBeanScopeBuilderTest$TDModule] has unsatisfied requires [io.avaje.inject.LegacyBeanScopeBuilderTest$MyFeature]");
   }
 
   @Test
@@ -168,7 +168,7 @@ class LegacyBeanScopeBuilderTest {
     assertThatThrownBy(factoryOrder::orderModules)
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining(
-            "has unsatisfied requiresPackages [io.avaje.inject.BeanScopeBuilderTest$Mod3] ");
+            "has unsatisfied requiresPackages [io.avaje.inject.LegacyBeanScopeBuilderTest$Mod3] ");
   }
 
   @Test
@@ -182,7 +182,7 @@ class LegacyBeanScopeBuilderTest {
     assertThatThrownBy(factoryOrder::orderModules)
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining(
-            "has unsatisfied requires [io.avaje.inject.BeanScopeBuilderTest$Mod3] ");
+            "has unsatisfied requires [io.avaje.inject.LegacyBeanScopeBuilderTest$Mod3] ");
   }
 
   private List<String> names(List<AvajeModule> factories) {

--- a/inject/src/test/java/io/avaje/inject/LegacyBeanScopeBuilderTest.java
+++ b/inject/src/test/java/io/avaje/inject/LegacyBeanScopeBuilderTest.java
@@ -16,14 +16,16 @@ import org.junit.jupiter.api.Test;
 
 import io.avaje.inject.spi.AvajeModule;
 import io.avaje.inject.spi.Builder;
-import io.avaje.inject.spi.GenericType;
+import io.avaje.inject.spi.Module;
 
 @SuppressWarnings("all")
-class BeanScopeBuilderTest {
+class LegacyBeanScopeBuilderTest {
 
   @Test
   void depends_providedByParent() {
-    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(new TDBeanScope(MyFeature.class), Collections.emptySet(), false);
+    DBeanScopeBuilder.FactoryOrder factoryOrder =
+        new DBeanScopeBuilder.FactoryOrder(
+            new TDBeanScope(MyFeature.class), Collections.emptySet(), false);
     factoryOrder.add(bc("1", EMPTY_CLASSES, of(MyFeature.class)));
     factoryOrder.orderModules();
 
@@ -32,16 +34,20 @@ class BeanScopeBuilderTest {
 
   @Test
   void depends_notProvidedByParent_expect_IllegalStateException() {
-    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(new TDBeanScope(FeatureA.class), Collections.emptySet(), false);
+    DBeanScopeBuilder.FactoryOrder factoryOrder =
+        new DBeanScopeBuilder.FactoryOrder(
+            new TDBeanScope(FeatureA.class), Collections.emptySet(), false);
     factoryOrder.add(bc("1", EMPTY_CLASSES, of(MyFeature.class)));
     assertThatThrownBy(factoryOrder::orderModules)
-      .isInstanceOf(IllegalStateException.class)
-      .hasMessageContaining("Module [io.avaje.inject.BeanScopeBuilderTest$TDModule] has unsatisfied requires [io.avaje.inject.BeanScopeBuilderTest$MyFeature]");
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(
+            "AvajeModule [io.avaje.inject.BeanScopeBuilderTest$TDModule] has unsatisfied requires [io.avaje.inject.BeanScopeBuilderTest$MyFeature]");
   }
 
   @Test
   void noDepends() {
-    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder =
+        new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
     factoryOrder.add(bc("1", EMPTY_CLASSES, EMPTY_CLASSES));
     factoryOrder.add(bc("2", EMPTY_CLASSES, EMPTY_CLASSES));
     factoryOrder.add(bc("3", EMPTY_CLASSES, EMPTY_CLASSES));
@@ -52,7 +58,8 @@ class BeanScopeBuilderTest {
 
   @Test
   void providedFirst() {
-    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder =
+        new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
     factoryOrder.add(bc("two", EMPTY_CLASSES, EMPTY_CLASSES));
     factoryOrder.add(bc("one", of(Mod3.class), EMPTY_CLASSES));
     factoryOrder.orderModules();
@@ -62,7 +69,8 @@ class BeanScopeBuilderTest {
 
   @Test
   void name_depends() {
-    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder =
+        new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
     factoryOrder.add(bc("two", EMPTY_CLASSES, of(Mod3.class)));
     factoryOrder.add(bc("one", EMPTY_CLASSES, EMPTY_CLASSES));
     factoryOrder.orderModules();
@@ -72,7 +80,8 @@ class BeanScopeBuilderTest {
 
   @Test
   void name_depends4() {
-    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder =
+        new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
     factoryOrder.add(bc("1", EMPTY_CLASSES, of(Mod3.class)));
     factoryOrder.add(bc("2", EMPTY_CLASSES, of(Mod4.class)));
     factoryOrder.add(bc("3", of(Mod3.class), of(Mod4.class)));
@@ -85,7 +94,8 @@ class BeanScopeBuilderTest {
 
   @Test
   void nameFeature_depends() {
-    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder =
+        new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
     factoryOrder.add(bc("1", of(FeatureA.class), of(Mod3.class)));
     factoryOrder.add(bc("2", EMPTY_CLASSES, of(Mod4.class, FeatureA.class)));
     factoryOrder.add(bc("3", of(Mod3.class), of(Mod4.class)));
@@ -98,7 +108,8 @@ class BeanScopeBuilderTest {
 
   @Test
   void feature_depends() {
-    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder =
+        new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
     factoryOrder.add(bc("two", EMPTY_CLASSES, of(MyFeature.class)));
     factoryOrder.add(bc("one", of(MyFeature.class), null));
     factoryOrder.orderModules();
@@ -107,20 +118,9 @@ class BeanScopeBuilderTest {
   }
 
   @Test
-  void feature_depends_generic() {
-    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
-    factoryOrder.add(bc("two", EMPTY_CLASSES, of(new GenericType<Map<String, MyFeature>>() {})));
-    factoryOrder.add(bc("one", of(new GenericType<Map<String, MyFeature>>() {}), EMPTY_CLASSES));
-    factoryOrder.add(bc("three", of(new GenericType<Map<String, MyFeature>>() {}), EMPTY_CLASSES));
-    factoryOrder.orderModules();
-
-    assertThat(names(factoryOrder.factories())).containsExactly("one", "three", "two");
-  }
-
-
-  @Test
   void feature_depends2() {
-    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder =
+        new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
     factoryOrder.add(bc("two", EMPTY_CLASSES, of(MyFeature.class)));
     factoryOrder.add(bc("one", of(MyFeature.class), EMPTY_CLASSES));
     factoryOrder.add(bc("three", of(MyFeature.class), EMPTY_CLASSES));
@@ -131,7 +131,8 @@ class BeanScopeBuilderTest {
 
   @Test
   void name_requiresPackage() {
-    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder =
+        new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
     factoryOrder.add(bc("1", EMPTY_CLASSES, new Class[0], of(Mod3.class)));
     factoryOrder.add(bc("2", EMPTY_CLASSES, new Class[0], of(Mod4.class)));
     factoryOrder.add(bc("3", of(Mod3.class), new Class[0], of(Mod4.class)));
@@ -144,7 +145,8 @@ class BeanScopeBuilderTest {
 
   @Test
   void name_requiresPackage_mixed() {
-    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
+    DBeanScopeBuilder.FactoryOrder factoryOrder =
+        new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
     factoryOrder.add(bc("1", EMPTY_CLASSES, new Class[0], of(Mod3.class)));
     factoryOrder.add(bc("2", EMPTY_CLASSES, of(Mod4.class), new Class[0]));
     factoryOrder.add(bc("3", of(Mod3.class), new Class[0], of(Mod4.class)));
@@ -157,50 +159,54 @@ class BeanScopeBuilderTest {
 
   @Test
   void missingRequiresPackage_expect_unsatisfiedRequiresPackages() {
-    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), false);
+    DBeanScopeBuilder.FactoryOrder factoryOrder =
+        new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), false);
     factoryOrder.add(bc("1", EMPTY_CLASSES, new Class[0], of(Mod3.class)));
     factoryOrder.add(bc("2", EMPTY_CLASSES, of(Mod4.class), new Class[0]));
     factoryOrder.add(bc("4", of(Mod4.class), new Class[0]));
 
     assertThatThrownBy(factoryOrder::orderModules)
-      .isInstanceOf(IllegalStateException.class)
-      .hasMessageContaining("has unsatisfied requiresPackages [io.avaje.inject.BeanScopeBuilderTest$Mod3] ");
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(
+            "has unsatisfied requiresPackages [io.avaje.inject.BeanScopeBuilderTest$Mod3] ");
   }
 
   @Test
   void missingRequires_expect_unsatisfiedRequires() {
-    DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), false);
+    DBeanScopeBuilder.FactoryOrder factoryOrder =
+        new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), false);
     factoryOrder.add(bc("1", EMPTY_CLASSES, of(Mod3.class), new Class[0]));
     factoryOrder.add(bc("2", EMPTY_CLASSES, of(Mod4.class), new Class[0]));
     factoryOrder.add(bc("4", of(Mod4.class), new Class[0]));
 
     assertThatThrownBy(factoryOrder::orderModules)
-      .isInstanceOf(IllegalStateException.class)
-      .hasMessageContaining("has unsatisfied requires [io.avaje.inject.BeanScopeBuilderTest$Mod3] ");
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(
+            "has unsatisfied requires [io.avaje.inject.BeanScopeBuilderTest$Mod3] ");
   }
 
   private List<String> names(List<AvajeModule> factories) {
-    return factories.stream()
-      .map(AvajeModule::toString)
-      .collect(Collectors.toList());
+    return factories.stream().map(AvajeModule::toString).collect(Collectors.toList());
   }
 
-  private TDModule bc(String name, Type[] provides, Type[] requires) {
+  private TDModule bc(String name, Class<?>[] provides, Class<?>[] requires) {
     return bc(name, provides, requires, new Class[0]);
   }
 
-  private TDModule bc(String name, Type[] provides, Type[] requires, Type[] requiresPkg) {
+  private TDModule bc(
+      String name, Class<?>[] provides, Class<?>[] requires, Class<?>[] requiresPkg) {
     return new TDModule(name, provides, requires, requiresPkg);
   }
 
   private static class TDModule implements AvajeModule {
 
     final String name;
-    final Type[] provides;
-    final Type[] requires;
-    final Type[] requiresPackages;
+    final Class<?>[] provides;
+    final Class<?>[] requires;
+    final Class<?>[] requiresPackages;
 
-    private TDModule(String name, Type[] provides, Type[] requires, Type[] requiresPackages) {
+    private TDModule(
+        String name, Class<?>[] provides, Class<?>[] requires, Class<?>[] requiresPackages) {
       this.name = name;
       this.provides = provides;
       this.requires = requires;
@@ -213,7 +219,7 @@ class BeanScopeBuilderTest {
     }
 
     @Override
-    public Type[] provides() {
+    public Class<?>[] provides() {
       return provides;
     }
 
@@ -223,33 +229,30 @@ class BeanScopeBuilderTest {
     }
 
     @Override
-    public Type[] requires() {
+    public Class<?>[] requires() {
       return requires;
     }
 
     @Override
-    public Type[] requiresPackages() {
+    public Class<?>[] requiresPackages() {
       return requiresPackages;
     }
 
     @Override
-    public void build(Builder parent) {
-
-    }
+    public void build(Builder parent) {}
   }
 
-  Type[] of(Type... cls) {
-    return cls != null ? cls : new Type[0];
+  Class<?>[] of(Class<?>... cls) {
+    return cls != null ? cls : new Class<?>[0];
   }
 
-  class MyFeature {
-  }
-  class FeatureA {
-  }
-  class Mod3 {
-  }
-  class Mod4 {
-  }
+  class MyFeature {}
+
+  class FeatureA {}
+
+  class Mod3 {}
+
+  class Mod4 {}
 
   static class TDBeanScope implements BeanScope {
 
@@ -330,8 +333,6 @@ class BeanScopeBuilderTest {
     }
 
     @Override
-    public void close() {
-
-    }
+    public void close() {}
   }
 }

--- a/inject/src/test/java/io/avaje/inject/spi/DContextEntryTest.java
+++ b/inject/src/test/java/io/avaje/inject/spi/DContextEntryTest.java
@@ -99,16 +99,16 @@ class DContextEntryTest {
   void getWithName_when_currentModule() {
 
     DContextEntry entry = new DContextEntry();
-    entry.add(DContextEntryBean.of("N1", "same", BeanEntry.NORMAL, Module.class));
+    entry.add(DContextEntryBean.of("N1", "same", BeanEntry.NORMAL, AvajeModule.class));
     entry.add(DContextEntryBean.of("N2", "same", BeanEntry.NORMAL, null));
     entry.add(DContextEntryBean.of("N3", "same", BeanEntry.NORMAL, OtherModule.class));
 
     assertEquals(entry.get("same", null), "N2");
-    assertEquals(entry.get("same", Module.class), "N1");
+    assertEquals(entry.get("same", AvajeModule.class), "N1");
     assertEquals(entry.get("same", OtherModule.class), "N3");
 
     assertEquals(entry.get(null, null), "N2");
-    assertEquals(entry.get(null, Module.class), "N1");
+    assertEquals(entry.get(null, AvajeModule.class), "N1");
     assertEquals(entry.get(null, OtherModule.class), "N3");
   }
 
@@ -116,16 +116,16 @@ class DContextEntryTest {
   void getWithoutName_when_currentModule() {
 
     DContextEntry entry = new DContextEntry();
-    entry.add(DContextEntryBean.of("N1", null, BeanEntry.NORMAL, Module.class));
+    entry.add(DContextEntryBean.of("N1", null, BeanEntry.NORMAL, AvajeModule.class));
     entry.add(DContextEntryBean.of("N2", null, BeanEntry.NORMAL, null));
     entry.add(DContextEntryBean.of("N3", null, BeanEntry.NORMAL, OtherModule.class));
 
     assertEquals(entry.get(null, null), "N2");
-    assertEquals(entry.get(null, Module.class), "N1");
+    assertEquals(entry.get(null, AvajeModule.class), "N1");
     assertEquals(entry.get(null, OtherModule.class), "N3");
 
     assertNull(entry.get("notThere", null));
-    assertNull(entry.get("notThere", Module.class));
+    assertNull(entry.get("notThere", AvajeModule.class));
     assertNull(entry.get("notThere", OtherModule.class));
   }
 
@@ -133,12 +133,12 @@ class DContextEntryTest {
   void getWithName_expect_matchOnName() {
 
     DContextEntry entry = new DContextEntry();
-    entry.add(DContextEntryBean.of("N1", "same", BeanEntry.NORMAL, Module.class));
+    entry.add(DContextEntryBean.of("N1", "same", BeanEntry.NORMAL, AvajeModule.class));
     entry.add(DContextEntryBean.of("N2", null, BeanEntry.NORMAL, null));
     entry.add(DContextEntryBean.of("N3", null, BeanEntry.NORMAL, OtherModule.class));
 
     assertEquals(entry.get("same", null), "N1");
-    assertEquals(entry.get("same", Module.class), "N1");
+    assertEquals(entry.get("same", AvajeModule.class), "N1");
     assertEquals(entry.get("same", OtherModule.class), "N1");
   }
 
@@ -146,12 +146,12 @@ class DContextEntryTest {
   void getWithoutName_expect_matchOnNoName() {
 
     DContextEntry entry = new DContextEntry();
-    entry.add(DContextEntryBean.of("N1", null, BeanEntry.NORMAL, Module.class));
+    entry.add(DContextEntryBean.of("N1", null, BeanEntry.NORMAL, AvajeModule.class));
     entry.add(DContextEntryBean.of("N2", "same", BeanEntry.NORMAL, null));
     entry.add(DContextEntryBean.of("N3", "same", BeanEntry.NORMAL, OtherModule.class));
 
     assertEquals(entry.get(null, null), "N1");
-    assertEquals(entry.get(null, Module.class), "N1");
+    assertEquals(entry.get(null, AvajeModule.class), "N1");
     assertEquals(entry.get(null, OtherModule.class), "N1");
   }
 
@@ -159,11 +159,11 @@ class DContextEntryTest {
   void when_noQualifier_expect_matchedToNoQualider() {
 
     DContextEntry entry = new DContextEntry();
-    entry.add(DContextEntryBean.of("N1", null, BeanEntry.NORMAL, Module.class));
-    entry.add(DContextEntryBean.of("N2", "myName", BeanEntry.NORMAL, Module.class));
+    entry.add(DContextEntryBean.of("N1", null, BeanEntry.NORMAL, AvajeModule.class));
+    entry.add(DContextEntryBean.of("N2", "myName", BeanEntry.NORMAL, AvajeModule.class));
 
-    assertEquals(entry.get("myName", Module.class), "N2");
-    assertEquals(entry.get(null, Module.class), "N1");
+    assertEquals(entry.get("myName", AvajeModule.class), "N2");
+    assertEquals(entry.get(null, AvajeModule.class), "N1");
   }
 
   @Test
@@ -173,11 +173,11 @@ class DContextEntryTest {
     entry.add(DContextEntryBean.of("N1", null, BeanEntry.NORMAL, null));
     entry.add(DContextEntryBean.of("N2", "myName", BeanEntry.NORMAL, null));
 
-    assertEquals(entry.get("myName", Module.class), "N2");
-    assertEquals(entry.get(null, Module.class), "N1");
+    assertEquals(entry.get("myName", AvajeModule.class), "N2");
+    assertEquals(entry.get(null, AvajeModule.class), "N1");
   }
 
-  class OtherModule implements Module {
+  class OtherModule implements AvajeModule {
     @Override
     public Class<?>[] classes() {
       return new Class[0];


### PR DESCRIPTION
Upon experimentation, it seems the `Class<?>` to `Type` changes we've made are backwards incompatible. Breaking every single multi-module project/plugin library based on avaje is pretty cringe. 

- Reverts changes to Module/Plugin classes and adds deprecation notices
- Creates super classes based on `Type` for the sake of compatibility (for whatever reason this works)
- renames `PropertyRequiresPlugin` 
- modifies scope builder, generator, and maven plugin to service load the new interfaces
Requires https://github.com/avaje/avaje-spi-service/pull/18 and also takes care of #559 