### PR TITLE
Mark maven plugin goal as thread safe

### DIFF
--- a/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
+++ b/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
@@ -46,7 +46,8 @@ import io.avaje.inject.spi.Plugin;
 @Mojo(
     name = "provides",
     defaultPhase = LifecyclePhase.PROCESS_SOURCES,
-    requiresDependencyResolution = ResolutionScope.COMPILE)
+    requiresDependencyResolution = ResolutionScope.COMPILE,
+    threadSafe = true)
 public class AutoProvidesMojo extends AbstractMojo {
 
   @Parameter(defaultValue = "${project}", readonly = true, required = true)


### PR DESCRIPTION
We have no mutable state that is shared across different instances.

Resolves this warning for parallel builds.
```
[WARNING] *****************************************************************
[WARNING] The following plugins are not marked as thread-safe in blackbox-test-inject:
[WARNING]   io.avaje:avaje-inject-maven-plugin:10.5-RC3
[WARNING]
[WARNING] Enable debug to see precisely which goals are not marked as thread-safe.
[WARNING] *****************************************************************
```