### PR TITLE
Make Jakarta Inject required in module-info

### DIFF
--- a/inject/src/main/java/module-info.java
+++ b/inject/src/main/java/module-info.java
@@ -4,11 +4,11 @@ module io.avaje.inject {
   exports io.avaje.inject.spi;
 
   requires transitive io.avaje.applog;
+  requires transitive jakarta.inject;
   requires static io.avaje.config;
   requires static org.mockito;
   requires static io.avaje.spi;
 
-  requires static transitive jakarta.inject;
   requires static transitive org.jspecify;
 
   uses io.avaje.inject.spi.InjectExtension;


### PR DESCRIPTION
I ran into some jlink trouble.

This changes `jakarta.inject` from being `static`/optional to being a required module dependency in module-info.  