### PR TITLE
Write SPIs to META-INF/generated-services so that they can be merged later via avaje-spi-service

### DIFF
--- a/inject-generator/pom.xml
+++ b/inject-generator/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-spi-service</artifactId>
-      <version>1.9</version>
+      <version>1.10</version>
     </dependency>
 
     <dependency>

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -29,11 +29,7 @@ final class ProcessingContext {
     private final List<ModuleData> modules = new ArrayList<>();
     private final List<TypeElement> delayQueue = new ArrayList<>();
     private final List<String> spiServices = new ArrayList<>();
-    private final boolean spiPresent =
-        APContext.typeElement("io.avaje.spi.internal.ServiceProcessor") != null;
     private boolean strictWiring;
-
-    Ctx() {}
 
     void registerProvidedTypes(Set<String> moduleFileProvided) {
       ExternalProvider.registerModuleProvidedTypes(providedTypes);
@@ -100,7 +96,7 @@ final class ProcessingContext {
   static FileObject createMetaInfWriterFor(String interfaceType) throws IOException {
 
     var serviceFile =
-        CTX.get().spiPresent
+        APContext.typeElement("io.avaje.spi.internal.ServiceProcessor") != null
             ? interfaceType.replace("META-INF/services/", "META-INF/generated-services/")
             : interfaceType;
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -29,6 +29,8 @@ final class ProcessingContext {
     private final List<ModuleData> modules = new ArrayList<>();
     private final List<TypeElement> delayQueue = new ArrayList<>();
     private final List<String> spiServices = new ArrayList<>();
+    private final boolean spiPresent =
+        APContext.typeElement("io.avaje.spi.internal.ServiceProcessor") != null;
     private boolean strictWiring;
 
     Ctx() {}
@@ -96,11 +98,13 @@ final class ProcessingContext {
   }
 
   static FileObject createMetaInfWriterFor(String interfaceType) throws IOException {
-    return filer()
-        .createResource(
-            StandardLocation.CLASS_OUTPUT,
-            "",
-            interfaceType.replace("META-INF/services/", "META-INF/generated-services/"));
+
+    var serviceFile =
+        CTX.get().spiPresent
+            ? interfaceType.replace("META-INF/services/", "META-INF/generated-services/")
+            : interfaceType;
+
+    return filer().createResource(StandardLocation.CLASS_OUTPUT, "", serviceFile);
   }
 
   static TypeElement elementMaybe(String rawType) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -96,7 +96,11 @@ final class ProcessingContext {
   }
 
   static FileObject createMetaInfWriterFor(String interfaceType) throws IOException {
-    return filer().createResource(StandardLocation.CLASS_OUTPUT, "", interfaceType);
+    return filer()
+        .createResource(
+            StandardLocation.CLASS_OUTPUT,
+            "",
+            interfaceType.replace("META-INF/services/", "META-INF/generated-services/"));
   }
 
   static TypeElement elementMaybe(String rawType) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -29,6 +29,7 @@ final class ProcessingContext {
     private final List<ModuleData> modules = new ArrayList<>();
     private final List<TypeElement> delayQueue = new ArrayList<>();
     private final List<String> spiServices = new ArrayList<>();
+    private final boolean spiPresent = APContext.typeElement("io.avaje.spi.internal.ServiceProcessor") != null;
     private boolean strictWiring;
 
     void registerProvidedTypes(Set<String> moduleFileProvided) {
@@ -40,10 +41,6 @@ final class ProcessingContext {
   static void init(Set<String> moduleFileProvided, boolean performModuleValidation) {
     CTX.set(new Ctx());
     CTX.get().registerProvidedTypes(moduleFileProvided);
-  }
-
-  static void testInit() {
-    CTX.set(new Ctx());
   }
 
   static String loadMetaInfServices() {
@@ -94,11 +91,10 @@ final class ProcessingContext {
   }
 
   static FileObject createMetaInfWriterFor(String interfaceType) throws IOException {
-
     var serviceFile =
-        APContext.typeElement("io.avaje.spi.internal.ServiceProcessor") != null
-            ? interfaceType.replace("META-INF/services/", "META-INF/generated-services/")
-            : interfaceType;
+      CTX.get().spiPresent
+        ? interfaceType.replace("META-INF/services/", "META-INF/generated-services/")
+        : interfaceType;
 
     return filer().createResource(StandardLocation.CLASS_OUTPUT, "", serviceFile);
   }
@@ -202,7 +198,6 @@ final class ProcessingContext {
         writer.close();
       }
     } catch (IOException e) {
-      e.printStackTrace();
       logError("Failed to write services file " + e.getMessage());
     }
   }

--- a/inject-generator/src/test/java/io/avaje/inject/generator/InjectProcessorTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/InjectProcessorTest.java
@@ -26,6 +26,8 @@ import javax.tools.ToolProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import io.avaje.spi.internal.ServiceProcessor;
+
 class InjectProcessorTest {
 
   @AfterEach
@@ -67,7 +69,7 @@ class InjectProcessorTest {
             List.of("--release=" + Integer.getInteger("java.specification.version")),
             null,
             files);
-    task.setProcessors(Arrays.asList(new InjectProcessor()));
+    task.setProcessors(Arrays.asList(new InjectProcessor(), new ServiceProcessor()));
 
     assertThat(task.call()).isTrue();
   }

--- a/inject-generator/src/test/java/io/avaje/inject/generator/InjectProcessorTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/InjectProcessorTest.java
@@ -8,7 +8,6 @@ import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -69,7 +68,7 @@ class InjectProcessorTest {
             List.of("--release=" + Integer.getInteger("java.specification.version")),
             null,
             files);
-    task.setProcessors(Arrays.asList(new InjectProcessor(), new ServiceProcessor()));
+    task.setProcessors(List.of(new InjectProcessor(), new ServiceProcessor()));
 
     assertThat(task.call()).isTrue();
   }

--- a/inject-generator/src/test/java/io/avaje/inject/generator/InjectProcessorTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/InjectProcessorTest.java
@@ -53,7 +53,7 @@ class InjectProcessorTest {
     final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
     final StandardJavaFileManager manager = compiler.getStandardFileManager(null, null, null);
 
-    manager.setLocation(StandardLocation.SOURCE_PATH, Arrays.asList(new File(source)));
+    manager.setLocation(StandardLocation.SOURCE_PATH, List.of(new File(source)));
 
     final Set<Kind> fileKinds = Collections.singleton(Kind.SOURCE);
 

--- a/inject-generator/src/test/java/io/avaje/inject/generator/UtilTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/UtilTest.java
@@ -27,7 +27,6 @@ class UtilTest {
 
   @Test
   void nestedPackageOf() {
-    ProcessingContext.testInit();
     assertEquals(Util.nestedPackageOf("com.example.Foo.Bar"), "com.example");
     assertEquals(Util.nestedPackageOf("com.example.other.foo.Bar"), "com.example.other");
   }


### PR DESCRIPTION
Now relies on spi-service to write spis

relies on https://github.com/avaje/avaje-spi-service/pull/25

---
Note: This ultimately is required because with the change to a common service interface of InjectExtension we now more likely get multiple services registering for the same InjectExtension api interface - so those need to be merged into the same META-INF/services file via avaje-spi-service.