### PR TITLE
Fix Gradle Build Folder Detection

### DIFF
--- a/inject-generator/pom.xml
+++ b/inject-generator/pom.xml
@@ -13,7 +13,7 @@
   <name>avaje inject generator</name>
   <description>annotation processor generating source code for avaje-inject dependency injection</description>
   <properties>
-    <avaje.prisms.version>1.32</avaje.prisms.version>
+    <avaje.prisms.version>1.33</avaje.prisms.version>
     <!-- VALHALLA-START ___
     <maven.compiler.enablePreview>false</maven.compiler.enablePreview>
     ____ VALHALLA-END -->

--- a/inject-gradle-plugin/src/main/java/io/avaje/inject/plugin/AvajeInjectPlugin.java
+++ b/inject-gradle-plugin/src/main/java/io/avaje/inject/plugin/AvajeInjectPlugin.java
@@ -30,9 +30,9 @@ public class AvajeInjectPlugin implements Plugin<Project> {
   public void apply(Project project) {
     project.afterEvaluate(
         prj -> {
-          // run it automatically after clean
-          Task cleanTask = prj.getTasks().getByName("clean");
-          cleanTask.doLast(it -> writeProvides(project));
+          // run it automatically before build
+          Task buildTask = prj.getTasks().getByName("build");
+          buildTask.doFirst(it -> writeProvides(project));
         });
     // register a task to run it manually
     project.task("discoverModules").doLast(task -> writeProvides(project));
@@ -110,7 +110,7 @@ public class AvajeInjectPlugin implements Plugin<Project> {
   }
 
   private void writeModuleCSV(ClassLoader classLoader, FileWriter moduleWriter) throws IOException {
-    
+
     final List<AvajeModule> avajeModules = new ArrayList<>();
     ServiceLoader.load(Module.class, classLoader).forEach(avajeModules::add);
     ServiceLoader.load(InjectExtension.class, classLoader).stream()


### PR DESCRIPTION
Currently, the inject-gradle-plugin's outputs are not detected by the processor. 

- gradle plugin now runs before build instead of after clean

Depends on https://github.com/avaje/avaje-prisms/pull/86