### PR TITLE
Fix partial compile regression introduced in 10.0-RC5

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -53,7 +53,9 @@ final class ProcessingContext {
 
   private static boolean isInjectModule(String spi) {
     var moduleType = APContext.typeElement(spi);
-    return moduleType != null && moduleType.getSuperclass().toString().contains("AvajeModule");
+    return moduleType != null && moduleType.getInterfaces().stream()
+      .map(TypeMirror::toString)
+      .anyMatch(s -> s.contains("AvajeModule"));
   }
 
   static List<String> loadMetaInfCustom() {


### PR DESCRIPTION
10.0-RC5 introduced a regression that stops "Partial Compilation" from working. This is due to the ProcessingContext.isInjectModule() not correctly detecting the current module. This meant no existing module was found, no dependency meta data for the module was read, a new module is created for the components included in the partial compile and generally that will fail with missing dependencies.

A workaround is to perform a full compile (but this isn't really a workable solution - its important that partial compile works).