### PR TITLE
Fix NPE on module.name()

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -458,7 +458,8 @@ final class ScopeInfo {
 
   void readModuleMetaData(TypeElement moduleType) {
     final InjectModulePrism module = InjectModulePrism.getInstanceOn(moduleType);
-    details(module.name(), moduleType);
+    final String name = module == null ? null : module.name();
+    details(name, moduleType);
     readFactoryMetaData(moduleType);
   }
 


### PR DESCRIPTION
I have only observed this NPE on partial compilation errors. This might not be strictly required but putting this fix in for that odd case.