### PR TITLE
Restore AutoProvides to include http common interfaces

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
@@ -20,6 +20,7 @@ final class Constants {
 
   static final String PATH = "io.avaje.http.api.Path";
   static final String CONTROLLER = "io.avaje.http.api.Controller";
+  static final String HTTP_GENERATED = "io.avaje.http.api.Generated";
 
   static final String AT_SINGLETON = "@Singleton";
   static final String AT_PROXY = "@Proxy";

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
@@ -20,7 +20,6 @@ final class Constants {
 
   static final String PATH = "io.avaje.http.api.Path";
   static final String CONTROLLER = "io.avaje.http.api.Controller";
-  static final String HTTP_GENERATED = "io.avaje.http.api.Generated";
 
   static final String AT_SINGLETON = "@Singleton";
   static final String AT_PROXY = "@Proxy";

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -3,16 +3,13 @@ package io.avaje.inject.generator;
 import static io.avaje.inject.generator.APContext.logWarn;
 import static io.avaje.inject.generator.APContext.types;
 import static io.avaje.inject.generator.ProcessingContext.asElement;
-import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.*;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
@@ -21,6 +18,15 @@ import javax.lang.model.type.TypeMirror;
  */
 final class TypeExtendsReader {
 
+  private static final Optional<List<UType>> CONTROLLER_INTERFACE =
+      Optional.ofNullable(APContext.typeElement("io.helidon.webserver.http.HttpFeature"))
+          .or(
+              () ->
+                  Optional.ofNullable(APContext.typeElement("io.javalin.Javalin"))
+                      .map(x -> APContext.typeElement("io.avaje.http.api.AvajeJavalinPlugin")))
+          .map(TypeElement::asType)
+          .map(UType::parse)
+          .map(List::of);
   private static final String JAVA_LANG_OBJECT = "java.lang.Object";
   private static final String JAVA_LANG_RECORD = "java.lang.Record";
   private final UType baseUType;
@@ -34,6 +40,8 @@ final class TypeExtendsReader {
   private final boolean publicAccess;
   private final boolean autoProvide;
   private final boolean proxyBean;
+  private final boolean controller;
+  private final boolean generatedBeanFactory;
   private boolean closeable;
   /**
    * The implied qualifier name based on naming convention.
@@ -51,23 +59,26 @@ final class TypeExtendsReader {
     this.publicAccess = baseType.getModifiers().contains(Modifier.PUBLIC);
     this.autoProvide = autoProvide();
     this.proxyBean = proxyBean;
+    this.controller = hasAnnotation(Constants.CONTROLLER) || hasAnnotation(Constants.HTTP_GENERATED);
+    this.generatedBeanFactory = GeneratedPrism.isPresent(baseType);
   }
 
   private boolean autoProvide() {
     return publicAccess
+      && !controller
+      && !generatedBeanFactory
       && !FactoryPrism.isPresent(baseType)
-      && !ProxyPrism.isPresent(baseType)
-      && !GeneratedPrism.isPresent(baseType)
-      && !isController();
+      && !ProxyPrism.isPresent(baseType);
   }
 
-  @SuppressWarnings("unchecked")
-  private boolean isController() {
-    try {
-      return baseType.getAnnotation((Class<Annotation>) Class.forName(Constants.CONTROLLER)) != null;
-    } catch (final ClassNotFoundException e) {
-      return false;
+  private boolean hasAnnotation(String annotationFQN) {
+    for (final var m : baseType.getAnnotationMirrors()) {
+      final CharSequence mfqn = ((TypeElement) m.getAnnotationType().asElement()).getQualifiedName();
+      if (annotationFQN.contentEquals(mfqn)) {
+        return true;
+      }
     }
+    return false;
   }
 
   UType baseType() {
@@ -119,6 +130,11 @@ final class TypeExtendsReader {
   }
 
   List<UType> autoProvides() {
+    if (controller || implementsBeanFactory()) {
+
+      // http controller, http route, or http request scoped controller via BeanFactory
+      return CONTROLLER_INTERFACE.orElseGet(List::of);
+    }
     if (baseTypeIsInterface) {
       return List.of(Util.unwrapProvider(baseUType));
     }
@@ -130,6 +146,15 @@ final class TypeExtendsReader {
       autoProvides.add(Util.unwrapProvider(baseUType));
     }
     return autoProvides;
+  }
+
+  private boolean implementsBeanFactory() {
+    for (UType interfaceType : interfaceTypes) {
+      if (Constants.BEAN_FACTORY.equals(interfaceType.mainType())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   List<UType> provides() {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -3,12 +3,16 @@ package io.avaje.inject.generator;
 import static io.avaje.inject.generator.APContext.logWarn;
 import static io.avaje.inject.generator.APContext.types;
 import static io.avaje.inject.generator.ProcessingContext.asElement;
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import javax.lang.model.element.*;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
@@ -30,8 +34,6 @@ final class TypeExtendsReader {
   private final boolean publicAccess;
   private final boolean autoProvide;
   private final boolean proxyBean;
-  private final boolean controller;
-  private final boolean generatedBeanFactory;
   private boolean closeable;
   /**
    * The implied qualifier name based on naming convention.
@@ -49,26 +51,23 @@ final class TypeExtendsReader {
     this.publicAccess = baseType.getModifiers().contains(Modifier.PUBLIC);
     this.autoProvide = autoProvide();
     this.proxyBean = proxyBean;
-    this.controller = hasAnnotation(Constants.CONTROLLER) || hasAnnotation(Constants.HTTP_GENERATED);
-    this.generatedBeanFactory = GeneratedPrism.isPresent(baseType);
   }
 
   private boolean autoProvide() {
     return publicAccess
-      && !controller
-      && !generatedBeanFactory
       && !FactoryPrism.isPresent(baseType)
-      && !ProxyPrism.isPresent(baseType);
+      && !ProxyPrism.isPresent(baseType)
+      && !GeneratedPrism.isPresent(baseType)
+      && !isController();
   }
 
-  private boolean hasAnnotation(String annotationFQN) {
-    for (final var m : baseType.getAnnotationMirrors()) {
-      final CharSequence mfqn = ((TypeElement) m.getAnnotationType().asElement()).getQualifiedName();
-      if (annotationFQN.contentEquals(mfqn)) {
-        return true;
-      }
+  @SuppressWarnings("unchecked")
+  private boolean isController() {
+    try {
+      return baseType.getAnnotation((Class<Annotation>) Class.forName(Constants.CONTROLLER)) != null;
+    } catch (final ClassNotFoundException e) {
+      return false;
     }
-    return false;
   }
 
   UType baseType() {
@@ -120,10 +119,6 @@ final class TypeExtendsReader {
   }
 
   List<UType> autoProvides() {
-    if (controller || implementsBeanFactory()) {
-      // http controller, http route, or http request scoped controller via BeanFactory
-      return List.of();
-    }
     if (baseTypeIsInterface) {
       return List.of(Util.unwrapProvider(baseUType));
     }
@@ -135,15 +130,6 @@ final class TypeExtendsReader {
       autoProvides.add(Util.unwrapProvider(baseUType));
     }
     return autoProvides;
-  }
-
-  private boolean implementsBeanFactory() {
-    for (UType interfaceType : interfaceTypes) {
-      if (Constants.BEAN_FACTORY.equals(interfaceType.mainType())) {
-        return true;
-      }
-    }
-    return false;
   }
 
   List<UType> provides() {


### PR DESCRIPTION
From what I've seen from doing support, it's not uncommon to provide HTTP routes to other modules.