### PR TITLE
Add `@BeanTypes` Annotation to Limit Injection Types

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/beantypes/AbstractSuperClass.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/beantypes/AbstractSuperClass.java
@@ -1,0 +1,3 @@
+package org.example.myapp.beantypes;
+
+public abstract class AbstractSuperClass {}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/beantypes/BeanTypeComponent.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/beantypes/BeanTypeComponent.java
@@ -1,0 +1,14 @@
+package org.example.myapp.beantypes;
+
+import org.example.myapp.config.AppConfig.SomeInterface;
+import org.other.one.SomeOptionalDep;
+
+import io.avaje.inject.BeanTypes;
+import io.avaje.inject.Component;
+import jakarta.inject.Named;
+
+@Component
+@Named("type")
+@BeanTypes(AbstractSuperClass.class)
+public class BeanTypeComponent extends AbstractSuperClass
+    implements SomeInterface, SomeOptionalDep, LimitedInterface {}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/beantypes/LimitedFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/beantypes/LimitedFactory.java
@@ -1,0 +1,17 @@
+package org.example.myapp.beantypes;
+
+import io.avaje.inject.Bean;
+import io.avaje.inject.BeanTypes;
+import io.avaje.inject.Factory;
+import jakarta.inject.Named;
+
+@Factory
+public class LimitedFactory {
+
+  @Bean
+  @Named("factory")
+  @BeanTypes(LimitedInterface.class)
+  BeanTypeComponent bean() {
+    return new BeanTypeComponent();
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/beantypes/LimitedInterface.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/beantypes/LimitedInterface.java
@@ -1,0 +1,3 @@
+package org.example.myapp.beantypes;
+
+public interface LimitedInterface {}

--- a/blackbox-test-inject/src/test/java/org/example/myapp/beantypes/BeanTypeComponentTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/beantypes/BeanTypeComponentTest.java
@@ -1,0 +1,21 @@
+package org.example.myapp.beantypes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.inject.BeanScope;
+
+class BeanTypesTest {
+
+  @Test
+  void testBeanTypesRestrictingInjection() {
+    try (var scope = BeanScope.builder().build()) {
+
+      assertFalse(scope.contains(BeanTypeComponent.class));
+      assertThat(scope.get(AbstractSuperClass.class)).isNotNull();
+      assertThat(scope.get(LimitedInterface.class)).isNotNull();
+    }
+  }
+}

--- a/inject-generator/src/main/java/io/avaje/inject/generator/AssistBeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/AssistBeanReader.java
@@ -33,7 +33,13 @@ final class AssistBeanReader {
   AssistBeanReader(TypeElement beanType) {
     this.beanType = beanType;
     this.type = beanType.getQualifiedName().toString();
-    this.typeReader = new TypeReader(UType.parse(beanType.asType()), beanType, importTypes, false);
+    this.typeReader =
+        new TypeReader(
+            Optional.empty(),
+            UType.parse(beanType.asType()),
+            beanType,
+            importTypes,
+            false);
 
     typeReader.process();
     qualifierName = typeReader.name();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/AssistBeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/AssistBeanReader.java
@@ -34,12 +34,12 @@ final class AssistBeanReader {
     this.beanType = beanType;
     this.type = beanType.getQualifiedName().toString();
     this.typeReader =
-        new TypeReader(
-            Optional.empty(),
-            UType.parse(beanType.asType()),
-            beanType,
-            importTypes,
-            false);
+      new TypeReader(
+        Optional.empty(),
+        UType.parse(beanType.asType()),
+        beanType,
+        importTypes,
+        false);
 
     typeReader.process();
     qualifierName = typeReader.name();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -58,9 +58,11 @@ final class BeanReader {
     this.primary = PrimaryPrism.isPresent(beanType);
     this.secondary = !primary && SecondaryPrism.isPresent(beanType);
     this.lazy = !FactoryPrism.isPresent(beanType) && LazyPrism.isPresent(beanType);
+    final var beantypes = BeanTypesPrism.getOptionalOn(beanType);
+    beantypes.ifPresent(p -> Util.validateBeanTypes(beanType, p.value()));
     this.typeReader =
         new TypeReader(
-            BeanTypesPrism.getOptionalOn(beanType),
+            beantypes,
             UType.parse(beanType.asType()),
             beanType,
             importTypes,

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -61,12 +61,12 @@ final class BeanReader {
     final var beantypes = BeanTypesPrism.getOptionalOn(beanType);
     beantypes.ifPresent(p -> Util.validateBeanTypes(beanType, p.value()));
     this.typeReader =
-        new TypeReader(
-            beantypes,
-            UType.parse(beanType.asType()),
-            beanType,
-            importTypes,
-            factory);
+      new TypeReader(
+        beantypes,
+        UType.parse(beanType.asType()),
+        beanType,
+        importTypes,
+        factory);
 
     typeReader.process();
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -58,7 +58,13 @@ final class BeanReader {
     this.primary = PrimaryPrism.isPresent(beanType);
     this.secondary = !primary && SecondaryPrism.isPresent(beanType);
     this.lazy = !FactoryPrism.isPresent(beanType) && LazyPrism.isPresent(beanType);
-    this.typeReader = new TypeReader(UType.parse(beanType.asType()), beanType, importTypes, factory);
+    this.typeReader =
+        new TypeReader(
+            BeanTypesPrism.getOptionalOn(beanType),
+            UType.parse(beanType.asType()),
+            beanType,
+            importTypes,
+            factory);
 
     typeReader.process();
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -95,7 +95,7 @@ final class MethodReader {
       this.initMethod = initMethod;
       this.destroyMethod = destroyMethod;
     } else {
-      this.typeReader = new TypeReader(genericType, returnElement, importTypes);
+      this.typeReader = new TypeReader(BeanTypesPrism.getOptionalOn(element),genericType, returnElement, importTypes);
       typeReader.process();
       MethodLifecycleReader lifecycleReader = new MethodLifecycleReader(returnElement, initMethod, destroyMethod);
       this.initMethod = lifecycleReader.initMethod();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -95,7 +95,9 @@ final class MethodReader {
       this.initMethod = initMethod;
       this.destroyMethod = destroyMethod;
     } else {
-      this.typeReader = new TypeReader(BeanTypesPrism.getOptionalOn(element),genericType, returnElement, importTypes);
+      final var beantypes = BeanTypesPrism.getOptionalOn(element);
+      beantypes.ifPresent(p -> Util.validateBeanTypes(element, p.value()));
+      this.typeReader = new TypeReader(beantypes, genericType, returnElement, importTypes);
       typeReader.process();
       MethodLifecycleReader lifecycleReader = new MethodLifecycleReader(returnElement, initMethod, destroyMethod);
       this.initMethod = lifecycleReader.initMethod();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeReader.java
@@ -3,6 +3,7 @@ package io.avaje.inject.generator;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
 
 import java.util.List;
 import java.util.Optional;
@@ -47,7 +48,8 @@ final class TypeReader {
     this.injectsTypes =
         injectsTypes.map(BeanTypesPrism::value).stream()
             .flatMap(List::stream)
-            .map(UType::parse).collect(toList());
+            .map(UType::parse)
+            .collect(toList());
     this.forBean = forBean;
     this.beanType = beanType;
     this.importTypes = importTypes;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeReader.java
@@ -46,16 +46,15 @@ final class TypeReader {
       ImportTypeMap importTypes,
       boolean factory) {
     this.injectsTypes =
-        injectsTypes.map(BeanTypesPrism::value).stream()
-            .flatMap(List::stream)
-            .map(UType::parse)
-            .collect(toList());
+      injectsTypes.map(BeanTypesPrism::value).stream()
+        .flatMap(List::stream)
+        .map(UType::parse)
+        .collect(toList());
     this.forBean = forBean;
     this.beanType = beanType;
     this.importTypes = importTypes;
     final boolean proxyBean = forBean && ProxyPrism.isPresent(beanType);
-    this.extendsReader =
-        new TypeExtendsReader(genericType, beanType, factory, importTypes, proxyBean);
+    this.extendsReader = new TypeExtendsReader(genericType, beanType, factory, importTypes, proxyBean);
     this.annotationReader = new TypeAnnotationReader(beanType);
   }
 
@@ -74,11 +73,10 @@ final class TypeReader {
     if (!injectsTypes.isEmpty()) {
       return injectsTypes.stream().map(UType::full).collect(toList());
     }
-
     return extendsReader.autoProvides().stream()
-        .filter(u -> u.componentTypes().stream().noneMatch(p -> p.kind() == TypeKind.TYPEVAR))
-        .map(UType::full)
-        .collect(toList());
+      .filter(u -> u.componentTypes().stream().noneMatch(p -> p.kind() == TypeKind.TYPEVAR))
+      .map(UType::full)
+      .collect(toList());
   }
 
   String providesAspect() {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -382,15 +382,13 @@ final class Util {
 
   static void validateBeanTypes(Element origin, List<TypeMirror> beanType) {
     TypeMirror targetType =
-        origin instanceof TypeElement
-            ? origin.asType()
-            : ((ExecutableElement) origin).getReturnType();
-    beanType.stream()
-        .forEach(
-            t -> {
-              if (!APContext.types().isAssignable(targetType, t)) {
-                APContext.logError(origin, "%s does not extend type %s", targetType, beanType);
-              }
-            });
+      origin instanceof TypeElement
+        ? origin.asType()
+        : ((ExecutableElement) origin).getReturnType();
+    beanType.forEach(type -> {
+      if (!APContext.types().isAssignable(targetType, type)) {
+        APContext.logError(origin, "%s does not extend type %s", targetType, beanType);
+      }
+    });
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -2,7 +2,9 @@ package io.avaje.inject.generator;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -376,5 +378,19 @@ final class Util {
       // no valhalla
     }
     return "";
+  }
+
+  static void validateBeanTypes(Element origin, List<TypeMirror> beanType) {
+    TypeMirror targetType =
+        origin instanceof TypeElement
+            ? origin.asType()
+            : ((ExecutableElement) origin).getReturnType();
+    beanType.stream()
+        .forEach(
+            t -> {
+              if (!APContext.types().isAssignable(targetType, t)) {
+                APContext.logError(origin, "%s does not extend type %s", targetType, beanType);
+              }
+            });
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/package-info.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/package-info.java
@@ -12,6 +12,7 @@
 @GeneratePrism(Generated.class)
 @GeneratePrism(Inject.class)
 @GeneratePrism(InjectModule.class)
+@GeneratePrism(BeanTypes.class)
 @GeneratePrism(Lazy.class)
 @GeneratePrism(Named.class)
 @GeneratePrism(PreDestroy.class)

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/supertypes/LimitedFactory.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/supertypes/LimitedFactory.java
@@ -1,0 +1,15 @@
+package io.avaje.inject.generator.models.valid.supertypes;
+
+import io.avaje.inject.Bean;
+import io.avaje.inject.BeanTypes;
+import io.avaje.inject.Factory;
+
+@Factory
+public class LimitedFactory {
+
+  @Bean
+  @BeanTypes(SomeInterface.class)
+  OtherComponent bean() {
+    return new OtherComponent();
+  }
+}

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/supertypes/LimitedOtherComponent.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/supertypes/LimitedOtherComponent.java
@@ -1,0 +1,9 @@
+package io.avaje.inject.generator.models.valid.supertypes;
+
+import io.avaje.inject.BeanTypes;
+import io.avaje.inject.Component;
+
+@Component
+@BeanTypes(SomeInterface2.class)
+public class LimitedOtherComponent extends AbstractSuperClass
+    implements SomeInterface, SomeInterface2 {}

--- a/inject/src/main/java/io/avaje/inject/BeanTypes.java
+++ b/inject/src/main/java/io/avaje/inject/BeanTypes.java
@@ -1,0 +1,11 @@
+package io.avaje.inject;
+
+import java.lang.annotation.*;
+
+/** Limits the types exposed by this bean to the given types. */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface BeanTypes {
+
+  Class<?>[] value();
+}


### PR DESCRIPTION
- Creates `@BeanTypes` annotation to define the injectable types associated with a bean. 
- the values provided to the annotation will also override auto-provides generation

Given the class:

```java
@Component
@BeanTypes(SomeInterface2.class)
public class LimitedOtherComponent extends AbstractSuperClass
    implements SomeInterface, SomeInterface2 {}
```

the following will be generated: 

```java
@Generated("io.avaje.inject.generator")
public final class LimitedOtherComponent$DI  {

  /**
   * Create and register LimitedOtherComponent.
   */
  public static void build(Builder builder) {
    if (builder.isAddBeanFor(SomeInterface2.class)) {
      var bean = new LimitedOtherComponent();
      builder.register(bean);
    }
  }
}
```