### PR TITLE
Cease reading supertypes for `java.lang`

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -244,11 +244,10 @@ final class TypeExtendsReader {
     } else {
       if (qualifierName == null) {
         final String mainType = rawUType.mainType();
-        final String iShortName = Util.shortName(mainType);
-        if (beanSimpleName.endsWith(iShortName)) {
+        final String shortName = Util.shortName(mainType);
+        if (beanSimpleName.endsWith(shortName)) {
           // derived qualifier name based on prefix to interface short name
-          qualifierName =
-              beanSimpleName.substring(0, beanSimpleName.length() - iShortName.length());
+          qualifierName = beanSimpleName.substring(0, beanSimpleName.length() - shortName.length());
         }
       }
       interfaceTypes.add(rawUType);

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
@@ -62,8 +62,10 @@ final class DBeanMap {
     qualifiers.add(supplied.name());
     DContextEntryBean entryBean = DContextEntryBean.supplied(supplied.source(), supplied.name(), supplied.priority());
     beans.computeIfAbsent(suppliedType.getTypeName(), s -> new DContextEntry()).add(entryBean);
-    for (Class<?> anInterface : supplied.interfaces()) {
-      beans.computeIfAbsent(anInterface.getTypeName(), s -> new DContextEntry()).add(entryBean);
+    if (!suppliedType.getTypeName().startsWith("java.lang")) {
+      for (Class<?> anInterface : supplied.interfaces()) {
+        beans.computeIfAbsent(anInterface.getTypeName(), s -> new DContextEntry()).add(entryBean);
+      }
     }
   }
 


### PR DESCRIPTION
Currently, the processor adds the supertypes of `java.lang` classes as keys for wiring. When beans are supplied manually this can cause issues.

Given:

```java
public enum State {
    ON, OFF
}

@Factory
public class Configuration {

    @Bean
    public State state() {
        return State.ON;
    }
}
```

Before: 
```java
  public static void build_state(Builder builder) {
    if (builder.isAddBeanFor(State.class, TYPE_EnumState, Constable.class, Comparable.class, Serializable.class)) {
      var factory = builder.get(Configuration.class);
      var bean = factory.state();
      builder.register(bean);
    }
  }
```
After: 
```java
  public static void build_state(Builder builder) {
    if (builder.isAddBeanFor(State.class)) {
      var factory = builder.get(Configuration.class);
      var bean = factory.state();
      builder.register(bean);
    }
  }
```

Fixes #710 