### PR TITLE
Rename InjectSPI to InjectExtension

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ Example ex = beanScope.get(Example.class);
 ### Java Module Usage
 When working with Java modules you need to add a `provides` statement in your `module-info.java` with the generated class.
 ```java
-import io.avaje.inject.spi.InjectSPI;
+import io.avaje.inject.spi.InjectExtension;
 
 module org.example {
 
   requires io.avaje.inject;
   // you must define the fully qualified class name of the generated classes. if you use an import statement, compilation will fail
-  provides InjectSPI with org.example.ExampleModule;
+  provides InjectExtension with org.example.ExampleModule;
 }
 ```
 

--- a/blackbox-aspect/src/main/java/module-info.java
+++ b/blackbox-aspect/src/main/java/module-info.java
@@ -4,6 +4,6 @@ module blackbox.aspect {
   requires io.avaje.inject.aop;
 
   //remove this and compilation fails
-  provides io.avaje.inject.spi.InjectSPI with org.example.external.aspect.sub.ExampleExternalAspectModule;
+  provides io.avaje.inject.spi.InjectExtension with org.example.external.aspect.sub.ExampleExternalAspectModule;
 
 }

--- a/blackbox-other/pom.xml
+++ b/blackbox-other/pom.xml
@@ -18,6 +18,13 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-inject-events</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- annotation processor -->
     <dependency>

--- a/blackbox-test-inject/pom.xml
+++ b/blackbox-test-inject/pom.xml
@@ -91,7 +91,7 @@
 			<plugin>
 				<groupId>io.avaje</groupId>
 				<artifactId>avaje-inject-maven-plugin</artifactId>
-				<version>10.0-RC5</version>
+				<version>10.0-RC6</version>
 				<executions>
 					<execution>
 						<phase>process-sources</phase>

