### PR TITLE
Allow ordering by Comparable compareTo

### DIFF
--- a/inject/src/main/java/io/avaje/inject/BeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/BeanScope.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.lang.Comparable;
 
 import org.jspecify.annotations.Nullable;
 
@@ -197,6 +198,11 @@ public interface BeanScope extends AutoCloseable {
    * Return the list of beans that implement the given type.
    */
   <T> List<T> list(Type type);
+
+  /**
+   * Return the list of beans that implement the interface sorting by their compareTo function
+   */
+  <T extends Comparable<T>> List<T> listComparable(Class<T> type);
 
   /**
    * Return the list of beans that implement the interface sorting by priority.

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
@@ -173,7 +173,7 @@ final class DBeanScope implements BeanScope {
 
   @Override
   public <T extends Comparable<T>> List<T> listComparable(Class<T> type) {
-    return listOf(type).stream().sorted().collect(Collectors.toList());
+    return <T>listOf(type).stream().sorted().collect(Collectors.toList());
   }
 
   @SuppressWarnings("unchecked")

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
@@ -173,7 +173,7 @@ final class DBeanScope implements BeanScope {
 
   @Override
   public <T extends Comparable<T>> List<T> listComparable(Class<T> type) {
-    return <T>listOf(type).stream().sorted().collect(Collectors.toList());
+    return this.<T>listOf(type).stream().sorted().collect(Collectors.toList());
   }
 
   @SuppressWarnings("unchecked")

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
@@ -173,7 +173,7 @@ final class DBeanScope implements BeanScope {
 
   @Override
   public <T extends Comparable<T>> List<T> listComparable(Class<T> type) {
-    return listOf(type).stream().sorted().toList();
+    return listOf(type).stream().sorted().collect(Collectors.toList());
   }
 
   @SuppressWarnings("unchecked")

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.lang.Comparable;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -168,6 +169,11 @@ final class DBeanScope implements BeanScope {
   @Override
   public <T> List<T> list(Type type) {
     return listOf(type);
+  }
+
+  @Override
+  public <T extends Comparable<T>> List<T> listComparable(Class<T> type) {
+    return listOf(type).stream().sorted().toList();
   }
 
   @SuppressWarnings("unchecked")

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScopeProxy.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScopeProxy.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.lang.Comparable;
+import java.util.stream.Collectors;
 
 import io.avaje.inject.BeanEntry;
 import io.avaje.inject.BeanScope;

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScopeProxy.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScopeProxy.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.lang.Comparable;
 
 import io.avaje.inject.BeanEntry;
 import io.avaje.inject.BeanScope;
@@ -102,6 +103,15 @@ final class DBeanScopeProxy implements BeanScope {
       return delegate.list(type);
     } else {
       return builder.list(type);
+    }
+  }
+
+  @Override
+  public <T extends Comparable<T>> List<T> listComparable(Class<T> type) {
+    if (delegate != null) {
+      return delegate.list(type).stream().sorted().toList();
+    } else {
+      return builder.list(type).stream().sorted().toList();
     }
   }
 

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScopeProxy.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScopeProxy.java
@@ -109,9 +109,9 @@ final class DBeanScopeProxy implements BeanScope {
   @Override
   public <T extends Comparable<T>> List<T> listComparable(Class<T> type) {
     if (delegate != null) {
-      return delegate.list(type).stream().sorted().toList();
+      return delegate.list(type).stream().sorted().collect(Collectors.toList());
     } else {
-      return builder.list(type).stream().sorted().toList();
+      return builder.list(type).stream().sorted().collect(Collectors.toList());
     }
   }
 

--- a/inject/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
+++ b/inject/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
@@ -307,7 +307,7 @@ class BeanScopeBuilderTest {
 
     @Override
     public <T extends Comparable<T>> List<T> listComparable(Class<T> type) {
-      return return null;
+      return null;
     }
 
     @Override

--- a/inject/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
+++ b/inject/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.lang.Comparable;
 
 import org.junit.jupiter.api.Test;
 
@@ -302,6 +303,11 @@ class BeanScopeBuilderTest {
     @Override
     public <T> List<T> list(Type type) {
       return null;
+    }
+
+    @Override
+    public <T extends Comparable<T>> List<T> listComparable(Class<T> type) {
+      return return null;
     }
 
     @Override

--- a/inject/src/test/java/io/avaje/inject/LegacyBeanScopeBuilderTest.java
+++ b/inject/src/test/java/io/avaje/inject/LegacyBeanScopeBuilderTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.lang.Comparable;
 
 import org.junit.jupiter.api.Test;
 
@@ -304,6 +305,11 @@ class LegacyBeanScopeBuilderTest {
 
     @Override
     public <T> List<T> list(Type type) {
+      return null;
+    }
+
+    @Override
+    public <T extends Comparable<T>> List<T> listComparable(Class<T> type) {
       return null;
     }
 


### PR DESCRIPTION
We already have listByPriority and listByAnnotation but now we are able to sort it when our interface implements Comparable<T> without using any reflection or Runtime annotations