### PR TITLE
maven plugin: #567 Followup, Simplify ServiceLoader of InjectPlugin

### DIFF
--- a/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
+++ b/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
@@ -15,7 +15,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.ServiceLoader;
-import java.util.ServiceLoader.Provider;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
@@ -106,11 +105,7 @@ public class AutoProvidesMojo extends AbstractMojo {
 
     final List<InjectPlugin> plugins = new ArrayList<>();
     ServiceLoader.load(Plugin.class, newClassLoader).forEach(plugins::add);
-    ServiceLoader.load(InjectPlugin.class, newClassLoader).stream()
-        .map(Provider::get)
-        .filter(InjectPlugin.class::isInstance)
-        .map(InjectPlugin.class::cast)
-        .forEach(plugins::add);
+    ServiceLoader.load(InjectPlugin.class, newClassLoader).forEach(plugins::add);
 
     for (final var plugin : plugins) {
       log.info("Loaded Plugin: " + plugin.getClass().getTypeName());
@@ -134,13 +129,9 @@ public class AutoProvidesMojo extends AbstractMojo {
     final Log log = getLog();
     final List<AvajeModule> avajeModules = new ArrayList<>();
     ServiceLoader.load(Module.class, newClassLoader).forEach(avajeModules::add);
-    ServiceLoader.load(AvajeModule.class, newClassLoader).stream()
-        .map(Provider::get)
-        .filter(AvajeModule.class::isInstance)
-        .map(AvajeModule.class::cast)
-        .forEach(avajeModules::add);
-    for (final var module : avajeModules) {
+    ServiceLoader.load(AvajeModule.class, newClassLoader).forEach(avajeModules::add);
 
+    for (final var module : avajeModules) {
       final var name = module.getClass().getTypeName();
       log.info("Detected External Module: " + name);
 


### PR DESCRIPTION
I don't why we have the .filter() and ::cast for the service loading here, seems unnecessary and can simplify. 