### PR TITLE
Fix Inject Plugin CSV Generation/Parsing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,6 @@ jobs:
     - name: Maven version
       run: mvn --version
     - name: Build with Maven
-      run: mvn clean install
+      run: mvn clean test
     - name: Build with Maven (javax)
       run: ./jakarta-to-javax.sh && mvn clean test && ./javax-to-jakarta.sh

--- a/blackbox-aspect/pom.xml
+++ b/blackbox-aspect/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>avaje-inject-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>10.1</version>
+    <version>10.2-RC1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/blackbox-other/pom.xml
+++ b/blackbox-other/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>avaje-inject-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>10.1</version>
+    <version>10.2-RC1</version>
   </parent>
 
   <artifactId>blackbox-other</artifactId>

--- a/blackbox-test-inject/pom.xml
+++ b/blackbox-test-inject/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>avaje-inject-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>10.1</version>
+    <version>10.2-RC1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -97,7 +97,7 @@
 			<plugin>
 				<groupId>io.avaje</groupId>
 				<artifactId>avaje-inject-maven-plugin</artifactId>
-				<version>10.0-RC9</version>
+				<version>${project.version}</version>
 				<executions>
 					<execution>
 						<phase>process-sources</phase>

--- a/inject-aop/pom.xml
+++ b/inject-aop/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-inject-parent</artifactId>
-    <version>10.1</version>
+    <version>10.2-RC1</version>
   </parent>
   <artifactId>avaje-inject-aop</artifactId>
   <dependencies>

--- a/inject-events/pom.xml
+++ b/inject-events/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-inject-parent</artifactId>
-    <version>10.1</version>
+    <version>10.2-RC1</version>
   </parent>
   <artifactId>avaje-inject-events</artifactId>
   <name>avaje inject events</name>

