### PR TITLE
Fix ExternalProvider warning message

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -51,7 +51,7 @@ final class ExternalProvider {
 
   static void registerModuleProvidedTypes(Set<String> providedTypes) {
     if (!INJECT_AVAILABLE) {
-      if (!pluginExists("avaje-module-provides.txt")) {
+      if (!pluginExists("avaje-module-dependencies.csv")) {
         APContext.logNote("Unable to detect Avaje Inject in Annotation Processor ClassPath, use the Avaje Inject Maven/Gradle plugin for detecting Inject Modules from dependencies");
       }
       return;


### PR DESCRIPTION
Since we don't create `avaje-module-provides.txt` anymore, detection should be based on the generated `avaje-module-dependencies.csv` provided by the plugins