### PR TITLE
Fix Gradle Test Resource Detection

### DIFF
--- a/inject-generator/pom.xml
+++ b/inject-generator/pom.xml
@@ -13,7 +13,7 @@
   <name>avaje inject generator</name>
   <description>annotation processor generating source code for avaje-inject dependency injection</description>
   <properties>
-    <avaje.prisms.version>1.33</avaje.prisms.version>
+    <avaje.prisms.version>1.34</avaje.prisms.version>
     <!-- VALHALLA-START ___
     <maven.compiler.enablePreview>false</maven.compiler.enablePreview>
     ____ VALHALLA-END -->

--- a/inject-gradle-plugin/src/main/java/io/avaje/inject/plugin/AvajeInjectPlugin.java
+++ b/inject-gradle-plugin/src/main/java/io/avaje/inject/plugin/AvajeInjectPlugin.java
@@ -31,7 +31,7 @@ public class AvajeInjectPlugin implements Plugin<Project> {
     project.afterEvaluate(
         prj -> {
           // run it automatically before build
-          Task buildTask = prj.getTasks().getByName("build");
+          Task buildTask = prj.getTasks().getByName("compileJava");
           buildTask.doFirst(it -> writeProvides(project));
         });
     // register a task to run it manually


### PR DESCRIPTION
- change gradle plugin to run before the `compileJava` task
- bump prisms version


Relies on https://github.com/avaje/avaje-prisms/pull/89