### PR TITLE
Adds new SPI Annotation

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/ConfigPropertiesPlugin.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/ConfigPropertiesPlugin.java
@@ -3,10 +3,13 @@ package org.example.myapp;
 import io.avaje.config.Config;
 import io.avaje.inject.Component;
 import io.avaje.inject.spi.ConfigPropertyPlugin;
+import io.avaje.inject.spi.InjectSpi;
+
 import org.other.one.OtherComponent2;
 
 import java.util.Optional;
 
+@InjectSpi
 @Component.Import(value = OtherComponent2.class)
 public class ConfigPropertiesPlugin implements ConfigPropertyPlugin {
 

--- a/blackbox-test-inject/src/main/resources/META-INF/services/io.avaje.inject.spi.PropertyRequiresPlugin
+++ b/blackbox-test-inject/src/main/resources/META-INF/services/io.avaje.inject.spi.PropertyRequiresPlugin
@@ -1,1 +1,0 @@
-org.example.myapp.ConfigPropertiesPlugin

--- a/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
@@ -36,6 +36,7 @@ import static io.avaje.inject.generator.ProcessingContext.*;
   FactoryPrism.PRISM_TYPE,
   ImportPrism.PRISM_TYPE,
   InjectModulePrism.PRISM_TYPE,
+  InjectSpiPrism.PRISM_TYPE,
   PrototypePrism.PRISM_TYPE,
   QualifierPrism.PRISM_TYPE,
   ScopePrism.PRISM_TYPE,
@@ -150,6 +151,7 @@ public final class InjectProcessor extends AbstractProcessor {
       .map(UType::fullWithoutAnnotations)
       .forEach(ProcessingContext::addOptionalType);
 
+    maybeElements(roundEnv, InjectSpiPrism.PRISM_TYPE).ifPresent(this::registerSPI);
     allScopes.readBeans(roundEnv);
     defaultScope.write(processingOver);
     allScopes.write(processingOver);
@@ -327,5 +329,12 @@ public final class InjectProcessor extends AbstractProcessor {
           }
         }
       });
+  }
+
+  private void registerSPI(Set<? extends Element> beans) {
+    ElementFilter.typesIn(beans).stream()
+        .map(TypeElement::getQualifiedName)
+        .map(Object::toString)
+        .forEach(ProcessingContext::addInjectSPI);
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/package-info.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/package-info.java
@@ -11,6 +11,7 @@
 @GeneratePrism(Factory.class)
 @GeneratePrism(Generated.class)
 @GeneratePrism(Inject.class)
+@GeneratePrism(InjectSpi.class)
 @GeneratePrism(InjectModule.class)
 @GeneratePrism(Lazy.class)
 @GeneratePrism(Named.class)
@@ -33,9 +34,7 @@ package io.avaje.inject.generator;
 import io.avaje.inject.*;
 import io.avaje.inject.aop.Aspect;
 import io.avaje.inject.aop.AOPFallback;
-import io.avaje.inject.spi.DependencyMeta;
-import io.avaje.inject.spi.Generated;
-import io.avaje.inject.spi.Proxy;
+import io.avaje.inject.spi.*;
 import io.avaje.prism.GeneratePrism;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;

--- a/inject/src/main/java/io/avaje/inject/spi/InjectSpi.java
+++ b/inject/src/main/java/io/avaje/inject/spi/InjectSpi.java
@@ -1,0 +1,12 @@
+package io.avaje.inject.spi;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/** Marker annotation that generates META-INF entries for {@link InjectExtension} Classes */
+@Target(TYPE)
+@Retention(SOURCE)
+public @interface InjectSpi {}


### PR DESCRIPTION
Trying to auto-register services with avaje-spi is a dead end. So I suppose we need to make spi annotation for the generators.