### PR TITLE
Update parent pom, tidy use argLine in properties

### DIFF
--- a/blackbox-test-inject/pom.xml
+++ b/blackbox-test-inject/pom.xml
@@ -12,11 +12,6 @@
   <groupId>io.avaje.blackboxtest</groupId>
   <artifactId>blackbox-test-inject</artifactId>
 
-  <properties>
-    <maven.compiler.release>11</maven.compiler.release>
-    <argLine>-Dnet.bytebuddy.experimental=true</argLine>
-  </properties>
-
   <dependencies>
 
     <dependency>

--- a/inject-generator/pom.xml
+++ b/inject-generator/pom.xml
@@ -51,13 +51,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <useModulePath>false</useModulePath>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <annotationProcessorPaths>

--- a/inject-test/pom.xml
+++ b/inject-test/pom.xml
@@ -141,14 +141,6 @@
         </configuration>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <useModulePath>false</useModulePath>
-          <argLine>-Dnet.bytebuddy.experimental=true</argLine>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/inject/pom.xml
+++ b/inject/pom.xml
@@ -102,17 +102,6 @@
         </executions>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <argLine>
-            --add-opens io.avaje.inject/io.avaje.inject.spi=ALL-UNNAMED
-            --add-opens io.avaje.inject/io.avaje.inject.aop=ALL-UNNAMED
-          </argLine>
-        </configuration>
-      </plugin>
-
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.avaje</groupId>
     <artifactId>java11-oss</artifactId>
-    <version>4.3</version>
+    <version>4.4</version>
   </parent>
   <scm>
     <developerConnection>scm:git:git@github.com:avaje/avaje-inject.git</developerConnection>
@@ -20,6 +20,8 @@
 
   <properties>
     <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
+    <surefire.useModulePath>false</surefire.useModulePath>
+    <argLine>-Dnet.bytebuddy.experimental=true</argLine>
   </properties>
 
   <modules>


### PR DESCRIPTION
The updated parent pom allows overriding argLine via properties section. We desire this to tidy things up and make it easier to support a EA Valhalla build.