### PR TITLE
Make `@Lazy` work on a package/module level

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -57,7 +57,7 @@ final class BeanReader {
     this.prototype = PrototypePrism.isPresent(beanType);
     this.primary = PrimaryPrism.isPresent(beanType);
     this.secondary = !primary && SecondaryPrism.isPresent(beanType);
-    this.lazy = !FactoryPrism.isPresent(beanType) && LazyPrism.isPresent(beanType);
+    this.lazy = !FactoryPrism.isPresent(beanType) && isLazy(beanType);
     final var beantypes = BeanTypesPrism.getOptionalOn(beanType);
     beantypes.ifPresent(p -> Util.validateBeanTypes(beanType, p.value()));
     this.typeReader =
@@ -91,6 +91,17 @@ final class BeanReader {
       this.proxy = false;
     }
     this.delayed = shouldDelay();
+  }
+
+  private boolean isLazy(Element element) {
+    if (element == null) {
+      return false;
+    }
+    if (LazyPrism.isPresent(beanType)) {
+      return true;
+    }
+
+    return isLazy(element.getEnclosingElement());
   }
 
   /**

--- a/inject/src/main/java/io/avaje/inject/Lazy.java
+++ b/inject/src/main/java/io/avaje/inject/Lazy.java
@@ -6,12 +6,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a Singleton, Component or Factory method beans to be initialised lazily.
- * <p>
- * When annotating a {@link Factory} as {@code @Lazy} it means that the factory
- * itself is not lazy but all beans that it provides will have lazy initialisation.
+ * Marks a Singleton, Component or Factory method beans to be initialized lazily.
+ *
+ * <p>When annotating a {@link Factory} as {@code @Lazy} it means that the factory itself is not
+ * lazy but all beans that it provides will have lazy initialization.
+ *
+ * <p>When annotating a package or a module declaration, all beans contained within that package/module will
+ * have lazy initialization.
  */
 @Retention(RetentionPolicy.SOURCE)
-@Target({ElementType.METHOD, ElementType.TYPE})
-public @interface Lazy {
-}
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.PACKAGE, ElementType.MODULE})
+public @interface Lazy {}


### PR DESCRIPTION
Now can add `@Lazy` to a module/package to make all beans within lazy, instead of needing to annotate each bean manually.

It's one way to solve #692 