### PR TITLE
Refactor rename AvajeModule interface to InjectModule

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Constants.java
@@ -28,7 +28,7 @@ final class Constants {
   static final String AT_GENERATED_COMMENT = "(\"io.avaje.inject.generator\")";
   static final String META_INF_SPI = "META-INF/services/io.avaje.inject.spi.InjectExtension";
   static final String META_INF_TESTMODULE = "META-INF/services/io.avaje.inject.test.TestModule";
-  static final String META_INF_CUSTOM = "META-INF/services/io.avaje.inject.spi.AvajeModule.Custom";
+  static final String META_INF_CUSTOM = "META-INF/services/io.avaje.inject.spi.InjectModule.Custom";
 
   static final String BEANSCOPE = "io.avaje.inject.BeanScope";
   static final String INJECTMODULE = "io.avaje.inject.InjectModule";
@@ -53,7 +53,7 @@ final class Constants {
   static final String BEAN_FACTORY2 = "io.avaje.inject.spi.BeanFactory2";
   static final String BUILDER = "io.avaje.inject.spi.Builder";
   static final String DEPENDENCYMETA = "io.avaje.inject.spi.DependencyMeta";
-  static final String MODULE = "io.avaje.inject.spi.AvajeModule";
+  static final String MODULE = "io.avaje.inject.spi.InjectModule";
   static final String GENERICTYPE = "io.avaje.inject.spi.GenericType";
 
   static final String CONDITIONAL_DEPENDENCY = "con:";

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -18,7 +18,7 @@ import java.util.Set;
 
 import javax.tools.StandardLocation;
 
-import io.avaje.inject.spi.AvajeModule;
+import io.avaje.inject.spi.InjectModule;
 import io.avaje.inject.spi.InjectPlugin;
 
 /**
@@ -64,7 +64,7 @@ final class ExternalProvider {
       return;
     }
 
-    List<AvajeModule> modules = LoadServices.loadModules(CLASS_LOADER);
+    List<InjectModule> modules = LoadServices.loadModules(CLASS_LOADER);
     if (modules.isEmpty()) {
       APContext.logNote("No external modules detected");
       return;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/LoadServices.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/LoadServices.java
@@ -10,17 +10,17 @@ import java.util.ServiceLoader;
 
 final class LoadServices {
 
-  static List<AvajeModule> loadModules(ClassLoader classLoader) {
-    List<AvajeModule> modules = new ArrayList<>();
+  static List<InjectModule> loadModules(ClassLoader classLoader) {
+    List<InjectModule> modules = new ArrayList<>();
     // load using older Module
     ServiceLoader.load(Module.class, classLoader).forEach(modules::add);
-    // load newer AvajeModule
+    // load newer InjectModule
     final var iterator = ServiceLoader.load(InjectExtension.class, classLoader).iterator();
     while (iterator.hasNext()) {
       try {
         final var spi = iterator.next();
-        if (spi instanceof AvajeModule) {
-          modules.add((AvajeModule) spi);
+        if (spi instanceof InjectModule) {
+          modules.add((InjectModule) spi);
         }
       } catch (final ServiceConfigurationError expected) {
         // ignore expected error reading the module that we are also writing

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -57,7 +57,7 @@ final class ProcessingContext {
 
   private static boolean isInjectModule(String spi) {
     var moduleType = APContext.typeElement(spi);
-    return moduleType != null && moduleType.getSuperclass().toString().contains("AvajeModule");
+    return moduleType != null && moduleType.getSuperclass().toString().contains("InjectModule");
   }
 
   static List<String> loadMetaInfCustom() {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -26,11 +26,11 @@ final class ScopeInfo {
     /**
      * Default scope.
      */
-    DEFAULT("AvajeModule"),
+    DEFAULT("io.avaje.inject.spi.InjectModule"),
     /**
      * Custom scope.
      */
-    CUSTOM("AvajeModule.Custom"),
+    CUSTOM("io.avaje.inject.spi.InjectModule.Custom"),
     /**
      * Built-in Test scope.
      */

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
@@ -211,7 +211,6 @@ final class SimpleModuleWriter {
     importTypes.add(Constants.BEANSCOPE);
     importTypes.add(Constants.INJECTMODULE);
     importTypes.add(Constants.DEPENDENCYMETA);
-    importTypes.add(Constants.MODULE);
     importTypes.add(Constants.BUILDER);
     return importTypes;
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleOrderWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleOrderWriter.java
@@ -51,7 +51,7 @@ final class SimpleOrderWriter {
           + "import java.util.Set;\n"
           + "import io.avaje.inject.spi.Generated;\n"
           + "import io.avaje.inject.spi.ModuleOrdering;\n"
-          + "import io.avaje.inject.spi.AvajeModule;")
+          + "import io.avaje.inject.spi.InjectModule;")
       .eol();
 
     writer.eol();
@@ -67,7 +67,7 @@ final class SimpleOrderWriter {
     writer.append(Constants.AT_GENERATED).eol();
     writer.append("public final class %s implements ModuleOrdering {", shortName).eol().eol();
 
-    writer.append("  private final AvajeModule[] sortedModules = new AvajeModule[%s];", ordering.size()).eol();
+    writer.append("  private final InjectModule[] sortedModules = new InjectModule[%s];", ordering.size()).eol();
     writer.append("  private static final Map<String, Integer> INDEXES = Map.ofEntries(").eol();
     var size = ordering.size();
     var count = 0;
@@ -85,7 +85,7 @@ final class SimpleOrderWriter {
     writer.append(
       "\n"
         + "  @Override\n"
-        + "  public List<AvajeModule> factories() {\n"
+        + "  public List<InjectModule> factories() {\n"
         + "    return List.of(sortedModules);\n"
         + "  }\n"
         + "\n"
@@ -95,7 +95,7 @@ final class SimpleOrderWriter {
         + "  }\n"
         + "\n"
         + "  @Override\n"
-        + "  public void add(AvajeModule module) {\n"
+        + "  public void add(InjectModule module) {\n"
         + "    final var index = INDEXES.get(module.getClass().getTypeName());\n"
         + "    if (index != null) {\n"
         + "      sortedModules[index] = module;\n"

--- a/inject-generator/src/main/java/module-info.java
+++ b/inject-generator/src/main/java/module-info.java
@@ -1,3 +1,5 @@
+import io.avaje.inject.spi.InjectModule;
+
 module io.avaje.inject.generator {
 
   requires java.compiler;
@@ -11,7 +13,7 @@ module io.avaje.inject.generator {
   uses io.avaje.inject.spi.Plugin;
   uses io.avaje.inject.spi.Module;
   uses io.avaje.inject.spi.InjectPlugin;
-  uses io.avaje.inject.spi.AvajeModule;
+  uses InjectModule;
 
   provides javax.annotation.processing.Processor with io.avaje.inject.generator.InjectProcessor;
 }

--- a/inject-gradle-plugin/src/main/java/io/avaje/inject/plugin/AvajeInjectPlugin.java
+++ b/inject-gradle-plugin/src/main/java/io/avaje/inject/plugin/AvajeInjectPlugin.java
@@ -3,7 +3,7 @@ package io.avaje.inject.plugin;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
-import io.avaje.inject.spi.AvajeModule;
+import io.avaje.inject.spi.InjectModule;
 import io.avaje.inject.spi.InjectPlugin;
 import io.avaje.inject.spi.InjectExtension;
 import io.avaje.inject.spi.Module;
@@ -94,12 +94,12 @@ public class AvajeInjectPlugin implements Plugin<Project> {
   private void writeProvidedModules(ClassLoader classLoader, FileWriter moduleWriter) throws IOException {
     final Set<String> providedTypes = new HashSet<>();
 
-    final List<AvajeModule> avajeModules = new ArrayList<>();
+    final List<InjectModule> avajeModules = new ArrayList<>();
     ServiceLoader.load(Module.class, classLoader).forEach(avajeModules::add);
     ServiceLoader.load(InjectExtension.class, classLoader).stream()
         .map(Provider::get)
-        .filter(AvajeModule.class::isInstance)
-        .map(AvajeModule.class::cast)
+        .filter(InjectModule.class::isInstance)
+        .map(InjectModule.class::cast)
         .forEach(avajeModules::add);
 
     for (final var module : avajeModules) {

--- a/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
+++ b/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
@@ -29,7 +29,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 
-import io.avaje.inject.spi.AvajeModule;
+import io.avaje.inject.spi.InjectModule;
 import io.avaje.inject.spi.InjectExtension;
 import io.avaje.inject.spi.InjectPlugin;
 import io.avaje.inject.spi.Module;
@@ -133,12 +133,12 @@ public class AutoProvidesMojo extends AbstractMojo {
     final Set<String> providedTypes = new HashSet<>();
 
     final Log log = getLog();
-    final List<AvajeModule> avajeModules = new ArrayList<>();
+    final List<InjectModule> avajeModules = new ArrayList<>();
     ServiceLoader.load(Module.class, newClassLoader).forEach(avajeModules::add);
     ServiceLoader.load(InjectExtension.class, newClassLoader).stream()
         .map(Provider::get)
-        .filter(AvajeModule.class::isInstance)
-        .map(AvajeModule.class::cast)
+        .filter(InjectModule.class::isInstance)
+        .map(InjectModule.class::cast)
         .forEach(avajeModules::add);
     for (final var module : avajeModules) {
       final var name = module.getClass().getTypeName();

--- a/inject-test/src/main/java/io/avaje/inject/test/GlobalInitialise.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/GlobalInitialise.java
@@ -1,7 +1,7 @@
 package io.avaje.inject.test;
 
 import io.avaje.inject.BeanScope;
-import io.avaje.inject.spi.AvajeModule;
+import io.avaje.inject.spi.InjectModule;
 import io.avaje.lang.Nullable;
 
 import java.io.IOException;
@@ -81,7 +81,7 @@ final class GlobalInitialise {
 
   private BeanScope buildFromModules(List<TestModule> testModules) {
     return BeanScope.builder()
-      .modules(testModules.toArray(AvajeModule[]::new))
+      .modules(testModules.toArray(InjectModule[]::new))
       .shutdownHook(shutdownHook)
       .build();
   }

--- a/inject-test/src/main/java/io/avaje/inject/test/TestModule.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/TestModule.java
@@ -1,9 +1,9 @@
 package io.avaje.inject.test;
 
-import io.avaje.inject.spi.AvajeModule;
+import io.avaje.inject.spi.InjectModule;
 
 /**
  * Marker for Test scope module.
  */
-public interface TestModule extends AvajeModule.Custom {
+public interface TestModule extends InjectModule.Custom {
 }

--- a/inject-test/src/test/java/org/example/coffee/BeanScopeBuilderAddTest.java
+++ b/inject-test/src/test/java/org/example/coffee/BeanScopeBuilderAddTest.java
@@ -2,7 +2,7 @@ package org.example.coffee;
 
 import io.avaje.inject.BeanScope;
 import io.avaje.inject.spi.Builder;
-import io.avaje.inject.spi.AvajeModule;
+import io.avaje.inject.spi.InjectModule;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -28,7 +28,7 @@ public class BeanScopeBuilderAddTest {
     }
   }
 
-  public static class SillyModule implements AvajeModule {
+  public static class SillyModule implements InjectModule {
 
     @Override
     public Class<?>[] requires() {

--- a/inject-test/src/test/java/org/example/custom2/ParentScopeSpyTest.java
+++ b/inject-test/src/test/java/org/example/custom2/ParentScopeSpyTest.java
@@ -2,7 +2,7 @@ package org.example.custom2;
 
 import io.avaje.inject.BeanScope;
 import io.avaje.inject.spi.Builder;
-import io.avaje.inject.spi.AvajeModule;
+import io.avaje.inject.spi.InjectModule;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -64,7 +64,7 @@ class ParentScopeSpyTest {
     }
   }
 
-  static class MyTestModule implements AvajeModule.Custom {
+  static class MyTestModule implements InjectModule.Custom {
 
     private final Class<?>[] provides = new Class<?>[]{};
     private final Class<?>[] requires = new Class<?>[]{};

--- a/inject/README.md
+++ b/inject/README.md
@@ -4,13 +4,14 @@ APT based dependency injection for server side developers - https://avaje.io/inj
 ### Example module use
 
 ```java
-import io.avaje.inject.spi.AvajeModule;
+import io.avaje.inject.spi.InjectModule;
+import io.avaje.inject.spi.InjectModule;
 
 module org.example {
 
-    requires io.avaje.inject;
+  requires io.avaje.inject;
 
-    provides io.avaje.inject.spi.AvajeModule with org.example.ExampleModule;
+  provides InjectModule with org.example.ExampleModule;
 }
 ```
 

--- a/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/BeanScopeBuilder.java
@@ -1,6 +1,6 @@
 package io.avaje.inject;
 
-import io.avaje.inject.spi.AvajeModule;
+import io.avaje.inject.spi.InjectModule;
 import io.avaje.inject.spi.ConfigPropertyPlugin;
 import io.avaje.inject.spi.PropertyRequiresPlugin;
 import io.avaje.lang.NonNullApi;
@@ -78,7 +78,7 @@ public interface BeanScopeBuilder {
    * @param modules The modules that we want to include in dependency injection.
    * @return This BeanScopeBuilder
    */
-  BeanScopeBuilder modules(AvajeModule... modules);
+  BeanScopeBuilder modules(InjectModule... modules);
 
   /**
    * Return the PropertyRequiresPlugin used for this scope. This is useful for plugins that want to

--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -16,6 +16,7 @@ import java.util.function.Supplier;
 
 import io.avaje.applog.AppLog;
 import io.avaje.inject.spi.*;
+import io.avaje.inject.spi.InjectModule;
 import io.avaje.lang.NonNullApi;
 import io.avaje.lang.Nullable;
 import jakarta.inject.Provider;
@@ -29,7 +30,7 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
   private final List<SuppliedBean> suppliedBeans = new ArrayList<>();
   @SuppressWarnings("rawtypes")
   private final List<EnrichBean> enrichBeans = new ArrayList<>();
-  private final Set<AvajeModule> includeModules = new LinkedHashSet<>();
+  private final Set<InjectModule> includeModules = new LinkedHashSet<>();
   private final List<Runnable> postConstructList = new ArrayList<>();
   private final List<Consumer<BeanScope>> postConstructConsumerList = new ArrayList<>();
   private final List<ClosePair> preDestroyList = new ArrayList<>();
@@ -55,7 +56,7 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
   }
 
   @Override
-  public BeanScopeBuilder modules(AvajeModule... modules) {
+  public BeanScopeBuilder modules(InjectModule... modules) {
     this.includeModules.addAll(Arrays.asList(modules));
     return this;
   }
@@ -307,23 +308,23 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
     private final BeanScope parent;
     private final boolean suppliedBeans;
     private final Set<String> moduleNames = new LinkedHashSet<>();
-    private final List<AvajeModule> factories = new ArrayList<>();
+    private final List<InjectModule> factories = new ArrayList<>();
     private final List<FactoryState> queue = new ArrayList<>();
     private final List<FactoryState> queueNoDependencies = new ArrayList<>();
 
     private final Map<String, FactoryList> providesMap = new HashMap<>();
 
-    FactoryOrder(BeanScope parent, Set<AvajeModule> includeModules, boolean suppliedBeans) {
+    FactoryOrder(BeanScope parent, Set<InjectModule> includeModules, boolean suppliedBeans) {
       this.parent = parent;
       this.factories.addAll(includeModules);
       this.suppliedBeans = suppliedBeans;
-      for (final AvajeModule includeModule : includeModules) {
+      for (final InjectModule includeModule : includeModules) {
         moduleNames.add(includeModule.getClass().getName());
       }
     }
 
     @Override
-    public void add(AvajeModule module) {
+    public void add(InjectModule module) {
       final var factoryState = new FactoryState(module);
       providesMap
         .computeIfAbsent(module.getClass().getTypeName(), s -> new FactoryList())
@@ -372,7 +373,7 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
     }
 
     @Override
-    public List<AvajeModule> factories() {
+    public List<InjectModule> factories() {
       return factories;
     }
 
@@ -468,10 +469,10 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
   /** Wrapper on Factory holding the pushed state. */
   private static class FactoryState {
 
-    private final AvajeModule factory;
+    private final InjectModule factory;
     private boolean pushed;
 
-    private FactoryState(AvajeModule factory) {
+    private FactoryState(InjectModule factory) {
       this.factory = factory;
     }
 
@@ -484,7 +485,7 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
       return pushed;
     }
 
-    AvajeModule factory() {
+    InjectModule factory() {
       return factory;
     }
 

--- a/inject/src/main/java/io/avaje/inject/DServiceLoader.java
+++ b/inject/src/main/java/io/avaje/inject/DServiceLoader.java
@@ -1,6 +1,7 @@
 package io.avaje.inject;
 
 import io.avaje.inject.spi.*;
+import io.avaje.inject.spi.InjectModule;
 import io.avaje.inject.spi.Module;
 
 import java.util.ArrayList;
@@ -14,7 +15,7 @@ import java.util.ServiceLoader;
 final class DServiceLoader {
 
   private final List<InjectPlugin> plugins = new ArrayList<>();
-  private final List<AvajeModule> modules = new ArrayList<>();
+  private final List<InjectModule> modules = new ArrayList<>();
   private ModuleOrdering moduleOrdering;
   private ConfigPropertyPlugin propertyPlugin;
 
@@ -22,8 +23,8 @@ final class DServiceLoader {
     for (var spi : ServiceLoader.load(InjectExtension.class, classLoader)) {
       if (spi instanceof InjectPlugin) {
         plugins.add((InjectPlugin) spi);
-      } else if (spi instanceof AvajeModule) {
-        modules.add((AvajeModule) spi);
+      } else if (spi instanceof InjectModule) {
+        modules.add((InjectModule) spi);
       } else if (spi instanceof ModuleOrdering) {
         moduleOrdering = (ModuleOrdering) spi;
       } else if (spi instanceof ConfigPropertyPlugin) {
@@ -39,7 +40,7 @@ final class DServiceLoader {
     return plugins;
   }
 
-  List<AvajeModule> modules() {
+  List<InjectModule> modules() {
     return modules;
   }
 

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -280,5 +280,5 @@ public interface Builder {
   /**
    * Set the current module being wired.
    */
-  void currentModule(Class<? extends AvajeModule> currentModule);
+  void currentModule(Class<? extends InjectModule> currentModule);
 }

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
@@ -24,12 +24,12 @@ final class DBeanMap {
   private final Set<String> qualifiers = new HashSet<>();
 
   private NextBean nextBean;
-  private Class<? extends AvajeModule> currentModule;
+  private Class<? extends InjectModule> currentModule;
 
   DBeanMap() {
   }
 
-  void currentModule(Class<? extends AvajeModule> currentModule) {
+  void currentModule(Class<? extends InjectModule> currentModule) {
     this.currentModule = currentModule;
   }
 

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -44,7 +44,7 @@ class DBuilder implements Builder {
   }
 
   @Override
-  public void currentModule(Class<? extends AvajeModule> currentModule) {
+  public void currentModule(Class<? extends InjectModule> currentModule) {
     beanMap.currentModule(currentModule);
   }
 

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
@@ -29,7 +29,7 @@ final class DContextEntry {
     entries.add(entryBean);
   }
 
-  Provider<?> provider(String name, Class<? extends AvajeModule> currentModule) {
+  Provider<?> provider(String name, Class<? extends InjectModule> currentModule) {
     if (entries.size() == 1) {
       return entries.get(0).provider();
     }
@@ -46,7 +46,7 @@ final class DContextEntry {
     return new EntryMatcher(name, null).match(entries);
   }
 
-  Object get(String name, Class<? extends AvajeModule> currentModule) {
+  Object get(String name, Class<? extends InjectModule> currentModule) {
     if (entries.size() == 1) {
       return entries.get(0).bean();
     }
@@ -96,11 +96,11 @@ final class DContextEntry {
 
     private final String name;
     private final boolean impliedName;
-    private final Class<? extends AvajeModule> currentModule;
+    private final Class<? extends InjectModule> currentModule;
     private DContextEntryBean match;
     private DContextEntryBean ignoredSecondaryMatch;
 
-    EntryMatcher(String name, Class<? extends AvajeModule> currentModule) {
+    EntryMatcher(String name, Class<? extends InjectModule> currentModule) {
       this.currentModule = currentModule;
       if (name != null && name.startsWith("!")) {
         this.name = name.substring(1);

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntryBean.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntryBean.java
@@ -13,7 +13,7 @@ class DContextEntryBean {
   /**
    * Create taking into account if it is a Provider or the bean itself.
    */
-  static DContextEntryBean of(Object source, String name, int flag, Class<? extends AvajeModule> currentModule) {
+  static DContextEntryBean of(Object source, String name, int flag, Class<? extends InjectModule> currentModule) {
     if (source instanceof Provider) {
       return new ProtoProvider((Provider<?>)source, name, flag, currentModule);
     } else {
@@ -32,16 +32,16 @@ class DContextEntryBean {
     }
   }
 
-  static DContextEntryBean provider(boolean prototype, Provider<?> provider, String name, int flag, Class<? extends AvajeModule> currentModule) {
+  static DContextEntryBean provider(boolean prototype, Provider<?> provider, String name, int flag, Class<? extends InjectModule> currentModule) {
     return prototype ? new ProtoProvider(provider, name, flag, currentModule) : new OnceProvider(provider, name, flag, currentModule);
   }
 
   protected final Object source;
   protected final String name;
-  protected final Class<? extends AvajeModule> sourceModule;
+  protected final Class<? extends InjectModule> sourceModule;
   private final int flag;
 
-  private DContextEntryBean(Object source, String name, int flag, Class<? extends AvajeModule> currentModule) {
+  private DContextEntryBean(Object source, String name, int flag, Class<? extends InjectModule> currentModule) {
     this.source = source;
     this.name = name;
     this.flag = flag;
@@ -76,7 +76,7 @@ class DContextEntryBean {
     return qualifierName == null ? name == null : qualifierName.equalsIgnoreCase(name);
   }
 
-  final Class<? extends AvajeModule> sourceModule() {
+  final Class<? extends InjectModule> sourceModule() {
     return sourceModule;
   }
 
@@ -122,7 +122,7 @@ class DContextEntryBean {
 
     private final Provider<?> provider;
 
-    private ProtoProvider(Provider<?> provider, String name, int flag, Class<? extends AvajeModule> currentModule) {
+    private ProtoProvider(Provider<?> provider, String name, int flag, Class<? extends InjectModule> currentModule) {
       super(provider, name, flag, currentModule);
       this.provider = provider;
     }
@@ -147,7 +147,7 @@ class DContextEntryBean {
     private final Provider<?> provider;
     private Object bean;
 
-    private OnceProvider(Provider<?> provider, String name, int flag, Class<? extends AvajeModule> currentModule) {
+    private OnceProvider(Provider<?> provider, String name, int flag, Class<? extends InjectModule> currentModule) {
       super(provider, name, flag, currentModule);
       this.provider = provider;
     }

--- a/inject/src/main/java/io/avaje/inject/spi/InjectModule.java
+++ b/inject/src/main/java/io/avaje/inject/spi/InjectModule.java
@@ -5,7 +5,7 @@ import java.lang.reflect.Type;
 /**
  * A AvajeModule that can be included in BeanScope.
  */
-public interface AvajeModule extends InjectExtension {
+public interface InjectModule extends InjectExtension {
 
   /**
    * Empty array of classes.
@@ -37,7 +37,7 @@ public interface AvajeModule extends InjectExtension {
    * Return the classes that this module provides that we allow other modules to auto depend on.
    *
    * <p>This is a convenience when using multiple modules that is otherwise controlled manually by
-   * explicitly using {@link AvajeModule#provides()}.
+   * explicitly using {@link InjectModule#provides()}.
    */
   default Type[] autoProvides() {
     return EMPTY_CLASSES;
@@ -47,7 +47,7 @@ public interface AvajeModule extends InjectExtension {
    * Return the aspects that this module provides.
    *
    * <p>This is a convenience when using multiple modules that we otherwise manually specify via
-   * {@link AvajeModule#provides()}.
+   * {@link InjectModule#provides()}.
    */
   default Class<?>[] autoProvidesAspects() {
     return EMPTY_CLASSES;
@@ -58,7 +58,7 @@ public interface AvajeModule extends InjectExtension {
    * modules (that are in the classpath at compile time).
    *
    * <p>This is a convenience when using multiple modules that is otherwise controlled manually by
-   * explicitly using {@link AvajeModule#requires()} or {@link AvajeModule#requiresPackages()}.
+   * explicitly using {@link InjectModule#requires()} or {@link InjectModule#requiresPackages()}.
    */
   default Type[] autoRequires() {
     return EMPTY_CLASSES;
@@ -88,6 +88,6 @@ public interface AvajeModule extends InjectExtension {
   /**
    * Marker for custom scoped modules.
    */
-  interface Custom extends AvajeModule {
+  interface Custom extends InjectModule {
   }
 }

--- a/inject/src/main/java/io/avaje/inject/spi/Module.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Module.java
@@ -1,16 +1,12 @@
 package io.avaje.inject.spi;
 
-import java.lang.reflect.Type;
-
-import io.avaje.inject.InjectModule;
-
 /**
  * A Module that can be included in BeanScope.
  *
- * @deprecated migrate to {@link AvajeModule}
+ * @deprecated migrate to {@link InjectModule}
  */
 @Deprecated(forRemoval = true)
-public interface Module extends AvajeModule {
+public interface Module extends InjectModule {
 
   /**
    * Return the set of types this module explicitly provides to other modules.
@@ -40,7 +36,7 @@ public interface Module extends AvajeModule {
    * Return the classes that this module provides that we allow other modules to auto depend on.
    * <p>
    * This is a convenience when using multiple modules that is otherwise controlled manually by
-   * explicitly using {@link InjectModule#provides()}.
+   * explicitly using {@link io.avaje.inject.InjectModule#provides()}.
    */
   @Override
   default Class<?>[] autoProvides() {
@@ -51,7 +47,7 @@ public interface Module extends AvajeModule {
    * Return the aspects that this module provides.
    * <p>
    * This is a convenience when using multiple modules that we otherwise manually specify via
-   * {@link InjectModule#provides()}.
+   * {@link io.avaje.inject.InjectModule#provides()}.
    */
   @Override
   default Class<?>[] autoProvidesAspects() {
@@ -63,7 +59,7 @@ public interface Module extends AvajeModule {
    * external modules (that are in the classpath at compile time).
    * <p>
    * This is a convenience when using multiple modules that is otherwise controlled manually by
-   * explicitly using {@link InjectModule#requires()} or {@link InjectModule#requiresPackages()}.
+   * explicitly using {@link io.avaje.inject.InjectModule#requires()} or {@link io.avaje.inject.InjectModule#requiresPackages()}.
    */
   @Override
   default Class<?>[] autoRequires() {

--- a/inject/src/main/java/io/avaje/inject/spi/ModuleOrdering.java
+++ b/inject/src/main/java/io/avaje/inject/spi/ModuleOrdering.java
@@ -16,7 +16,7 @@ public interface ModuleOrdering extends InjectExtension {
   /**
    * The list of factories in the order they should be built.
    */
-  List<AvajeModule> factories();
+  List<InjectModule> factories();
 
   /**
    * Whether no modules are available
@@ -26,5 +26,5 @@ public interface ModuleOrdering extends InjectExtension {
   /**
    * Accept a module for ordering
    */
-  void add(AvajeModule module);
+  void add(InjectModule module);
 }

--- a/inject/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
+++ b/inject/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
@@ -1,6 +1,6 @@
 package io.avaje.inject;
 
-import static io.avaje.inject.spi.AvajeModule.EMPTY_CLASSES;
+import static io.avaje.inject.spi.InjectModule.EMPTY_CLASSES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -12,9 +12,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import io.avaje.inject.spi.InjectModule;
 import org.junit.jupiter.api.Test;
 
-import io.avaje.inject.spi.AvajeModule;
 import io.avaje.inject.spi.Builder;
 import io.avaje.inject.spi.GenericType;
 
@@ -179,9 +179,9 @@ class BeanScopeBuilderTest {
       .hasMessageContaining("has unsatisfied requires [io.avaje.inject.BeanScopeBuilderTest$Mod3] ");
   }
 
-  private List<String> names(List<AvajeModule> factories) {
+  private List<String> names(List<InjectModule> factories) {
     return factories.stream()
-      .map(AvajeModule::toString)
+      .map(InjectModule::toString)
       .collect(Collectors.toList());
   }
 
@@ -193,7 +193,7 @@ class BeanScopeBuilderTest {
     return new TDModule(name, provides, requires, requiresPkg);
   }
 
-  private static class TDModule implements AvajeModule {
+  private static class TDModule implements InjectModule {
 
     final String name;
     final Type[] provides;

--- a/inject/src/test/java/io/avaje/inject/LegacyBeanScopeBuilderTest.java
+++ b/inject/src/test/java/io/avaje/inject/LegacyBeanScopeBuilderTest.java
@@ -1,6 +1,6 @@
 package io.avaje.inject;
 
-import static io.avaje.inject.spi.AvajeModule.EMPTY_CLASSES;
+import static io.avaje.inject.spi.InjectModule.EMPTY_CLASSES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -12,9 +12,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import io.avaje.inject.spi.InjectModule;
 import org.junit.jupiter.api.Test;
 
-import io.avaje.inject.spi.AvajeModule;
 import io.avaje.inject.spi.Builder;
 import io.avaje.inject.spi.Module;
 
@@ -185,8 +185,8 @@ class LegacyBeanScopeBuilderTest {
             "has unsatisfied requires [io.avaje.inject.LegacyBeanScopeBuilderTest$Mod3] ");
   }
 
-  private List<String> names(List<AvajeModule> factories) {
-    return factories.stream().map(AvajeModule::toString).collect(Collectors.toList());
+  private List<String> names(List<InjectModule> factories) {
+    return factories.stream().map(InjectModule::toString).collect(Collectors.toList());
   }
 
   private TDModule bc(String name, Class<?>[] provides, Class<?>[] requires) {

--- a/inject/src/test/java/io/avaje/inject/spi/DContextEntryTest.java
+++ b/inject/src/test/java/io/avaje/inject/spi/DContextEntryTest.java
@@ -99,16 +99,16 @@ class DContextEntryTest {
   void getWithName_when_currentModule() {
 
     DContextEntry entry = new DContextEntry();
-    entry.add(DContextEntryBean.of("N1", "same", BeanEntry.NORMAL, AvajeModule.class));
+    entry.add(DContextEntryBean.of("N1", "same", BeanEntry.NORMAL, InjectModule.class));
     entry.add(DContextEntryBean.of("N2", "same", BeanEntry.NORMAL, null));
     entry.add(DContextEntryBean.of("N3", "same", BeanEntry.NORMAL, OtherModule.class));
 
     assertEquals(entry.get("same", null), "N2");
-    assertEquals(entry.get("same", AvajeModule.class), "N1");
+    assertEquals(entry.get("same", InjectModule.class), "N1");
     assertEquals(entry.get("same", OtherModule.class), "N3");
 
     assertEquals(entry.get(null, null), "N2");
-    assertEquals(entry.get(null, AvajeModule.class), "N1");
+    assertEquals(entry.get(null, InjectModule.class), "N1");
     assertEquals(entry.get(null, OtherModule.class), "N3");
   }
 
@@ -116,16 +116,16 @@ class DContextEntryTest {
   void getWithoutName_when_currentModule() {
 
     DContextEntry entry = new DContextEntry();
-    entry.add(DContextEntryBean.of("N1", null, BeanEntry.NORMAL, AvajeModule.class));
+    entry.add(DContextEntryBean.of("N1", null, BeanEntry.NORMAL, InjectModule.class));
     entry.add(DContextEntryBean.of("N2", null, BeanEntry.NORMAL, null));
     entry.add(DContextEntryBean.of("N3", null, BeanEntry.NORMAL, OtherModule.class));
 
     assertEquals(entry.get(null, null), "N2");
-    assertEquals(entry.get(null, AvajeModule.class), "N1");
+    assertEquals(entry.get(null, InjectModule.class), "N1");
     assertEquals(entry.get(null, OtherModule.class), "N3");
 
     assertNull(entry.get("notThere", null));
-    assertNull(entry.get("notThere", AvajeModule.class));
+    assertNull(entry.get("notThere", InjectModule.class));
     assertNull(entry.get("notThere", OtherModule.class));
   }
 
@@ -133,12 +133,12 @@ class DContextEntryTest {
   void getWithName_expect_matchOnName() {
 
     DContextEntry entry = new DContextEntry();
-    entry.add(DContextEntryBean.of("N1", "same", BeanEntry.NORMAL, AvajeModule.class));
+    entry.add(DContextEntryBean.of("N1", "same", BeanEntry.NORMAL, InjectModule.class));
     entry.add(DContextEntryBean.of("N2", null, BeanEntry.NORMAL, null));
     entry.add(DContextEntryBean.of("N3", null, BeanEntry.NORMAL, OtherModule.class));
 
     assertEquals(entry.get("same", null), "N1");
-    assertEquals(entry.get("same", AvajeModule.class), "N1");
+    assertEquals(entry.get("same", InjectModule.class), "N1");
     assertEquals(entry.get("same", OtherModule.class), "N1");
   }
 
@@ -146,12 +146,12 @@ class DContextEntryTest {
   void getWithoutName_expect_matchOnNoName() {
 
     DContextEntry entry = new DContextEntry();
-    entry.add(DContextEntryBean.of("N1", null, BeanEntry.NORMAL, AvajeModule.class));
+    entry.add(DContextEntryBean.of("N1", null, BeanEntry.NORMAL, InjectModule.class));
     entry.add(DContextEntryBean.of("N2", "same", BeanEntry.NORMAL, null));
     entry.add(DContextEntryBean.of("N3", "same", BeanEntry.NORMAL, OtherModule.class));
 
     assertEquals(entry.get(null, null), "N1");
-    assertEquals(entry.get(null, AvajeModule.class), "N1");
+    assertEquals(entry.get(null, InjectModule.class), "N1");
     assertEquals(entry.get(null, OtherModule.class), "N1");
   }
 
@@ -159,11 +159,11 @@ class DContextEntryTest {
   void when_noQualifier_expect_matchedToNoQualider() {
 
     DContextEntry entry = new DContextEntry();
-    entry.add(DContextEntryBean.of("N1", null, BeanEntry.NORMAL, AvajeModule.class));
-    entry.add(DContextEntryBean.of("N2", "myName", BeanEntry.NORMAL, AvajeModule.class));
+    entry.add(DContextEntryBean.of("N1", null, BeanEntry.NORMAL, InjectModule.class));
+    entry.add(DContextEntryBean.of("N2", "myName", BeanEntry.NORMAL, InjectModule.class));
 
-    assertEquals(entry.get("myName", AvajeModule.class), "N2");
-    assertEquals(entry.get(null, AvajeModule.class), "N1");
+    assertEquals(entry.get("myName", InjectModule.class), "N2");
+    assertEquals(entry.get(null, InjectModule.class), "N1");
   }
 
   @Test
@@ -173,11 +173,11 @@ class DContextEntryTest {
     entry.add(DContextEntryBean.of("N1", null, BeanEntry.NORMAL, null));
     entry.add(DContextEntryBean.of("N2", "myName", BeanEntry.NORMAL, null));
 
-    assertEquals(entry.get("myName", AvajeModule.class), "N2");
-    assertEquals(entry.get(null, AvajeModule.class), "N1");
+    assertEquals(entry.get("myName", InjectModule.class), "N2");
+    assertEquals(entry.get(null, InjectModule.class), "N1");
   }
 
-  class OtherModule implements AvajeModule {
+  class OtherModule implements InjectModule {
     @Override
     public Class<?>[] classes() {
       return new Class[0];


### PR DESCRIPTION
Note that I think this is reasonable in terms of @InjectModule being the same name in that the IDE auto-completion when using the annotation knows it's an annotation. So I don't think we get problematic use like this.

In the generated code is the one place that we do get the clash using both the annotation and interface and in this case we fully qualify the interface in the generated code.