--- a/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_injectFromTestModule_Test.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_injectFromTestModule_Test.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@ExtendWith(InjectExtension.class)
+@ExtendWith(InjectJunitExtension.class)
 class InjectExtension_injectFromTestModule_Test {
 
   @Inject

--- a/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_injectFromTestModule_Test.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_injectFromTestModule_Test.java
@@ -1,6 +1,6 @@
 package org.example.myapp;
 
-import io.avaje.inject.test.InjectExtension;
+import io.avaje.inject.test.InjectJunitExtension;
 import jakarta.inject.Inject;
 import org.example.myapp.testconfig.CountTestScopeStart;
 import org.junit.jupiter.api.Test;

--- a/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_injectLocalMock_Test.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_injectLocalMock_Test.java
@@ -1,6 +1,6 @@
 package org.example.myapp;
 
-import io.avaje.inject.test.InjectExtension;
+import io.avaje.inject.test.InjectJunitExtension;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_injectLocalMock_Test.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_injectLocalMock_Test.java
@@ -10,7 +10,7 @@ import org.mockito.Mock;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(InjectExtension.class)
+@ExtendWith(InjectJunitExtension.class)
 class InjectExtension_injectLocalMock_Test {
 
   @Inject HelloService helloService;

--- a/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_setupMethodStatic_Test.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_setupMethodStatic_Test.java
@@ -1,7 +1,7 @@
 package org.example.myapp;
 
 import io.avaje.inject.BeanScopeBuilder;
-import io.avaje.inject.test.InjectExtension;
+import io.avaje.inject.test.InjectJunitExtension;
 import io.avaje.inject.test.Setup;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;

--- a/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_setupMethodStatic_Test.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_setupMethodStatic_Test.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(InjectExtension.class)
+@ExtendWith(InjectJunitExtension.class)
 class InjectExtension_setupMethodStatic_Test {
 
   static @Inject HelloService helloService;

--- a/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_setupMethod_Test.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_setupMethod_Test.java
@@ -1,7 +1,7 @@
 package org.example.myapp;
 
 import io.avaje.inject.BeanScopeBuilder;
-import io.avaje.inject.test.InjectExtension;
+import io.avaje.inject.test.InjectJunitExtension;
 import io.avaje.inject.test.Setup;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;

--- a/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_setupMethod_Test.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_setupMethod_Test.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(InjectExtension.class)
+@ExtendWith(InjectJunitExtension.class)
 class InjectExtension_setupMethod_Test {
 
   @Inject

--- a/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_testDoubleViaInject_Test.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_testDoubleViaInject_Test.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@ExtendWith(InjectExtension.class)
+@ExtendWith(InjectJunitExtension.class)
 class InjectExtension_testDoubleViaInject_Test {
 
   @Inject HelloService helloService;

--- a/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_testDoubleViaInject_Test.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_testDoubleViaInject_Test.java
@@ -1,6 +1,6 @@
 package org.example.myapp;
 
-import io.avaje.inject.test.InjectExtension;
+import io.avaje.inject.test.InjectJunitExtension;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_testDoubleViaMock2_Test.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_testDoubleViaMock2_Test.java
@@ -10,7 +10,7 @@ import org.mockito.Mockito;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(InjectExtension.class)
+@ExtendWith(InjectJunitExtension.class)
 class InjectExtension_testDoubleViaMock2_Test {
 
   @Inject HelloService helloService;

--- a/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_testDoubleViaMock2_Test.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_testDoubleViaMock2_Test.java
@@ -1,6 +1,6 @@
 package org.example.myapp;
 
-import io.avaje.inject.test.InjectExtension;
+import io.avaje.inject.test.InjectJunitExtension;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_testDoubleViaMockStatic_Test.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_testDoubleViaMockStatic_Test.java
@@ -10,7 +10,7 @@ import org.mockito.Mockito;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(InjectExtension.class)
+@ExtendWith(InjectJunitExtension.class)
 class InjectExtension_testDoubleViaMockStatic_Test {
 
   static @Inject HelloService helloService;

--- a/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_testDoubleViaMockStatic_Test.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_testDoubleViaMockStatic_Test.java
@@ -1,6 +1,6 @@
 package org.example.myapp;
 
-import io.avaje.inject.test.InjectExtension;
+import io.avaje.inject.test.InjectJunitExtension;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_testDoubleViaMock_Test.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_testDoubleViaMock_Test.java
@@ -9,7 +9,7 @@ import org.mockito.Mock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@ExtendWith(InjectExtension.class)
+@ExtendWith(InjectJunitExtension.class)
 class InjectExtension_testDoubleViaMock_Test {
 
   @Inject HelloService helloService;

--- a/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_testDoubleViaMock_Test.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/InjectExtension_testDoubleViaMock_Test.java
@@ -1,6 +1,6 @@
 package org.example.myapp;
 
-import io.avaje.inject.test.InjectExtension;
+import io.avaje.inject.test.InjectJunitExtension;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/inject-events/src/main/resources/META-INF/services/io.avaje.inject.spi.InjectExtension
+++ b/inject-events/src/main/resources/META-INF/services/io.avaje.inject.spi.InjectExtension
@@ -1,0 +1,1 @@
+io.avaje.inject.events.spi.ObserverManagerPlugin

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
@@ -26,7 +26,7 @@ final class Constants {
   static final String AT_PROXY = "@Proxy";
   static final String AT_GENERATED = "@Generated(\"io.avaje.inject.generator\")";
   static final String AT_GENERATED_COMMENT = "(\"io.avaje.inject.generator\")";
-  static final String META_INF_SPI = "META-INF/services/io.avaje.inject.spi.InjectSPI";
+  static final String META_INF_SPI = "META-INF/services/io.avaje.inject.spi.InjectExtension";
   static final String META_INF_TESTMODULE = "META-INF/services/io.avaje.inject.test.TestModule";
   static final String META_INF_CUSTOM = "META-INF/services/io.avaje.inject.spi.AvajeModule.Custom";
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/LoadServices.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/LoadServices.java
@@ -15,7 +15,7 @@ final class LoadServices {
     // load using older Module
     ServiceLoader.load(Module.class, classLoader).forEach(modules::add);
     // load newer AvajeModule
-    final var iterator = ServiceLoader.load(InjectSPI.class, classLoader).iterator();
+    final var iterator = ServiceLoader.load(InjectExtension.class, classLoader).iterator();
     while (iterator.hasNext()) {
       try {
         final var spi = iterator.next();
@@ -32,7 +32,7 @@ final class LoadServices {
   static List<InjectPlugin> loadPlugins(ClassLoader classLoader) {
     List<InjectPlugin> plugins = new ArrayList<>();
     ServiceLoader.load(Plugin.class, classLoader).forEach(plugins::add);
-    ServiceLoader.load(InjectSPI.class, classLoader).forEach(spi -> {
+    ServiceLoader.load(InjectExtension.class, classLoader).forEach(spi -> {
       if (spi instanceof InjectPlugin) {
         plugins.add((InjectPlugin) spi);
       }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
@@ -33,7 +33,7 @@ final class SimpleModuleWriter {
       " *   module example {\n" +
       " *     requires io.avaje.inject;\n" +
       " *     \n" +
-      " *     provides io.avaje.inject.spi.InjectSPI with %s.%s;\n" +
+      " *     provides io.avaje.inject.spi.InjectExtension with %s.%s;\n" +
       " *     \n" +
       " *   }\n" +
       " * \n" +

--- a/inject-generator/src/main/java/module-info.java
+++ b/inject-generator/src/main/java/module-info.java
@@ -7,7 +7,7 @@ module io.avaje.inject.generator {
 
   requires static io.avaje.prism;
 
-  uses io.avaje.inject.spi.InjectSPI;
+  uses io.avaje.inject.spi.InjectExtension;
   uses io.avaje.inject.spi.Plugin;
   uses io.avaje.inject.spi.Module;
   uses io.avaje.inject.spi.InjectPlugin;

--- a/inject-generator/src/test/java/io/avaje/inject/generator/InjectProcessorTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/InjectProcessorTest.java
@@ -37,7 +37,7 @@ class InjectProcessorTest {
           .sorted(Comparator.reverseOrder())
           .map(Path::toFile)
           .forEach(File::delete);
-      Paths.get("io.avaje.inject.spi.InjectSPI").toAbsolutePath().toFile().delete();
+      Paths.get("io.avaje.inject.spi.InjectExtension").toAbsolutePath().toFile().delete();
     } catch (final Exception e) {
     }
   }

--- a/inject-gradle-plugin/build.gradle
+++ b/inject-gradle-plugin/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'io.avaje.inject'
-version '10.0-RC5'
+version '10.0-RC6'
 
 repositories {
   mavenLocal()

--- a/inject-gradle-plugin/src/main/java/io/avaje/inject/plugin/AvajeInjectPlugin.java
+++ b/inject-gradle-plugin/src/main/java/io/avaje/inject/plugin/AvajeInjectPlugin.java
@@ -5,7 +5,7 @@ import static java.util.stream.Collectors.toList;
 
 import io.avaje.inject.spi.AvajeModule;
 import io.avaje.inject.spi.InjectPlugin;
-import io.avaje.inject.spi.InjectSPI;
+import io.avaje.inject.spi.InjectExtension;
 import io.avaje.inject.spi.Module;
 import org.gradle.api.*;
 
@@ -69,7 +69,11 @@ public class AvajeInjectPlugin implements Plugin<Project> {
 
     List<InjectPlugin> allPlugins = new ArrayList<>();
     ServiceLoader.load(io.avaje.inject.spi.Plugin.class, cl).forEach(allPlugins::add);
-    ServiceLoader.load(io.avaje.inject.spi.InjectPlugin.class, cl).forEach(allPlugins::add);
+    ServiceLoader.load(InjectExtension.class, classLoader).stream()
+        .map(Provider::get)
+        .filter(InjectPlugin.class::isInstance)
+        .map(InjectPlugin.class::cast)
+        .forEach(allPlugins::add);
 
     for (final var plugin : allPlugins) {
       System.out.println("Loaded Plugin: " + plugin.getClass().getCanonicalName());
@@ -92,7 +96,7 @@ public class AvajeInjectPlugin implements Plugin<Project> {
 
     final List<AvajeModule> avajeModules = new ArrayList<>();
     ServiceLoader.load(Module.class, classLoader).forEach(avajeModules::add);
-    ServiceLoader.load(InjectSPI.class, classLoader).stream()
+    ServiceLoader.load(InjectExtension.class, classLoader).stream()
         .map(Provider::get)
         .filter(AvajeModule.class::isInstance)
         .map(AvajeModule.class::cast)

--- a/inject-maven-plugin/pom.xml
+++ b/inject-maven-plugin/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
-      <version>10.0-RC5</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
+++ b/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
@@ -30,8 +30,8 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 
 import io.avaje.inject.spi.AvajeModule;
+import io.avaje.inject.spi.InjectExtension;
 import io.avaje.inject.spi.InjectPlugin;
-import io.avaje.inject.spi.InjectSPI;
 import io.avaje.inject.spi.Module;
 import io.avaje.inject.spi.Plugin;
 
@@ -107,7 +107,7 @@ public class AutoProvidesMojo extends AbstractMojo {
 
     final List<InjectPlugin> plugins = new ArrayList<>();
     ServiceLoader.load(Plugin.class, newClassLoader).forEach(plugins::add);
-    ServiceLoader.load(InjectSPI.class, newClassLoader).stream()
+    ServiceLoader.load(InjectExtension.class, newClassLoader).stream()
         .map(Provider::get)
         .filter(InjectPlugin.class::isInstance)
         .map(InjectPlugin.class::cast)
@@ -135,7 +135,7 @@ public class AutoProvidesMojo extends AbstractMojo {
     final Log log = getLog();
     final List<AvajeModule> avajeModules = new ArrayList<>();
     ServiceLoader.load(Module.class, newClassLoader).forEach(avajeModules::add);
-    ServiceLoader.load(InjectSPI.class, newClassLoader).stream()
+    ServiceLoader.load(InjectExtension.class, newClassLoader).stream()
         .map(Provider::get)
         .filter(AvajeModule.class::isInstance)
         .map(AvajeModule.class::cast)

--- a/inject-test/src/main/java/io/avaje/inject/test/GlobalTestBeans.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/GlobalTestBeans.java
@@ -36,7 +36,7 @@ final class GlobalTestBeans implements ExtensionContext.Store.CloseableResource 
   private void initialise(ExtensionContext context) {
     globalBeans = GlobalInitialise.initialise(false);
     log.log(TRACE, "register global test BeanScope with beans {0}", globalBeans);
-    context.getRoot().getStore(ExtensionContext.Namespace.GLOBAL).put(InjectExtension.class.getCanonicalName(), this);
+    context.getRoot().getStore(ExtensionContext.Namespace.GLOBAL).put(InjectJunitExtension.class.getCanonicalName(), this);
   }
 
   /**

--- a/inject-test/src/main/java/io/avaje/inject/test/InjectJunitExtension.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/InjectJunitExtension.java
@@ -12,7 +12,7 @@ import java.lang.reflect.Method;
  * <p>
  * Supports injection for fields annotated with <code>@Mock, @Spy, @Captor, @Inject</code>.
  */
-public final class InjectExtension implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback {
+public final class InjectJunitExtension implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback {
 
   private static final System.Logger log = AppLog.getLogger("io.avaje.inject");
   private static final Namespace INJECT_NS = Namespace.create("io.avaje.inject.InjectTest");

--- a/inject-test/src/main/java/io/avaje/inject/test/InjectTest.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/InjectTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  *
  * <p>This is a JUnit 5 extension.
  */
-@ExtendWith(InjectExtension.class)
+@ExtendWith(InjectJunitExtension.class)
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface InjectTest {

--- a/inject-test/src/main/java/module-info.java
+++ b/inject-test/src/main/java/module-info.java
@@ -4,12 +4,12 @@ module io.avaje.inject.test {
 
   requires transitive io.avaje.inject;
   requires transitive io.avaje.inject.aop;
+  requires transitive io.avaje.inject.events;
   requires transitive org.junit.jupiter.engine;
   requires transitive org.junit.jupiter.api;
   requires static org.apiguardian.api; // needed for javadoc
   requires transitive org.mockito;
   requires transitive org.mockito.junit.jupiter;
-  requires static io.avaje.inject.events;
 //  requires transitive org.assertj.core;
 //  requires transitive net.bytebuddy;
   requires static java.net.http; // for testing only

--- a/inject-test/src/test/java/org/example/inherit/MyOneTest.java
+++ b/inject-test/src/test/java/org/example/inherit/MyOneTest.java
@@ -1,6 +1,6 @@
 package org.example.inherit;
 
-import io.avaje.inject.test.InjectExtension;
+import io.avaje.inject.test.InjectJunitExtension;
 import jakarta.inject.Inject;
 import org.example.inherit.notpublic.PubExposed;
 import org.junit.jupiter.api.Test;
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(InjectExtension.class)
+@ExtendWith(InjectJunitExtension.class)
 public class MyOneTest extends MyOneAbstract {
 
   @Inject

--- a/inject-test/src/test/java/org/example/injectextension/WithExtnBasicTest.java
+++ b/inject-test/src/test/java/org/example/injectextension/WithExtnBasicTest.java
@@ -1,6 +1,6 @@
 package org.example.injectextension;
 
-import io.avaje.inject.test.InjectExtension;
+import io.avaje.inject.test.InjectJunitExtension;
 import jakarta.inject.Inject;
 import org.example.coffee.CoffeeMaker;
 import org.example.coffee.Pump;
@@ -14,7 +14,7 @@ import org.mockito.Spy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(InjectExtension.class)
+@ExtendWith(InjectJunitExtension.class)
 class WithExtnBasicTest {
 
   @Mock Pump pump;

--- a/inject-test/src/test/java/org/example/injectextension/WithExtnCaptorTest.java
+++ b/inject-test/src/test/java/org/example/injectextension/WithExtnCaptorTest.java
@@ -1,6 +1,6 @@
 package org.example.injectextension;
 
-import io.avaje.inject.test.InjectExtension;
+import io.avaje.inject.test.InjectJunitExtension;
 import jakarta.inject.Inject;
 import org.example.coffee.fruit.AppleService;
 import org.example.coffee.fruit.PeachService;
@@ -13,7 +13,7 @@ import org.mockito.Mock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith(InjectExtension.class)
+@ExtendWith(InjectJunitExtension.class)
 class WithExtnCaptorTest {
 
   ArgumentCaptor<String> plainCaptor = ArgumentCaptor.forClass(String.class);

--- a/inject-test/src/test/java/org/example/injectextension/WithExtnNamedMocksTest.java
+++ b/inject-test/src/test/java/org/example/injectextension/WithExtnNamedMocksTest.java
@@ -1,7 +1,7 @@
 package org.example.injectextension;
 
 import io.avaje.inject.BeanScope;
-import io.avaje.inject.test.InjectExtension;
+import io.avaje.inject.test.InjectJunitExtension;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import org.example.coffee.qualifier.Blue;
@@ -14,7 +14,7 @@ import org.mockito.Mock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(InjectExtension.class)
+@ExtendWith(InjectJunitExtension.class)
 class WithExtnNamedMocksTest {
 
   @Mock @Blue SomeStore blueStore;

--- a/inject-test/src/test/java/org/example/injectextension/WithExtnNamedSpyTest.java
+++ b/inject-test/src/test/java/org/example/injectextension/WithExtnNamedSpyTest.java
@@ -1,7 +1,7 @@
 package org.example.injectextension;
 
 import io.avaje.inject.BeanScope;
-import io.avaje.inject.test.InjectExtension;
+import io.avaje.inject.test.InjectJunitExtension;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import org.example.coffee.qualifier.Blue;
@@ -14,7 +14,7 @@ import org.mockito.Spy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith(InjectExtension.class)
+@ExtendWith(InjectJunitExtension.class)
 class WithExtnNamedSpyTest {
 
   @Spy @Blue

--- a/inject-test/src/test/java/org/example/injectextension/WithExtnPrivateFieldsTest.java
+++ b/inject-test/src/test/java/org/example/injectextension/WithExtnPrivateFieldsTest.java
@@ -1,6 +1,6 @@
 package org.example.injectextension;
 
-import io.avaje.inject.test.InjectExtension;
+import io.avaje.inject.test.InjectJunitExtension;
 import jakarta.inject.Inject;
 import org.example.coffee.CoffeeMaker;
 import org.example.coffee.Pump;
@@ -13,7 +13,7 @@ import org.mockito.Spy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(InjectExtension.class)
+@ExtendWith(InjectJunitExtension.class)
 public class WithExtnPrivateFieldsTest {
 
   @Mock

--- a/inject/src/main/java/io/avaje/inject/DServiceLoader.java
+++ b/inject/src/main/java/io/avaje/inject/DServiceLoader.java
@@ -19,7 +19,7 @@ final class DServiceLoader {
   private PropertyRequiresPlugin propertyPlugin;
 
   DServiceLoader(ClassLoader classLoader) {
-    for (var spi : ServiceLoader.load(InjectSPI.class, classLoader)) {
+    for (var spi : ServiceLoader.load(InjectExtension.class, classLoader)) {
       if (spi instanceof InjectPlugin) {
         plugins.add((InjectPlugin) spi);
       } else if (spi instanceof AvajeModule) {

--- a/inject/src/main/java/io/avaje/inject/spi/AvajeModule.java
+++ b/inject/src/main/java/io/avaje/inject/spi/AvajeModule.java
@@ -5,7 +5,7 @@ import java.lang.reflect.Type;
 /**
  * A AvajeModule that can be included in BeanScope.
  */
-public interface AvajeModule extends InjectSPI {
+public interface AvajeModule extends InjectExtension {
 
   /**
    * Empty array of classes.

--- a/inject/src/main/java/io/avaje/inject/spi/InjectExtension.java
+++ b/inject/src/main/java/io/avaje/inject/spi/InjectExtension.java
@@ -4,4 +4,4 @@ import io.avaje.spi.Service;
 
 /** Superclass for all Inject SPI classes */
 @Service
-public interface InjectSPI {}
+public interface InjectExtension {}

--- a/inject/src/main/java/io/avaje/inject/spi/InjectPlugin.java
+++ b/inject/src/main/java/io/avaje/inject/spi/InjectPlugin.java
@@ -10,7 +10,7 @@ import java.lang.reflect.Type;
  * <p>Typically, a plugin might provide a default dependency via {@link
  * BeanScopeBuilder#provideDefault(Type, java.util.function.Supplier)}.
  */
-public interface InjectPlugin extends InjectSPI {
+public interface InjectPlugin extends InjectExtension {
 
   /**
    * Empty array of classes.

--- a/inject/src/main/java/io/avaje/inject/spi/ModuleOrdering.java
+++ b/inject/src/main/java/io/avaje/inject/spi/ModuleOrdering.java
@@ -6,7 +6,7 @@ import java.util.Set;
 /**
  * Determines Wiring order.
  */
-public interface ModuleOrdering extends InjectSPI {
+public interface ModuleOrdering extends InjectExtension {
 
   /**
    * Order the factories, returning the ordered list of module names.

--- a/inject/src/main/java/io/avaje/inject/spi/PropertyRequiresPlugin.java
+++ b/inject/src/main/java/io/avaje/inject/spi/PropertyRequiresPlugin.java
@@ -12,7 +12,7 @@ import io.avaje.lang.NonNullApi;
  * System#getProperty(String)} and {@link System#getenv(String)}.
  */
 @NonNullApi
-public interface PropertyRequiresPlugin extends InjectSPI {
+public interface PropertyRequiresPlugin extends InjectExtension {
 
   /**
    * Return a configuration value that might not exist.

--- a/inject/src/main/java/module-info.java
+++ b/inject/src/main/java/module-info.java
@@ -10,7 +10,7 @@ module io.avaje.inject {
   requires static org.mockito;
   requires static io.avaje.spi;
 
-  uses io.avaje.inject.spi.InjectSPI;
+  uses io.avaje.inject.spi.InjectExtension;
   uses io.avaje.inject.spi.Module;
   uses io.avaje.inject.spi.Plugin;
 


### PR DESCRIPTION
This one's just an aesthetic change I guess if we think `InjectSPI` is too simplistic 

- Rename InjectSPI to InjectExtension
- Rename the existing `InjectExtension` to `InjectJunitExtension`