### PR TITLE
Restore autoProvides to exclude http controllers and generated http routes

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
@@ -20,6 +20,7 @@ final class Constants {
 
   static final String PATH = "io.avaje.http.api.Path";
   static final String CONTROLLER = "io.avaje.http.api.Controller";
+  static final String HTTP_GENERATED = "io.avaje.http.api.Generated";
 
   static final String AT_SINGLETON = "@Singleton";
   static final String AT_PROXY = "@Proxy";


### PR DESCRIPTION
The change to autoProvides for Event support also meant that http controllers and http routes started to get included into autoProvides. The problem there is that http controllers are not expected to be public exported types and autoProvides with GenericType doesn't check is the type parameters are public.