### PR TITLE
Make Annotations Source Retention

### DIFF
--- a/inject/src/main/java/io/avaje/inject/AssistFactory.java
+++ b/inject/src/main/java/io/avaje/inject/AssistFactory.java
@@ -54,7 +54,7 @@ import java.lang.annotation.Target;
  * }</pre>
  */
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.SOURCE)
 public @interface AssistFactory {
 
   /** Specify the factory interface for which the implementation will be generated. */

--- a/inject/src/main/java/io/avaje/inject/Bean.java
+++ b/inject/src/main/java/io/avaje/inject/Bean.java
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
  * }</pre>
  */
 @Target(ElementType.METHOD)
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.SOURCE)
 public @interface Bean {
 
   /**

--- a/inject/src/main/java/io/avaje/inject/Component.java
+++ b/inject/src/main/java/io/avaje/inject/Component.java
@@ -1,14 +1,11 @@
 package io.avaje.inject;
 
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.MODULE;
-import static java.lang.annotation.ElementType.PACKAGE;
-import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Identify a bean as component with singleton scope that avaje-inject will use.
@@ -48,8 +45,8 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  *
  * @see InjectModule#ignoreSingleton()
  */
-@Target(ElementType.TYPE)
-@Retention(RetentionPolicy.SOURCE)
+@Target(TYPE)
+@Retention(RUNTIME)
 public @interface Component {
 
   /**
@@ -70,7 +67,9 @@ public @interface Component {
   @Target({TYPE, PACKAGE, MODULE})
   @interface Import {
 
-    /** Types to generate DI classes for. */
+    /**
+     * Types to generate DI classes for.
+     */
     Class<?>[] value();
   }
 }

--- a/inject/src/main/java/io/avaje/inject/Component.java
+++ b/inject/src/main/java/io/avaje/inject/Component.java
@@ -49,7 +49,7 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  * @see InjectModule#ignoreSingleton()
  */
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.SOURCE)
 public @interface Component {
 
   /**

--- a/inject/src/main/java/io/avaje/inject/External.java
+++ b/inject/src/main/java/io/avaje/inject/External.java
@@ -2,7 +2,7 @@ package io.avaje.inject;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -17,6 +17,6 @@ import java.lang.reflect.Type;
  * {@link BeanScopeBuilder#bean(String, Type, Object)}.
  */
 @Documented
-@Retention(RUNTIME)
+@Retention(SOURCE)
 @Target({FIELD, PARAMETER})
 public @interface External {}

--- a/inject/src/main/java/io/avaje/inject/Factory.java
+++ b/inject/src/main/java/io/avaje/inject/Factory.java
@@ -45,6 +45,6 @@ import java.lang.annotation.Target;
  * }</pre>
  */
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.SOURCE)
 public @interface Factory {
 }

--- a/inject/src/main/java/io/avaje/inject/InjectModule.java
+++ b/inject/src/main/java/io/avaje/inject/InjectModule.java
@@ -3,7 +3,7 @@ package io.avaje.inject;
 import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -42,7 +42,7 @@ import java.lang.annotation.Target;
  *
  * }</pre>
  */
