### PR TITLE
Add annotation for module-path `InjectPlugin` auto-detection

### DIFF
--- a/blackbox-aspect/src/main/java/module-info.java
+++ b/blackbox-aspect/src/main/java/module-info.java
@@ -1,3 +1,5 @@
+import org.example.external.aspect.spi.AspectPlugin;
+
 module blackbox.aspect {
 
   exports org.example.external.aspect;
@@ -6,7 +8,6 @@ module blackbox.aspect {
   requires io.avaje.inject;
   requires io.avaje.inject.aop;
 
-  //remove this and compilation fails
-  provides io.avaje.inject.spi.InjectExtension with org.example.external.aspect.sub.ExampleExternalAspectModule;
+  provides io.avaje.inject.spi.InjectExtension with AspectPlugin, org.example.external.aspect.sub.ExampleExternalAspectModule;
 
 }

--- a/blackbox-aspect/src/main/java/org/example/external/aspect/PluginProvidedClass.java
+++ b/blackbox-aspect/src/main/java/org/example/external/aspect/PluginProvidedClass.java
@@ -1,0 +1,3 @@
+package org.example.external.aspect;
+
+public class PluginProvidedClass {}

--- a/blackbox-aspect/src/main/java/org/example/external/aspect/spi/AspectPlugin.java
+++ b/blackbox-aspect/src/main/java/org/example/external/aspect/spi/AspectPlugin.java
@@ -1,0 +1,22 @@
+package org.example.external.aspect.spi;
+
+import org.example.external.aspect.PluginProvidedClass;
+
+import io.avaje.inject.BeanScopeBuilder;
+import io.avaje.inject.spi.InjectPlugin;
+import io.avaje.inject.spi.PluginProvides;
+
+@PluginProvides(provides = PluginProvidedClass.class)
+public class AspectPlugin implements InjectPlugin {
+
+  @Override
+  public Class<?>[] provides() {
+
+    return new Class<?>[] {PluginProvidedClass.class};
+  }
+
+  @Override
+  public void apply(BeanScopeBuilder builder) {
+    builder.beans(new PluginProvidedClass());
+  }
+}

--- a/blackbox-aspect/src/main/java/org/example/external/aspect/spi/AspectPlugin.java
+++ b/blackbox-aspect/src/main/java/org/example/external/aspect/spi/AspectPlugin.java
@@ -11,7 +11,6 @@ public class AspectPlugin implements InjectPlugin {
 
   @Override
   public Class<?>[] provides() {
-
     return new Class<?>[] {PluginProvidedClass.class};
   }
 

--- a/blackbox-test-inject/src/test/java/org/example/myapp/other/WireOther.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/other/WireOther.java
@@ -1,5 +1,6 @@
 package org.example.myapp.other;
 
+import org.example.external.aspect.PluginProvidedClass;
 import org.other.one.OtherComponent;
 
 import jakarta.inject.Singleton;
@@ -7,8 +8,10 @@ import jakarta.inject.Singleton;
 @Singleton
 public class WireOther {
   OtherComponent component;
+  PluginProvidedClass plugin;
 
-  public WireOther(OtherComponent component) {
+  public WireOther(OtherComponent component, PluginProvidedClass plugin) {
     this.component = component;
+    this.plugin = plugin;
   }
 }

--- a/blackbox-test-inject/src/test/java/org/example/myapp/other/WireOther.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/other/WireOther.java
@@ -1,0 +1,14 @@
+package org.example.myapp.other;
+
+import org.other.one.OtherComponent;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class WireOther {
+  OtherComponent component;
+
+  public WireOther(OtherComponent component) {
+    this.component = component;
+  }
+}

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -298,13 +298,18 @@ final class ExternalProvider {
             // for whatever reason, compilation breaks if we don't filter out the current module
             .filter(m -> m != APContext.getProjectModuleElement())
             .collect(toList());
+
+    var types = APContext.types();
+    var spi = APContext.typeElement("io.avaje.inject.spi.InjectExtension").asType();
+
     final var checkEnclosing =
         allModules.stream()
             .flatMap(m -> m.getEnclosedElements().stream())
             .flatMap(p -> p.getEnclosedElements().stream())
             .map(TypeElement.class::cast)
             .filter(t -> t.getKind() == ElementKind.CLASS)
-            .filter(t -> t.getModifiers().contains(Modifier.PUBLIC));
+            .filter(t -> t.getModifiers().contains(Modifier.PUBLIC))
+            .filter(t -> types.isAssignable(t.asType(), spi));
 
     final var checkDirectives =
         allModules.stream()

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -296,7 +296,7 @@ final class ExternalProvider {
             .filter(m -> !m.getQualifiedName().toString().startsWith("java"))
             .filter(m -> !m.getQualifiedName().toString().startsWith("jdk"))
             // for whatever reason, compilation breaks if we don't filter out the current module
-            .filter(m -> m != APContext.getProjectModuleElement())
+            .filter(m -> !m.equals(APContext.getProjectModuleElement()))
             .collect(toList());
 
     var types = APContext.types();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -212,7 +212,7 @@ final class ExternalProvider {
 
     var types = APContext.types();
     var spi = APContext.typeElement("io.avaje.inject.spi.AvajeModule").asType();
-  stream
+    stream
         .filter(t -> t.getInterfaces().stream().anyMatch(i -> types.isAssignable(i, spi)))
         .distinct()
         .forEach(

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -111,13 +111,6 @@ final class ExternalProvider {
    * types and the only thing providing them is the plugin.
    */
   static void registerPluginProvidedTypes(ScopeInfo defaultScope) {
-    avajePlugins.forEach((k, v) -> {
-      if (APContext.typeElement(k) != null) {
-        APContext.logNote("Loaded Plugin: %s", k);
-        v.forEach(defaultScope::pluginProvided);
-      }
-    });
-    defaultScope.pluginProvided("io.avaje.inject.event.ObserverManager");
     if (!INJECT_AVAILABLE) {
       if (!pluginExists("avaje-module-dependencies.csv")) {
         APContext.logNote(
@@ -172,9 +165,21 @@ final class ExternalProvider {
   }
 
   static void scanAllInjectPlugins(ScopeInfo defaultScope) {
-    if (!defaultScope.pluginProvided().isEmpty()) {
+    final var noPlugins = !defaultScope.pluginProvided().isEmpty();
+
+    avajePlugins.forEach(
+        (k, v) -> {
+          if (APContext.typeElement(k) != null) {
+            APContext.logNote("Loaded Plugin: %s", k);
+            v.forEach(defaultScope::pluginProvided);
+          }
+        });
+    defaultScope.pluginProvided("io.avaje.inject.event.ObserverManager");
+
+    if (noPlugins) {
       return;
     }
+
     var stream = getInjectExtensions();
     stream
         .filter(PluginProvidesPrism::isPresent)

--- a/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
@@ -350,24 +350,16 @@ public final class InjectProcessor extends AbstractProcessor {
   }
 
   private boolean isExtension(TypeElement te) {
-
-    PluginProvidesPrism.getOptionalOn(te)
-        .ifPresent(
-            t -> {
-              if (!APContext.isAssignable(te, "io.avaje.inject.spi.InjectPlugin")) {
-                APContext.logError(
-                    te, "PluginProvides can only be placed on io.avaje.inject.spi.InjectPlugin");
-              }
-            });
-
-    ServiceProviderPrism.getOptionalOn(te)
-        .ifPresent(
-            t -> {
-              if (APContext.isAssignable(te, "io.avaje.inject.spi.InjectPlugin")) {
-                APContext.logWarn(
-                    te, "PluginProvides should be used to auto register InjectPlugins");
-              }
-            });
+    PluginProvidesPrism.getOptionalOn(te).ifPresent(t -> {
+      if (!APContext.isAssignable(te, "io.avaje.inject.spi.InjectPlugin")) {
+        APContext.logError(te, "PluginProvides can only be placed on io.avaje.inject.spi.InjectPlugin");
+      }
+    });
+    ServiceProviderPrism.getOptionalOn(te).ifPresent(t -> {
+      if (APContext.isAssignable(te, "io.avaje.inject.spi.InjectPlugin")) {
+        APContext.logWarn(te, "PluginProvides should be used to auto register InjectPlugins");
+      }
+    });
 
     return APContext.isAssignable(te, "io.avaje.inject.spi.InjectExtension");
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
@@ -39,11 +39,12 @@ import static io.avaje.inject.generator.ProcessingContext.*;
   FactoryPrism.PRISM_TYPE,
   ImportPrism.PRISM_TYPE,
   InjectModulePrism.PRISM_TYPE,
+  PluginProvidesPrism.PRISM_TYPE,
   PrototypePrism.PRISM_TYPE,
   QualifierPrism.PRISM_TYPE,
   ScopePrism.PRISM_TYPE,
   SingletonPrism.PRISM_TYPE,
-  "io.avaje.spi.ServiceProvider"
+  ServiceProviderPrism.PRISM_TYPE
 })
 public final class InjectProcessor extends AbstractProcessor {
 
@@ -158,7 +159,8 @@ public final class InjectProcessor extends AbstractProcessor {
         ProcessingContext.addOptionalType(type.fullWithoutAnnotations(), null);
       });
 
-    maybeElements(roundEnv, "io.avaje.spi.ServiceProvider").ifPresent(this::registerSPI);
+    maybeElements(roundEnv, ServiceProviderPrism.PRISM_TYPE).ifPresent(this::registerSPI);
+    maybeElements(roundEnv, PluginProvidesPrism.PRISM_TYPE).ifPresent(this::registerSPI);
     allScopes.readBeans(roundEnv);
     defaultScope.write(processingOver);
     allScopes.write(processingOver);
@@ -348,6 +350,25 @@ public final class InjectProcessor extends AbstractProcessor {
   }
 
   private boolean isExtension(TypeElement te) {
+
+    PluginProvidesPrism.getOptionalOn(te)
+        .ifPresent(
+            t -> {
+              if (!APContext.isAssignable(te, "io.avaje.inject.spi.InjectPlugin")) {
+                APContext.logError(
+                    te, "PluginProvides can only be placed on io.avaje.inject.spi.InjectPlugin");
+              }
+            });
+
+    ServiceProviderPrism.getOptionalOn(te)
+        .ifPresent(
+            t -> {
+              if (APContext.isAssignable(te, "io.avaje.inject.spi.InjectPlugin")) {
+                APContext.logWarn(
+                    te, "PluginProvides should be used to auto register InjectPlugins");
+              }
+            });
+
     return APContext.isAssignable(te, "io.avaje.inject.spi.InjectExtension");
   }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -249,7 +249,8 @@ final class ProcessingContext {
     }
   }
 
-  static void registerExternalProvidedTypes() {
-    ExternalProvider.scanTheWorld(CTX.get().providedTypes);
+  static void registerExternalProvidedTypes(ScopeInfo scopeInfo) {
+    ExternalProvider.scanAllInjectPlugins(scopeInfo);
+    ExternalProvider.scanAllAvajeModules(CTX.get().providedTypes);
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -343,7 +343,7 @@ final class ScopeInfo {
     writeBeanHelpers();
     initialiseModule();
     if (processingOver && !metaData.isEmpty()) {
-      ProcessingContext.registerExternalProvidedTypes();
+      ProcessingContext.registerExternalProvidedTypes(this);
       writeModule();
     }
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/package-info.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/package-info.java
@@ -15,6 +15,7 @@
 @GeneratePrism(BeanTypes.class)
 @GeneratePrism(Lazy.class)
 @GeneratePrism(Named.class)
+@GeneratePrism(PluginProvides.class)
 @GeneratePrism(PreDestroy.class)
 @GeneratePrism(Primary.class)
 @GeneratePrism(Profile.class)
@@ -29,6 +30,7 @@
 @GeneratePrism(Singleton.class)
 @GeneratePrism(Scope.class)
 @GeneratePrism(Secondary.class)
+@GeneratePrism(io.avaje.spi.ServiceProvider.class)
 package io.avaje.inject.generator;
 
 import io.avaje.inject.*;

--- a/inject-generator/src/main/java/module-info.java
+++ b/inject-generator/src/main/java/module-info.java
@@ -6,6 +6,7 @@ module io.avaje.inject.generator {
   requires io.avaje.inject.events;
 
   requires static io.avaje.prism;
+  requires static io.avaje.spi;
 
   uses io.avaje.inject.spi.InjectExtension;
   uses io.avaje.inject.spi.Plugin;

--- a/inject/src/main/java/io/avaje/inject/spi/PluginProvides.java
+++ b/inject/src/main/java/io/avaje/inject/spi/PluginProvides.java
@@ -5,15 +5,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** Hold bean dependency metadata for compile time InjectPlugin auto detection. */
+/** Registers {@link InjectPlugin} classes for auto detection */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.CLASS)
 public @interface PluginProvides {
 
-  /** The types this component provides. */
+  /** The types this plugin provides. */
   Class<?>[] provides() default {};
 
-  /** Fully Qualified Strings of the classes provided. Use when the plugin provides generic types */
+  /** Fully Qualified Strings of the classes provided. Use when providing generic types */
   String[] providesStrings() default {};
 
   /** The aspects this component provides. */

--- a/inject/src/main/java/io/avaje/inject/spi/PluginProvides.java
+++ b/inject/src/main/java/io/avaje/inject/spi/PluginProvides.java
@@ -1,0 +1,21 @@
+package io.avaje.inject.spi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Hold bean dependency metadata for compile time InjectPlugin auto detection. */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.CLASS)
+public @interface PluginProvides {
+
+  /** The types this component provides. */
+  Class<?>[] provides() default {};
+
+  /** Fully Qualified Strings of the classes provided. Use when the plugin provides generic types */
+  String[] providesStrings() default {};
+
+  /** The aspects this component provides. */
+  Class<?>[] providesAspects() default {};
+}

--- a/inject/src/main/java/io/avaje/inject/spi/PluginProvides.java
+++ b/inject/src/main/java/io/avaje/inject/spi/PluginProvides.java
@@ -5,17 +5,30 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** Registers {@link InjectPlugin} classes for auto detection */
+/**
+ * Registers {@link InjectPlugin} classes for auto-detection.
+ * <p>
+ * Plugins can be registered traditionally via service loading etc but
+ * if we use this {@code @PluginProvides} annotation, then avaje inject
+ * can ALSO auto-detect the plugin and the types that it provides.
+ * Otherwise, we need to use Maven/Gradle plugins to perform this detection.
+ */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.CLASS)
 public @interface PluginProvides {
 
-  /** The types this plugin provides. */
+  /**
+   * The types this plugin provides.
+   */
   Class<?>[] provides() default {};
 
-  /** Fully Qualified Strings of the classes provided. Use when providing generic types */
+  /**
+   * Fully Qualified Strings of the classes provided. Use when providing generic types
+   */
   String[] providesStrings() default {};
 
-  /** The aspects this component provides. */
+  /**
+   * The aspects this component provides.
+   */
   Class<?>[] providesAspects() default {};
 }


### PR DESCRIPTION
- adds a `@PluginProvides` annotation that the processor can autodetect via `getAllModuleElements` (not sure I like the name though, feel free to change it if you got a better one)
- writes plugin/module text files for reuse during test compilation 

resolves #724 