### PR TITLE
Fix Inject-test such that it does NOT have a dependency on inject-events

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -205,12 +205,15 @@ final class ProcessingContext {
   }
 
   static void writeSPIServicesFile() {
-
     Optional.ofNullable(APContext.getProjectModuleElement())
         .filter(m -> "io.avaje.inject.test".equals(m.getQualifiedName().toString()))
         .ifPresent(m -> CTX.get().spiServices.remove(EVENTS_SPI));
 
     readExistingMetaInfServices();
+    if (CTX.get().spiServices.isEmpty()) {
+      // no services to register
+      return;
+    }
     try {
       FileObject jfo = createMetaInfWriterFor(Constants.META_INF_SPI);
       if (jfo != null) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -205,6 +205,11 @@ final class ProcessingContext {
   }
 
   static void writeSPIServicesFile() {
+
+    Optional.ofNullable(APContext.getProjectModuleElement())
+        .filter(m -> "io.avaje.inject.test".equals(m.getQualifiedName().toString()))
+        .ifPresent(m -> CTX.get().spiServices.remove(EVENTS_SPI));
+
     readExistingMetaInfServices();
     try {
       FileObject jfo = createMetaInfWriterFor(Constants.META_INF_SPI);

--- a/inject-test/src/test/resources/META-INF/services/io.avaje.inject.spi.InjectExtension
+++ b/inject-test/src/test/resources/META-INF/services/io.avaje.inject.spi.InjectExtension
@@ -1,0 +1,1 @@
+io.avaje.inject.events.spi.ObserverManagerPlugin


### PR DESCRIPTION
Currently, when inject-test is built, it has a `META-INF/services/InjectExtension` with an entry for `io.avaje.inject.events.spi.ObserverManagerPlugin`. 

This means that it has hard dependency on inject-events. When events is not present this exception occurs:

```
java.util.ServiceConfigurationError: ServiceConfiguration io.avaje.inject.spi.InjectExtension: Provider io.avaje.inject.events.spi.ObserverManagerPlugin not found
```
this pr makes it so that entry is not added to inject-test