### PR TITLE
Add GA/EA JDK to PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [11,17,21,GA]
+        java_version: [11,17,21]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [11,17,21]
+        java_version: [11,17,21,GA]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/jdk-ea.yml
+++ b/.github/workflows/jdk-ea.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '39 1 * * 1,3,5'
+  push
 
 jobs:
   build:

--- a/.github/workflows/jdk-ea.yml
+++ b/.github/workflows/jdk-ea.yml
@@ -2,10 +2,10 @@
 name: avaje-inject EA
 
 on:
+  push:
   workflow_dispatch:
   schedule:
     - cron: '39 1 * * 1,3,5'
-  push
 
 jobs:
   build:


### PR DESCRIPTION
I mean it would be great to have immediate feedback when a PR will break on the latest JDK instead of waiting for a time later in the week