--- a/inject-generator/pom.xml
+++ b/inject-generator/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-inject-parent</artifactId>
-    <version>10.1</version>
+    <version>10.2-RC1</version>
   </parent>
 
   <artifactId>avaje-inject-generator</artifactId>

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -74,22 +74,20 @@ final class ExternalProvider {
     for (final var module : modules) {
       final var name = module.getClass().getTypeName();
       APContext.logNote("Detected Module: " + name);
-      final var provides = new HashSet<>(providedTypes);
+      final var provides = new HashSet<String>();
       for (final var provide : module.provides()) {
-        providedTypes.add(provide.getTypeName());
         provides.add(provide.getTypeName());
       }
       for (final var provide : module.autoProvides()) {
-        providedTypes.add(provide.getTypeName());
         provides.add(provide.getTypeName());
       }
       for (final var provide : module.autoProvidesAspects()) {
         final var aspectType = Util.wrapAspect(provide.getTypeName());
-        providedTypes.add(aspectType);
         provides.add(aspectType);
       }
       registerExternalMetaData(name);
-      readMetaDataProvides(providedTypes);
+      readMetaDataProvides(provides);
+      providedTypes.addAll(provides);
       final var requires = Arrays.stream(module.requires()).map(Type::getTypeName).collect(toList());
 
       Arrays.stream(module.autoRequires()).map(Type::getTypeName).forEach(requires::add);

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -1,27 +1,16 @@
 package io.avaje.inject.generator;
 
-import static java.util.Map.entry;
-import static java.util.stream.Collectors.toList;
-
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-
-import static java.util.List.of;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Stream;
+import io.avaje.inject.spi.AvajeModule;
+import io.avaje.inject.spi.InjectPlugin;
 
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.ElementFilter;
-import io.avaje.inject.spi.AvajeModule;
-import io.avaje.inject.spi.InjectPlugin;
+import java.lang.reflect.Type;
+import java.util.*;
+
+import static java.util.List.of;
+import static java.util.Map.entry;
+import static java.util.stream.Collectors.toList;
 
 /**
  * The types provided by other modules in the classpath at compile time.
@@ -74,7 +63,7 @@ final class ExternalProvider {
     for (final var module : modules) {
       final var name = module.getClass().getTypeName();
       APContext.logNote("Detected Module: " + name);
-      final var provides = new HashSet<String>();
+      final var provides = new TreeSet<String>();
       for (final var provide : module.provides()) {
         provides.add(provide.getTypeName());
       }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
@@ -100,17 +100,16 @@ public final class InjectProcessor extends AbstractProcessor {
     pluginFileProvided.addAll(lines("avaje-plugin-provides.txt"));
 
     lines("avaje-module-dependencies.csv").stream()
-        .filter(s -> s.contains("|") && !s.startsWith("External Module Type"))
-        .distinct()
-        .map(l -> l.split("\\|"))
-        .map(ModuleData::of)
-        .flatMap(Optional::stream)
-        .forEach(
-            m -> {
-              ExternalProvider.registerExternalMetaData(m.name());
-              ExternalProvider.readMetaDataProvides(moduleFileProvided);
-              this.moduleData.add(m);
-            });
+      .filter(s -> s.contains("|") && !s.startsWith("External Module Type"))
+      .distinct()
+      .map(l -> l.split("\\|"))
+      .map(ModuleData::of)
+      .flatMap(Optional::stream)
+      .forEach(m -> {
+        ExternalProvider.registerExternalMetaData(m.name());
+        ExternalProvider.readMetaDataProvides(moduleFileProvided);
+        this.moduleData.add(m);
+      });
   }
 
   private List<String> lines(String relativeName) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
@@ -100,16 +100,17 @@ public final class InjectProcessor extends AbstractProcessor {
     pluginFileProvided.addAll(lines("avaje-plugin-provides.txt"));
 
     lines("avaje-module-dependencies.csv").stream()
-      .skip(1)
-      .filter(s -> !s.startsWith("External Module Type"))
-      .distinct()
-      .map(l -> l.split("\\|"))
-      .map(ModuleData::new)
-      .forEach(m -> {
-        ExternalProvider.registerExternalMetaData(m.name());
-        ExternalProvider.readMetaDataProvides(moduleFileProvided);
-        this.moduleData.add(m);
-      });
+        .filter(s -> s.contains("|") && !s.startsWith("External Module Type"))
+        .distinct()
+        .map(l -> l.split("\\|"))
+        .map(ModuleData::of)
+        .flatMap(Optional::stream)
+        .forEach(
+            m -> {
+              ExternalProvider.registerExternalMetaData(m.name());
+              ExternalProvider.readMetaDataProvides(moduleFileProvided);
+              this.moduleData.add(m);
+            });
   }
 
   private List<String> lines(String relativeName) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ModuleData.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ModuleData.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.toList;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 final class ModuleData {
 
@@ -18,10 +19,20 @@ final class ModuleData {
     this.requires = requires;
   }
 
-  ModuleData(String[] moduleCsv) {
-    this.fqn = moduleCsv[0];
-    this.provides = Arrays.stream(moduleCsv[1].split(",")).filter(not(String::isBlank)).collect(toList());
-    this.requires = Arrays.stream(moduleCsv[2].split(",")).filter(not(String::isBlank)).collect(toList());
+  static Optional<ModuleData> of(String[] moduleCsv) {
+    try {
+      return Optional.of(
+          new ModuleData(
+              moduleCsv[0],
+              Arrays.stream(moduleCsv[1].split(",")).filter(not(String::isBlank)).collect(toList()),
+              Arrays.stream(moduleCsv[2].split(","))
+                  .filter(not(String::isBlank))
+                  .collect(toList())));
+
+    } catch (Exception e) {
+      System.err.println("Failed to parse" + Arrays.toString(moduleCsv));
+    }
+    return Optional.empty();
   }
 
   List<String> provides() {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ModuleData.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ModuleData.java
@@ -22,12 +22,12 @@ final class ModuleData {
   static Optional<ModuleData> of(String[] moduleCsv) {
     try {
       return Optional.of(
-          new ModuleData(
-              moduleCsv[0],
-              Arrays.stream(moduleCsv[1].split(",")).filter(not(String::isBlank)).collect(toList()),
-              Arrays.stream(moduleCsv[2].split(","))
-                  .filter(not(String::isBlank))
-                  .collect(toList())));
+        new ModuleData(
+          moduleCsv[0],
+          Arrays.stream(moduleCsv[1].split(",")).filter(not(String::isBlank)).collect(toList()),
+          Arrays.stream(moduleCsv[2].split(","))
+            .filter(not(String::isBlank))
+            .collect(toList())));
 
     } catch (Exception e) {
       System.err.println("Failed to parse" + Arrays.toString(moduleCsv));

--- a/inject-gradle-plugin/build.gradle
+++ b/inject-gradle-plugin/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'io.avaje.inject'
-version '10.1'
+version '10.2-RC1'
 
 repositories {
   mavenLocal()
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'io.avaje:avaje-inject:10.1'
+  implementation 'io.avaje:avaje-inject:10.2-RC1'
   implementation gradleApi()
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'

--- a/inject-gradle-plugin/src/main/java/io/avaje/inject/plugin/AvajeInjectPlugin.java
+++ b/inject-gradle-plugin/src/main/java/io/avaje/inject/plugin/AvajeInjectPlugin.java
@@ -110,8 +110,7 @@ public class AvajeInjectPlugin implements Plugin<Project> {
   }
 
   private void writeModuleCSV(ClassLoader classLoader, FileWriter moduleWriter) throws IOException {
-    final Set<String> providedTypes = new HashSet<>();
-
+    
     final List<AvajeModule> avajeModules = new ArrayList<>();
     ServiceLoader.load(Module.class, classLoader).forEach(avajeModules::add);
     ServiceLoader.load(InjectExtension.class, classLoader).stream()
@@ -127,17 +126,14 @@ public class AvajeInjectPlugin implements Plugin<Project> {
       final var provides = new ArrayList<String>();
       for (final var provide : module.provides()) {
         var type = provide.getTypeName();
-        providedTypes.add(type);
         provides.add(type);
       }
       for (final var provide : module.autoProvides()) {
         var type = provide.getTypeName();
-        providedTypes.add(type);
         provides.add(type);
       }
       for (final var provide : module.autoProvidesAspects()) {
         var type = wrapAspect(provide.getTypeName());
-        providedTypes.add(type);
         provides.add(type);
       }
 

--- a/inject-maven-plugin/pom.xml
+++ b/inject-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-inject-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>10.1</version>
+    <version>10.2-RC1</version>
   </parent>
 
   <artifactId>avaje-inject-maven-plugin</artifactId>

--- a/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
+++ b/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
@@ -95,7 +95,7 @@ public class AutoProvidesMojo extends AbstractMojo {
   }
 
   private FileWriter createFileWriter(String string) throws IOException {
-    return new FileWriter(new File(project.getBuild().getDirectory(), string), true);
+    return new FileWriter(new File(project.getBuild().getDirectory(), string));
   }
 
   private void writeProvidedPlugins(URLClassLoader newClassLoader, FileWriter pluginWriter) throws IOException {
@@ -128,7 +128,6 @@ public class AutoProvidesMojo extends AbstractMojo {
   }
 
   private void writeModuleCSV(ClassLoader newClassLoader, FileWriter moduleWriter) throws IOException {
-    final Set<String> providedTypes = new HashSet<>();
 
     final Log log = getLog();
     final List<AvajeModule> avajeModules = new ArrayList<>();
@@ -145,17 +144,16 @@ public class AutoProvidesMojo extends AbstractMojo {
       final var provides = new ArrayList<String>();
       for (final var provide : module.provides()) {
         var type = provide.getTypeName();
-        providedTypes.add(type);
         provides.add(type);
       }
+
       for (final var provide : module.autoProvides()) {
         var type = provide.getTypeName();
-        providedTypes.add(type);
         provides.add(type);
       }
+
       for (final var provide : module.autoProvidesAspects()) {
         var type = wrapAspect(provide.getTypeName());
-        providedTypes.add(type);
         provides.add(type);
       }
 
@@ -171,12 +169,7 @@ public class AutoProvidesMojo extends AbstractMojo {
       modules.add(new ModuleData(name, provides, requires));
     }
 
-    for (final String providedType : providedTypes) {
-      moduleWriter.write(providedType);
-      moduleWriter.write("\n");
-    }
-
-    moduleWriter.write("\nExternal Module Type|Provides|Requires");
+    moduleWriter.write("External Module Type|Provides|Requires");
     for (ModuleData avajeModule : modules) {
       moduleWriter.write("\n");
       moduleWriter.write(avajeModule.name());

--- a/inject-test/pom.xml
+++ b/inject-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-inject-parent</artifactId>
-    <version>10.1</version>
+    <version>10.2-RC1</version>
   </parent>
 
   <artifactId>avaje-inject-test</artifactId>

--- a/inject/pom.xml
+++ b/inject/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-inject-parent</artifactId>
-    <version>10.1</version>
+    <version>10.2-RC1</version>
   </parent>
 
   <artifactId>avaje-inject</artifactId>

--- a/jakarta-to-javax.sh
+++ b/jakarta-to-javax.sh
@@ -7,6 +7,7 @@ sed -i -E '0,/<version>[^<]*<\/version>/ s/<version>([^-]*)-?([^<]*)(<\/version>
 sed -i -E '0,/<version>[^<]*<\/version>/ s/<version>([^-]*)-?([^<]*)(<\/version>)/<version>\1-javax\2\3/' inject-aop/pom.xml
 sed -i -E '0,/<version>[^<]*<\/version>/ s/<version>([^-]*)-?([^<]*)(<\/version>)/<version>\1-javax\2\3/' inject-events/pom.xml
 sed -i -E '0,/<version>[^<]*<\/version>/ s/<version>([^-]*)-?([^<]*)(<\/version>)/<version>\1-javax\2\3/' inject-generator/pom.xml
+sed -i -E '0,/<version>[^<]*<\/version>/ s/<version>([^-]*)-?([^<]*)(<\/version>)/<version>\1-javax\2\3/' inject-maven-plugin/pom.xml
 sed -i -E '0,/<version>[^<]*<\/version>/ s/<version>([^-]*)-?([^<]*)(<\/version>)/<version>\1-javax\2\3/' inject-test/pom.xml
 sed -i -E '0,/<version>[^<]*<\/version>/ s/<version>([^-]*)-?([^<]*)(<\/version>)/<version>\1-javax\2\3/' blackbox-aspect/pom.xml
 sed -i -E '0,/<version>[^<]*<\/version>/ s/<version>([^-]*)-?([^<]*)(<\/version>)/<version>\1-javax\2\3/' blackbox-other/pom.xml

--- a/javax-to-jakarta.sh
+++ b/javax-to-jakarta.sh
@@ -7,6 +7,7 @@ sed -i 's/\(<version>[^<]*\)-javax\([^<]*<\/version>\)/\1\2/' inject/pom.xml
 sed -i 's/\(<version>[^<]*\)-javax\([^<]*<\/version>\)/\1\2/' inject-aop/pom.xml
 sed -i 's/\(<version>[^<]*\)-javax\([^<]*<\/version>\)/\1\2/' inject-events/pom.xml
 sed -i 's/\(<version>[^<]*\)-javax\([^<]*<\/version>\)/\1\2/' inject-generator/pom.xml
+sed -i 's/\(<version>[^<]*\)-javax\([^<]*<\/version>\)/\1\2/' inject-maven-plugin/pom.xml
 sed -i 's/\(<version>[^<]*\)-javax\([^<]*<\/version>\)/\1\2/' inject-test/pom.xml
 sed -i 's/\(<version>[^<]*\)-javax\([^<]*<\/version>\)/\1\2/' blackbox-aspect/pom.xml
 sed -i 's/\(<version>[^<]*\)-javax\([^<]*<\/version>\)/\1\2/' blackbox-other/pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.avaje</groupId>
   <artifactId>avaje-inject-parent</artifactId>
-  <version>10.1</version>
+  <version>10.2-RC1</version>
   <packaging>pom</packaging>
   <name>avaje inject parent</name>
   <description>parent pom for avaje inject library</description>


### PR DESCRIPTION
Fixes situations where compilation fails with `Fatal error compiling: java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1` 

- Now will not fail compilation if unable to parse the `avaje-module-dependencies.csv` file 
- remove extra newline and copied text from generated csv
- fix javax workflow to include the inject plugin