### PR TITLE
Generate Value Classes When on Valhalla

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
@@ -238,7 +238,7 @@ final class MetaData {
       appendProvides(append, "autoProvides", autoProvides);
     }
     append.append(")").append(NEWLINE);
-    append.append("  private void build_").append(buildName()).append("() {").append(NEWLINE);
+    append.append("  private void build_").append(buildName()).append("(Builder builder) {").append(NEWLINE);
     if (hasMethod()) {
       append.append("    ").append(Util.shortMethod(method)).append("(builder");
     } else {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleAssistWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleAssistWriter.java
@@ -91,7 +91,14 @@ final class SimpleAssistWriter {
     if (!beanReader.hasTargetFactory()) {
       writer.append("public ");
     }
-    writer.append("final class ").append(name).append(suffix);
+
+    var valhallaStr =
+        beanReader.injectFields().isEmpty()
+                || beanReader.injectFields().stream().noneMatch(FieldReader::assisted)
+            ? Util.valhalla()
+            : "";
+
+    writer.append("final %sclass ", valhallaStr).append(name).append(suffix);
 
     writeImplementsOrExtends();
     writer.append(" {").eol().eol();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleAssistWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleAssistWriter.java
@@ -91,12 +91,14 @@ final class SimpleAssistWriter {
     if (!beanReader.hasTargetFactory()) {
       writer.append("public ");
     }
-
-    var valhallaStr =
-        beanReader.injectFields().isEmpty()
-                || beanReader.injectFields().stream().noneMatch(FieldReader::assisted)
-            ? Util.valhalla()
-            : "";
+    var valhallaStr = Util.valhalla();
+    if (!valhallaStr.isBlank()
+        && (beanReader.injectFields().stream().anyMatch(FieldReader::assisted)
+            || beanReader.injectMethods().stream()
+                .flatMap(m -> m.params().stream())
+                .anyMatch(MethodParam::assisted))) {
+      valhallaStr = "";
+    }
 
     writer.append("final %sclass ", valhallaStr).append(name).append(suffix);
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleAssistWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleAssistWriter.java
@@ -92,18 +92,20 @@ final class SimpleAssistWriter {
       writer.append("public ");
     }
     var valhallaStr = Util.valhalla();
-    if (!valhallaStr.isBlank()
-        && (beanReader.injectFields().stream().anyMatch(FieldReader::assisted)
-            || beanReader.injectMethods().stream()
-                .flatMap(m -> m.params().stream())
-                .anyMatch(MethodParam::assisted))) {
+    if (!valhallaStr.isBlank() && hasAssistedFieldsOrParams()) {
       valhallaStr = "";
     }
 
     writer.append("final %sclass ", valhallaStr).append(name).append(suffix);
-
     writeImplementsOrExtends();
     writer.append(" {").eol().eol();
+  }
+
+  private boolean hasAssistedFieldsOrParams() {
+    return beanReader.injectFields().stream().anyMatch(FieldReader::assisted)
+      || beanReader.injectMethods().stream()
+      .flatMap(m -> m.params().stream())
+      .anyMatch(MethodParam::assisted);
   }
 
   private void writeImplementsOrExtends() {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
@@ -348,10 +348,10 @@ final class SimpleBeanWriter {
       shortName = shortName.replace(".", "$");
     }
     writer
-        .append("public final %sclass ", requestScopedController ? "" : Util.valhalla())
-        .append(shortName)
-        .append(suffix)
-        .append(" ");
+      .append("public final %sclass ", requestScopedController ? "" : Util.valhalla())
+      .append(shortName)
+      .append(suffix)
+      .append(" ");
     if (requestScopedController) {
       writer.append("implements ");
       beanReader.factoryInterface(writer);

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
@@ -333,21 +333,26 @@ final class SimpleBeanWriter {
   }
 
   private void writeClassStart() {
-    if (beanReader.isRequestScopedController()) {
+    final var requestScopedController = beanReader.isRequestScopedController();
+    if (requestScopedController) {
       writer.append(CODE_COMMENT_FACTORY, shortName).eol();
     } else {
       writer.append(CODE_COMMENT, shortName).eol();
     }
     writer.append(beanReader.generatedType()).append(Constants.AT_GENERATED_COMMENT).eol();
-    if (beanReader.isRequestScopedController()) {
+    if (requestScopedController) {
       writer.append(Constants.AT_SINGLETON).eol();
     }
     String shortName = this.shortName;
     if (beanReader.beanType().getNestingKind().isNested()) {
       shortName = shortName.replace(".", "$");
     }
-    writer.append("public final class ").append(shortName).append(suffix).append(" ");
-    if (beanReader.isRequestScopedController()) {
+    writer
+        .append("public final %sclass ", requestScopedController ? "" : Util.valhalla())
+        .append(shortName)
+        .append(suffix)
+        .append(" ");
+    if (requestScopedController) {
       writer.append("implements ");
       beanReader.factoryInterface(writer);
     }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
@@ -170,12 +170,11 @@ final class SimpleModuleWriter {
     if (scopeInfo.addWithBeans()) {
       writeWithBeans();
     }
-    writer.append("    this.builder = builder;").eol();
     writer.append("    // create beans in order based on constructor dependencies").eol();
     writer.append("    // i.e. \"provides\" followed by \"dependsOn\"").eol();
     for (MetaData metaData : ordering.ordered()) {
       if (!metaData.isGenerateProxy()) {
-        writer.append("    build_%s();", metaData.buildName()).eol();
+        writer.append("    build_%s(builder);", metaData.buildName()).eol();
       }
     }
     writer.append("  }").eol();
@@ -219,8 +218,7 @@ final class SimpleModuleWriter {
     scopeInfo.buildAtInjectModule(writer);
 
     String interfaceType = scopeInfo.type().type();
-    writer.append("public final class %s implements %s {", shortName, interfaceType).eol().eol();
-    writer.append("  private Builder builder;").eol().eol();
+    writer.append("public final %sclass %s implements %s {", Util.valhalla(), shortName, interfaceType).eol().eol();
     if (scopeInfo.addModuleConstructor()) {
       writeConstructor();
     }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleOrderWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleOrderWriter.java
@@ -58,7 +58,7 @@ final class SimpleOrderWriter {
         " */\n"
     );
     writer.append(Constants.AT_GENERATED).eol();
-    writer.append("public final class %s implements ModuleOrdering {", shortName).eol().eol();
+    writer.append("public final %sclass %s implements ModuleOrdering {", Util.valhalla(), shortName).eol().eol();
 
     writer.append("  private final AvajeModule[] sortedModules = new AvajeModule[%s];", ordering.size()).eol();
     writer.append("  private static final Map<String, Integer> INDEXES = Map.ofEntries(").eol();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -2,6 +2,7 @@ package io.avaje.inject.generator;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -368,4 +369,12 @@ final class Util {
       .collect(toList());
   }
 
+  static String valhalla() {
+    try {
+      if (Modifier.valueOf("VALUE") != null && APContext.previewEnabled()) return "value ";
+    } catch (IllegalArgumentException e) {
+      // no valhalla
+    }
+    return "";
+  }
 }


### PR DESCRIPTION
Was testing with valhalla, and thought why not?

- will generate value classes if on a valhalla JDK build and previews are enabled
- Modifies generated module classes to work as value types (no mutable fields)

```java
@Generated
@InjectModule
public final value class ApiModule implements AvajeModule {
  @Override
  public void build(Builder builder) {
    // builder is now passed into the DI methods instead of being a field
    build_config_HttpClientFactory(builder);
  }
...
```