### PR TITLE
Fix for unnamed generic types returned by @Factory @Bean

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/other/ConfigFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/other/ConfigFactory.java
@@ -5,6 +5,8 @@ import io.avaje.inject.Factory;
 import jakarta.inject.Named;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 @Factory
 class ConfigFactory {
@@ -19,5 +21,15 @@ class ConfigFactory {
   @Named("map2")
   Map<String, String> map2(Map<String, Long> map1) {
     return Map.of("a","hi", "b", "there", "count", String.valueOf(map1.size()));
+  }
+
+  @Bean
+  Set<UUID> setOfUuid() {
+    return Set.of(UUID.randomUUID());
+  }
+
+  @Bean
+  Set<Long> setOfLong() {
+    return Set.of(1L, 2L);
   }
 }

--- a/blackbox-test-inject/src/test/java/org/example/myapp/other/ConfigFactoryTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/other/ConfigFactoryTest.java
@@ -7,13 +7,17 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Type;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ConfigFactoryTest {
 
-  final Type TYPE_MapStringString = new GenericType<Map<String, String>>(){}.type();
-  final Type TYPE_MapStringLong = new GenericType<Map<String, Long>>(){}.type();
+  final Type TYPE_MapStringString = new GenericType<Map<String, String>>(){};
+  final Type TYPE_MapStringLong = new GenericType<Map<String, Long>>(){};
+  final Type TYPE_SetLong = new GenericType<Set<Long>>(){};
+  final Type TYPE_SetUUID = new GenericType<Set<UUID>>(){};
 
   @SuppressWarnings("unchecked")
   @Test
@@ -22,9 +26,13 @@ class ConfigFactoryTest {
 
       var map1 = (Map<String,String>)beanScope.get(TYPE_MapStringString);
       var map2 = (Map<String,Long>)beanScope.get(TYPE_MapStringLong);
-
       assertThat(map1).containsKeys("a", "b", "count");
       assertThat(map2).containsKeys("one", "two");
+
+      var setOfLong = (Set<Long>)beanScope.get(TYPE_SetLong);
+      var setOfUUID = (Set<UUID>)beanScope.get(TYPE_SetUUID);
+      assertThat(setOfLong).contains(1L, 2L);
+      assertThat(setOfUUID).hasSize(1);
     }
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
@@ -92,9 +92,17 @@ final class MetaData {
       if (name != null) {
         return trimType + "_" + name.replaceAll("[^a-zA-Z0-9_$]+", "_");
       } else {
+        if (buildNameIncludeMethod()) {
+          return trimType + "__" + Util.trimMethod(method);
+        }
         return trimType;
       }
     }
+  }
+
+  private boolean buildNameIncludeMethod() {
+    // generic type created via factory bean method
+    return type.contains("<") && hasMethod();
   }
 
   public String key() {


### PR DESCRIPTION
As currently the full generic type is not used in the generated build method name but just the top level main type then the generated build method can clash resulting in a compile error.

This fix detects this case and includes the factory method name in the "generated build method" such that it avoids the clash.