-@Retention(CLASS)
+@Retention(SOURCE)
 @Target({TYPE, PACKAGE, MODULE})
 public @interface InjectModule {
 

--- a/inject/src/main/java/io/avaje/inject/PostConstruct.java
+++ b/inject/src/main/java/io/avaje/inject/PostConstruct.java
@@ -1,11 +1,11 @@
 package io.avaje.inject;
 
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * The <code>PostConstruct</code> annotation is used on a method that needs to be executed
@@ -26,7 +26,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * </ul>
  */
 @Documented
-@Retention(RUNTIME)
+@Retention(SOURCE)
 @Target(METHOD)
 public @interface PostConstruct {
 }

--- a/inject/src/main/java/io/avaje/inject/PostConstruct.java
+++ b/inject/src/main/java/io/avaje/inject/PostConstruct.java
@@ -1,7 +1,7 @@
 package io.avaje.inject;
 
 import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  * </ul>
  */
 @Documented
-@Retention(SOURCE)
+@Retention(RUNTIME)
 @Target(METHOD)
 public @interface PostConstruct {
 }

--- a/inject/src/main/java/io/avaje/inject/PreDestroy.java
+++ b/inject/src/main/java/io/avaje/inject/PreDestroy.java
@@ -1,11 +1,11 @@
 package io.avaje.inject;
 
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * The <code>PreDestroy</code> annotation is used on a method as a callback notification
@@ -26,7 +26,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * </ul>
  */
 @Documented
-@Retention(RUNTIME)
+@Retention(SOURCE)
 @Target(METHOD)
 public @interface PreDestroy {
 

--- a/inject/src/main/java/io/avaje/inject/PreDestroy.java
+++ b/inject/src/main/java/io/avaje/inject/PreDestroy.java
@@ -1,7 +1,7 @@
 package io.avaje.inject;
 
 import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  * </ul>
  */
 @Documented
-@Retention(SOURCE)
+@Retention(RUNTIME)
 @Target(METHOD)
 public @interface PreDestroy {
 

--- a/inject/src/main/java/io/avaje/inject/Primary.java
+++ b/inject/src/main/java/io/avaje/inject/Primary.java
@@ -20,6 +20,6 @@ import java.lang.annotation.Target;
  * }</pre>
  */
 @Target({ElementType.TYPE, ElementType.METHOD})
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.SOURCE)
 public @interface Primary {
 }

--- a/inject/src/main/java/io/avaje/inject/Profile.java
+++ b/inject/src/main/java/io/avaje/inject/Profile.java
@@ -1,10 +1,12 @@
 package io.avaje.inject;
 
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Expresses a requirement for a bean to be wired/registered into the {@link BeanScope}.
@@ -32,7 +34,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <p>If no ConfigPropertyPlugin is found then the default implementation is used which uses
  * {@link System#getProperty(String)} and {@link System#getenv(String)}.
  */
-@Retention(RUNTIME)
+@Retention(SOURCE)
 @Target({TYPE, METHOD, ANNOTATION_TYPE})
 public @interface Profile {
 

--- a/inject/src/main/java/io/avaje/inject/Prototype.java
+++ b/inject/src/main/java/io/avaje/inject/Prototype.java
@@ -20,6 +20,6 @@ import java.lang.annotation.Target;
  * }</pre>
  */
 @Target({ElementType.TYPE, ElementType.METHOD})
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.SOURCE)
 public @interface Prototype {
 }

--- a/inject/src/main/java/io/avaje/inject/QualifiedMap.java
+++ b/inject/src/main/java/io/avaje/inject/QualifiedMap.java
@@ -1,11 +1,11 @@
 package io.avaje.inject;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
 /**
  * Marks an <code>Map&lt;String, T&gt; </code> field/parameter to receive a map of beans keyed
@@ -25,6 +25,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * }</pre>
  */
 @Target({PARAMETER, FIELD})
-@Retention(RUNTIME)
+@Retention(SOURCE)
 public @interface QualifiedMap {
 }

--- a/inject/src/main/java/io/avaje/inject/RequiresBean.java
+++ b/inject/src/main/java/io/avaje/inject/RequiresBean.java
@@ -1,11 +1,14 @@
 package io.avaje.inject;
 
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Expresses a requirement for a bean to be wired/registered into the {@link BeanScope}.
@@ -27,7 +30,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <p>In the sample above the MyService bean will get wired only if a bean of type {@code
  * OtherService} is already registered in the {@link BeanScope}.
  */
-@Retention(RUNTIME)
+@Retention(SOURCE)
 @Repeatable(RequiresBean.Container.class)
 @Target({TYPE, METHOD, ANNOTATION_TYPE})
 public @interface RequiresBean {

--- a/inject/src/main/java/io/avaje/inject/RequiresProperty.java
+++ b/inject/src/main/java/io/avaje/inject/RequiresProperty.java
@@ -1,11 +1,14 @@
 package io.avaje.inject;
 
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Expresses a requirement for a bean to be wired/registered into the {@link BeanScope}.
@@ -37,7 +40,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * If no ConfigPropertyPlugin is found then the default implementation is used which uses
  * {@link System#getProperty(String)} and {@link System#getenv(String)}.
  */
-@Retention(RUNTIME)
+@Retention(SOURCE)
 @Repeatable(RequiresProperty.Container.class)
 @Target({TYPE, METHOD, ANNOTATION_TYPE})
 public @interface RequiresProperty {

--- a/inject/src/main/java/io/avaje/inject/Secondary.java
+++ b/inject/src/main/java/io/avaje/inject/Secondary.java
@@ -24,6 +24,6 @@ import java.lang.annotation.Target;
  * }</pre>
  */
 @Target({ElementType.TYPE, ElementType.METHOD})
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.SOURCE)
 public @interface Secondary {
 }

--- a/inject/src/main/java/io/avaje/inject/spi/Proxy.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Proxy.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 /** Marks the type as being a Proxy. */
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.SOURCE)
 public @interface Proxy {}


### PR DESCRIPTION
Change annotations to have Class retention with the exception of:
- `@Component`
- `@PreDestroy`
- `@PostConstruct`

The reason for these exceptions is that for APM (Application Performance Monitoring) tools like `avaje-metrics` detect and enhance with timing all public methods of all `@Component` / `@Singleton`.  Lifecycle methods annotated with `@PreDestroy`/ `@PostConstruct` typically get excluded by default from APM so we need to detect those as well.

Note that if projects need some of these annotations to have RUNTIME or CLASS retention then please log an issue with the use case that you need to support - thanks.