### PR TITLE
Fix partial compile regression introduced in 10.1 via #645

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
@@ -47,7 +47,7 @@ final class MetaData {
     this.shortType = Util.shortName(type);
     this.method = meta.method();
     this.providesAspect = meta.providesAspect();
-    this.dependsOn = meta.dependsOn().stream().map(d -> new Dependency(d, name)).collect(Collectors.toList());
+    this.dependsOn = meta.dependsOn().stream().map(Dependency::new).collect(Collectors.toList());
     this.provides = Util.addQualifierSuffix(meta.provides(), name);
     this.autoProvides = Util.addQualifierSuffix(meta.autoProvides(), name);
     this.importedComponent = meta.importedComponent();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -53,7 +53,9 @@ final class ProcessingContext {
 
   private static boolean isInjectModule(String spi) {
     var moduleType = APContext.typeElement(spi);
-    return moduleType != null && moduleType.getSuperclass().toString().contains("AvajeModule");
+    return moduleType != null && moduleType.getInterfaces().stream()
+      .map(TypeMirror::toString)
+      .anyMatch(s -> s.contains("AvajeModule"));
   }
 
   static List<String> loadMetaInfCustom() {


### PR DESCRIPTION
Fixes a regression that breaks partial compilation when qualifiers are used.

Regression introduced in 10.1 via:
https://github.com/avaje/avaje-inject/pull/645/files

With this regression we observe compile errors stating that dependencies with qualifiers are missing. When reviewing the relevant generated @metadata dependsOn attributes in the generate source we see that there are qualifiers incorrectly appended to the factory type.

The fix is in the MetaData constructor, such that the dependsOn does NOT use the name/qualifier of the type.