### PR TITLE
Remove `exports` limitation from Module Path Detection

### DIFF
--- a/blackbox-aspect/src/main/java/module-info.java
+++ b/blackbox-aspect/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 module blackbox.aspect {
 
   exports org.example.external.aspect;
+  exports org.example.external.aspect.sub;
 
   requires io.avaje.inject;
   requires io.avaje.inject.aop;

--- a/blackbox-aspect/src/main/java/module-info.java
+++ b/blackbox-aspect/src/main/java/module-info.java
@@ -1,7 +1,6 @@
 module blackbox.aspect {
 
   exports org.example.external.aspect;
-  exports org.example.external.aspect.sub;
 
   requires io.avaje.inject;
   requires io.avaje.inject.aop;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -206,11 +206,8 @@ final class ExternalProvider {
             t -> {
               final var provides = new HashSet<String>();
               final var requires = new HashSet<String>();
-              Optional.of(t)
-                  .map(TypeElement::getEnclosedElements)
-                  .map(ElementFilter::methodsIn)
-                  .stream()
-                  .flatMap(List::stream)
+
+              ElementFilter.methodsIn(t.getEnclosedElements()).stream()
                   .map(DependencyMetaPrism::getInstanceOn)
                   .filter(Objects::nonNull)
                   .map(MetaData::new)


### PR DESCRIPTION
Removes the main weakness of #718 by reading the `provides` directives of all external modules.