### PR TITLE
Have the aop and events modules as opt-in dependencies rather than opt-out

### DIFF
--- a/blackbox-test-inject/pom.xml
+++ b/blackbox-test-inject/pom.xml
@@ -50,6 +50,18 @@
     </dependency>
 
     <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-inject-aop</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-inject-events</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>io.github.resilience4j</groupId>
       <artifactId>resilience4j-retry</artifactId>
       <version>1.7.1</version>

--- a/inject-events/pom.xml
+++ b/inject-events/pom.xml
@@ -12,7 +12,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
-      <version>10.0-RC5</version>
+      <version>10.0-RC6</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/inject-generator/pom.xml
+++ b/inject-generator/pom.xml
@@ -22,7 +22,19 @@
       <artifactId>avaje-inject</artifactId>
       <version>${project.version}</version>
     </dependency>
-    
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-inject-aop</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-inject-events</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-spi-service</artifactId>
@@ -36,7 +48,7 @@
       <optional>true</optional>
       <scope>provided</scope>
     </dependency>
-    
+
     <!-- test dependencies -->
     <dependency>
       <groupId>io.avaje</groupId>

--- a/inject-test/pom.xml
+++ b/inject-test/pom.xml
@@ -25,6 +25,18 @@
 
     <dependency>
       <groupId>io.avaje</groupId>
+      <artifactId>avaje-inject-aop</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-inject-events</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
       <artifactId>avaje-inject-generator</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/inject/pom.xml
+++ b/inject/pom.xml
@@ -20,12 +20,6 @@
 
     <dependency>
       <groupId>io.avaje</groupId>
-      <artifactId>avaje-inject-aop</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    
-    <dependency>
-      <groupId>io.avaje</groupId>
       <artifactId>avaje-lang</artifactId>
       <version>1.1</version>
     </dependency>
@@ -55,12 +49,6 @@
       <artifactId>mockito-core</artifactId>
       <version>5.12.0</version>
       <optional>true</optional>
-    </dependency>
-    
-     <dependency>
-      <groupId>io.avaje</groupId>
-      <artifactId>avaje-inject-events</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <!-- test dependencies -->


### PR DESCRIPTION
Currently people not wanting the avaje-inject-aop or avaje-inject-events dependencies need to exclude them.

This is the alternative where instead projects need to explicitly include those modules. An extension to this would be to rename avaje-inject to be avaje-inject-core and introduce a new avaje-inject which is just a composite of avaje-inject-core, avaje-inject-aop and avaje-inject-events.

Hmmm. Pondering this.