### PR TITLE
Update dependabot to actually group dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,8 @@ updates:
   ignore:
       - dependency-name: "jakarta.inject:jakarta.inject-api"
   groups:
-      dev-deps:
-        dependency-type: "development"
-      prod-deps:
-        dependency-type: "production"
+    patterns:
+      - "*"
 
 - package-ecosystem: "github-actions"
     directory: "/"
@@ -22,4 +20,7 @@ updates:
       prefix: "[workflow]"
     labels:
       - "dependencies"
-    target-branch: "master"
+    target-branch: "master"  
+    groups:
+      patterns:
+        - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,21 @@
 version: 2
 updates:
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: "weekly"
-  open-pull-requests-limit: 10
-  ignore:
-      - dependency-name: "jakarta.inject:jakarta.inject-api"
-  groups:
-    patterns:
-      - "*"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    ignore:
+       - dependency-name: "jakarta.inject:jakarta.inject-api"
+    groups:
+      dependencies:
+        patterns:
+        - "*"
+    labels:
+      - "dependencies"
+    target-branch: "master"
 
-- package-ecosystem: "github-actions"
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -20,7 +24,4 @@ updates:
       prefix: "[workflow]"
     labels:
       - "dependencies"
-    target-branch: "master"  
-    groups:
-      patterns:
-        - "*"
+    target-branch: "master"


### PR DESCRIPTION
Now dependabot should create a single PR for all the dependencies. [Example PR](https://github.com/SentryMan/avaje-javalin-api-example/pull/50)