### PR TITLE
Generate Meta-INF/services entry for `inject-events`

### DIFF
--- a/inject-events/src/main/resources/META-INF/services/io.avaje.inject.spi.InjectExtension
+++ b/inject-events/src/main/resources/META-INF/services/io.avaje.inject.spi.InjectExtension
@@ -1,1 +1,0 @@
-io.avaje.inject.events.spi.ObserverManagerPlugin

--- a/inject-generator/pom.xml
+++ b/inject-generator/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-spi-service</artifactId>
-      <version>2.6</version>
+      <version>2.7</version>
     </dependency>
     <!-- test dependencies -->
     <dependency>

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -19,6 +19,7 @@ import static java.util.stream.Collectors.toSet;
 
 final class ProcessingContext {
 
+  private static final String EVENTS_SPI = "io.avaje.inject.events.spi.ObserverManagerPlugin";
   private static final ThreadLocal<Ctx> CTX = new ThreadLocal<>();
   private static boolean processingOver;
   private ProcessingContext() {}
@@ -42,6 +43,17 @@ final class ProcessingContext {
   static void init(Set<String> moduleFileProvided, boolean performModuleValidation) {
     CTX.set(new Ctx());
     CTX.get().registerProvidedTypes(moduleFileProvided);
+    addEventSPI();
+  }
+
+  private static void addEventSPI() {
+    try {
+      if (typeElement(EVENTS_SPI) != null || Class.forName(EVENTS_SPI) != null) {
+        addInjectSPI(EVENTS_SPI);
+      }
+    } catch (final ClassNotFoundException e) {
+      // nothing
+    }
   }
 
   static String loadMetaInfServices() {
@@ -140,8 +152,12 @@ final class ProcessingContext {
   }
 
   static void validateModule() {
-    APContext.moduleInfoReader().ifPresent(reader ->
-      reader.validateServices("io.avaje.inject.spi.InjectExtension", CTX.get().spiServices));
+    APContext.moduleInfoReader()
+        .ifPresent(
+            reader -> {
+              CTX.get().spiServices.remove(EVENTS_SPI);
+              reader.validateServices("io.avaje.inject.spi.InjectExtension", CTX.get().spiServices);
+            });
   }
 
   static Optional<AspectImportPrism> getImportedAspect(String type) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -152,12 +152,10 @@ final class ProcessingContext {
   }
 
   static void validateModule() {
-    APContext.moduleInfoReader()
-        .ifPresent(
-            reader -> {
-              CTX.get().spiServices.remove(EVENTS_SPI);
-              reader.validateServices("io.avaje.inject.spi.InjectExtension", CTX.get().spiServices);
-            });
+    APContext.moduleInfoReader().ifPresent(reader -> {
+      CTX.get().spiServices.remove(EVENTS_SPI);
+      reader.validateServices("io.avaje.inject.spi.InjectExtension", CTX.get().spiServices);
+    });
   }
 
   static Optional<AspectImportPrism> getImportedAspect(String type) {

--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -287,7 +287,11 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
     if (moduleNames.isEmpty()) {
       log.log(
           Level.ERROR,
-          "Could not find any AvajeModule instances to wire. Possible Causes: \n1. No beans have been defined.\n2. The avaje-inject-generator depedency was not available during compilation\n3. Perhaps using Gradle and a misconfigured IDE? Refer to https://avaje.io/inject#gradle");
+          "Could not find any AvajeModule instances to wire. Possible Causes: \n"
+              + "1. No beans have been defined.\n"
+              + "2. The avaje-inject-generator depedency was not available during compilation\n"
+              + "3. Perhaps using Gradle and a misconfigured IDE? Refer to https://avaje.io/inject#gradle"
+              + "4. Perhaps this is a fat jar and you have not configured your maven asembly/shade or gradle build task to merge META-INF/services");
     }
 
     postConstructList.forEach(builder::addPostConstruct);


### PR DESCRIPTION
Generate Meta-INF/services entry for `inject-events` at compile time.

resolves #703 #702 #700 

relies on https://github.com/avaje/avaje-spi-service/pull/34