### PR TITLE
Rename `isAddBeanFor` to `isBeanAbsent`

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -294,8 +294,8 @@ final class BeanReader {
     new ConditionalWriter(writer, conditions).write();
   }
 
-  void buildBeanAbsent(Append writer) {
-    writer.append("    if (builder.isBeanAbsent(");
+  void buildCanRegister(Append writer) {
+    writer.append("    if (builder.canRegister(");
     if (name != null && !name.isEmpty()) {
       writer.append("\"%s\", ", name);
     }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -294,8 +294,8 @@ final class BeanReader {
     new ConditionalWriter(writer, conditions).write();
   }
 
-  void buildAddFor(Append writer) {
-    writer.append("    if (builder.isAddBeanFor(");
+  void buildBeanAbsent(Append writer) {
+    writer.append("    if (builder.isBeanAbsent(");
     if (name != null && !name.isEmpty()) {
       writer.append("\"%s\", ", name);
     }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -294,8 +294,8 @@ final class BeanReader {
     new ConditionalWriter(writer, conditions).write();
   }
 
-  void buildCanRegister(Append writer) {
-    writer.append("    if (builder.canRegister(");
+  void buildBeanAbsent(Append writer) {
+    writer.append("    if (builder.isBeanAbsent(");
     if (name != null && !name.isEmpty()) {
       writer.append("\"%s\", ", name);
     }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -86,7 +86,7 @@ final class MethodReader {
     String destroyMethod = (bean == null) ? null : bean.destroyMethod();
     this.destroyPriority = (bean == null) ? null : bean.destroyPriority();
     this.beanCloseable = (bean != null) && bean.autoCloseable();
-    // for multiRegister we desire a qualifier name such that builder.canRegister() uses it and allows
+    // for multiRegister we desire a qualifier name such that builder.isBeanAbsent() uses it and allows
     // other beans of the same type to also register, otherwise it defaults to slightly confusing behaviour
     this.name = multiRegister && qualifierName == null ? "multi" : qualifierName;
     TypeElement returnElement = multiRegister ? APContext.typeElement(uType.mainType()) : asElement(returnMirror);
@@ -352,7 +352,7 @@ final class MethodReader {
   }
 
   void buildAddFor(Append writer) {
-    writer.append("    if (builder.canRegister(");
+    writer.append("    if (builder.isBeanAbsent(");
     if (isVoid) {
       writer.append("Void.class");
     } else {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -86,7 +86,7 @@ final class MethodReader {
     String destroyMethod = (bean == null) ? null : bean.destroyMethod();
     this.destroyPriority = (bean == null) ? null : bean.destroyPriority();
     this.beanCloseable = (bean != null) && bean.autoCloseable();
-    // for multiRegister we desire a qualifier name such that builder.isAddBeanFor() uses it and allows
+    // for multiRegister we desire a qualifier name such that builder.isBeanAbsent() uses it and allows
     // other beans of the same type to also register, otherwise it defaults to slightly confusing behaviour
     this.name = multiRegister && qualifierName == null ? "multi" : qualifierName;
     TypeElement returnElement = multiRegister ? APContext.typeElement(uType.mainType()) : asElement(returnMirror);
@@ -352,7 +352,7 @@ final class MethodReader {
   }
 
   void buildAddFor(Append writer) {
-    writer.append("    if (builder.isAddBeanFor(");
+    writer.append("    if (builder.isBeanAbsent(");
     if (isVoid) {
       writer.append("Void.class");
     } else {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -86,7 +86,7 @@ final class MethodReader {
     String destroyMethod = (bean == null) ? null : bean.destroyMethod();
     this.destroyPriority = (bean == null) ? null : bean.destroyPriority();
     this.beanCloseable = (bean != null) && bean.autoCloseable();
-    // for multiRegister we desire a qualifier name such that builder.isBeanAbsent() uses it and allows
+    // for multiRegister we desire a qualifier name such that builder.canRegister() uses it and allows
     // other beans of the same type to also register, otherwise it defaults to slightly confusing behaviour
     this.name = multiRegister && qualifierName == null ? "multi" : qualifierName;
     TypeElement returnElement = multiRegister ? APContext.typeElement(uType.mainType()) : asElement(returnMirror);
@@ -352,7 +352,7 @@ final class MethodReader {
   }
 
   void buildAddFor(Append writer) {
-    writer.append("    if (builder.isBeanAbsent(");
+    writer.append("    if (builder.canRegister(");
     if (isVoid) {
       writer.append("Void.class");
     } else {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
@@ -172,7 +172,7 @@ final class SimpleBeanWriter {
 
   private void writeAddFor(MethodReader constructor) {
     beanReader.buildConditional(writer);
-    beanReader.buildCanRegister(writer);
+    beanReader.buildBeanAbsent(writer);
     if (beanReader.registerProvider()) {
       indent += "  ";
       writer.append("      builder.%s(() -> {", beanReader.lazy() ? "registerProvider" : "asPrototype().registerProvider").eol();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
@@ -172,7 +172,7 @@ final class SimpleBeanWriter {
 
   private void writeAddFor(MethodReader constructor) {
     beanReader.buildConditional(writer);
-    beanReader.buildAddFor(writer);
+    beanReader.buildBeanAbsent(writer);
     if (beanReader.registerProvider()) {
       indent += "  ";
       writer.append("      builder.%s(() -> {", beanReader.lazy() ? "registerProvider" : "asPrototype().registerProvider").eol();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
@@ -172,7 +172,7 @@ final class SimpleBeanWriter {
 
   private void writeAddFor(MethodReader constructor) {
     beanReader.buildConditional(writer);
-    beanReader.buildBeanAbsent(writer);
+    beanReader.buildCanRegister(writer);
     if (beanReader.registerProvider()) {
       indent += "  ";
       writer.append("      builder.%s(() -> {", beanReader.lazy() ? "registerProvider" : "asPrototype().registerProvider").eol();

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -35,7 +35,7 @@ public interface Builder {
 
   /**
    * Return true if the bean should be created and registered with the context.
-   * <p/>
+   * <p>
    * Returning false means there has been a supplied bean already registered and
    * that we should skip the creation and registration for this bean.
    *
@@ -46,9 +46,9 @@ public interface Builder {
 
   /**
    * Return true if the bean should be created and registered with the context.
-   *
-   * <p>Returning false means there has been a supplied bean already registered and that we should
-   * skip the creation and registration for this bean.
+   * <p>
+   * Returning false means there has been a supplied bean already registered and
+   * that we should skip the creation and registration for this bean.
    *
    * @param types The types that the bean implements and provides
    */
@@ -57,13 +57,6 @@ public interface Builder {
   }
 
   /**
-   * Return true if the bean should be created and registered with the context.
-   *
-   * <p>Returning false means there has been a supplied bean already registered and that we should
-   * skip the creation and registration for this bean.
-   *
-   * @param name The qualifier name
-   * @param types The types that the bean implements and provides
    * @deprecated use {@link #isBeanAbsent(String, Type...)}
    */
   @Deprecated(forRemoval = true)
@@ -72,12 +65,6 @@ public interface Builder {
   }
 
   /**
-   * Return true if the bean should be created and registered with the context.
-   *
-   * <p>Returning false means there has been a supplied bean already registered and that we should
-   * skip the creation and registration for this bean.
-   *
-   * @param types The types that the bean implements and provides
    * @deprecated use {@link #isBeanAbsent(Type...)} instead
    */
   @Deprecated(forRemoval = true)

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -42,7 +42,7 @@ public interface Builder {
    * @param name  The qualifier name
    * @param types The types that the bean implements and provides
    */
-  boolean isAddBeanFor(String name, Type... types);
+  boolean isBeanAbsent(String name, Type... types);
 
   /**
    * Return true if the bean should be created and registered with the context.
@@ -52,7 +52,36 @@ public interface Builder {
    *
    * @param types The types that the bean implements and provides
    */
-  boolean isAddBeanFor(Type... types);
+  boolean isBeanAbsent(Type... types);
+
+  /**
+   * Return true if the bean should be created and registered with the context.
+   *
+   * <p>Returning false means there has been a supplied bean already registered and that we should
+   * skip the creation and registration for this bean.
+   *
+   * @param name The qualifier name
+   * @param types The types that the bean implements and provides
+   * @deprecated use {@link #isBeanAbsent(String, Type...)}
+   */
+  @Deprecated(forRemoval = true)
+  default boolean isAddBeanFor(String name, Type... types) {
+    return isBeanAbsent(name, types);
+  }
+
+  /**
+   * Return true if the bean should be created and registered with the context.
+   *
+   * <p>Returning false means there has been a supplied bean already registered and that we should
+   * skip the creation and registration for this bean.
+   *
+   * @param types The types that the bean implements and provides
+   * @deprecated use {@link #isBeanAbsent(Type...)} instead
+   */
+  @Deprecated(forRemoval = true)
+  default boolean isAddBeanFor(Type... types) {
+    return isBeanAbsent(types);
+  }
 
   /**
    * Register the next bean as having Primary priority.

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -42,7 +42,7 @@ public interface Builder {
    * @param name  The qualifier name
    * @param types The types that the bean implements and provides
    */
-  boolean canRegister(String name, Type... types);
+  boolean isBeanAbsent(String name, Type... types);
 
   /**
    * Return true if the bean should be created and registered with the context.
@@ -52,8 +52,8 @@ public interface Builder {
    *
    * @param types The types that the bean implements and provides
    */
-  default boolean canRegister(Type... types) {
-    return canRegister(null, types);
+  default boolean isBeanAbsent(Type... types) {
+    return isBeanAbsent(null, types);
   }
 
   /**
@@ -64,11 +64,11 @@ public interface Builder {
    *
    * @param name The qualifier name
    * @param types The types that the bean implements and provides
-   * @deprecated use {@link #canRegister(String, Type...)}
+   * @deprecated use {@link #isBeanAbsent(String, Type...)}
    */
   @Deprecated(forRemoval = true)
   default boolean isAddBeanFor(String name, Type... types) {
-    return canRegister(name, types);
+    return isBeanAbsent(name, types);
   }
 
   /**
@@ -78,11 +78,11 @@ public interface Builder {
    * skip the creation and registration for this bean.
    *
    * @param types The types that the bean implements and provides
-   * @deprecated use {@link #canRegister(Type...)} instead
+   * @deprecated use {@link #isBeanAbsent(Type...)} instead
    */
   @Deprecated(forRemoval = true)
   default boolean isAddBeanFor(Type... types) {
-    return canRegister(types);
+    return isBeanAbsent(types);
   }
 
   /**

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -46,13 +46,15 @@ public interface Builder {
 
   /**
    * Return true if the bean should be created and registered with the context.
-   * <p/>
-   * Returning false means there has been a supplied bean already registered and
-   * that we should skip the creation and registration for this bean.
+   *
+   * <p>Returning false means there has been a supplied bean already registered and that we should
+   * skip the creation and registration for this bean.
    *
    * @param types The types that the bean implements and provides
    */
-  boolean isBeanAbsent(Type... types);
+  default boolean isBeanAbsent(Type... types) {
+    return isBeanAbsent(null, types);
+  }
 
   /**
    * Return true if the bean should be created and registered with the context.

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -42,7 +42,7 @@ public interface Builder {
    * @param name  The qualifier name
    * @param types The types that the bean implements and provides
    */
-  boolean isBeanAbsent(String name, Type... types);
+  boolean canRegister(String name, Type... types);
 
   /**
    * Return true if the bean should be created and registered with the context.
@@ -52,8 +52,8 @@ public interface Builder {
    *
    * @param types The types that the bean implements and provides
    */
-  default boolean isBeanAbsent(Type... types) {
-    return isBeanAbsent(null, types);
+  default boolean canRegister(Type... types) {
+    return canRegister(null, types);
   }
 
   /**
@@ -64,11 +64,11 @@ public interface Builder {
    *
    * @param name The qualifier name
    * @param types The types that the bean implements and provides
-   * @deprecated use {@link #isBeanAbsent(String, Type...)}
+   * @deprecated use {@link #canRegister(String, Type...)}
    */
   @Deprecated(forRemoval = true)
   default boolean isAddBeanFor(String name, Type... types) {
-    return isBeanAbsent(name, types);
+    return canRegister(name, types);
   }
 
   /**
@@ -78,11 +78,11 @@ public interface Builder {
    * skip the creation and registration for this bean.
    *
    * @param types The types that the bean implements and provides
-   * @deprecated use {@link #isBeanAbsent(Type...)} instead
+   * @deprecated use {@link #canRegister(Type...)} instead
    */
   @Deprecated(forRemoval = true)
   default boolean isAddBeanFor(Type... types) {
-    return isBeanAbsent(types);
+    return canRegister(types);
   }
 
   /**

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -49,11 +49,6 @@ class DBuilder implements Builder {
   }
 
   @Override
-  public final boolean isBeanAbsent(Type... types) {
-    return isBeanAbsent(null, types);
-  }
-
-  @Override
   public boolean isBeanAbsent(String name, Type... types) {
     parentMatch = null;
     next(name, types);

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -49,7 +49,7 @@ class DBuilder implements Builder {
   }
 
   @Override
-  public boolean canRegister(String name, Type... types) {
+  public boolean isBeanAbsent(String name, Type... types) {
     parentMatch = null;
     next(name, types);
     if (parentOverride || parent == null) {

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -49,12 +49,12 @@ class DBuilder implements Builder {
   }
 
   @Override
-  public final boolean isAddBeanFor(Type... types) {
-    return isAddBeanFor(null, types);
+  public final boolean isBeanAbsent(Type... types) {
+    return isBeanAbsent(null, types);
   }
 
   @Override
-  public boolean isAddBeanFor(String name, Type... types) {
+  public boolean isBeanAbsent(String name, Type... types) {
     parentMatch = null;
     next(name, types);
     if (parentOverride || parent == null) {

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -49,7 +49,7 @@ class DBuilder implements Builder {
   }
 
   @Override
-  public boolean isBeanAbsent(String name, Type... types) {
+  public boolean canRegister(String name, Type... types) {
     parentMatch = null;
     next(name, types);
     if (parentOverride || parent == null) {

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilderExtn.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilderExtn.java
@@ -34,8 +34,8 @@ final class DBuilderExtn extends DBuilder {
   }
 
   @Override
-  public boolean canRegister(String qualifierName, Type... types) {
-    if (!super.canRegister(qualifierName, types)) {
+  public boolean isBeanAbsent(String qualifierName, Type... types) {
+    if (!super.isBeanAbsent(qualifierName, types)) {
       enrichParentMatch();
       return false;
     }

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilderExtn.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilderExtn.java
@@ -34,8 +34,8 @@ final class DBuilderExtn extends DBuilder {
   }
 
   @Override
-  public boolean isAddBeanFor(String qualifierName, Type... types) {
-    if (!super.isAddBeanFor(qualifierName, types)) {
+  public boolean isBeanAbsent(String qualifierName, Type... types) {
+    if (!super.isBeanAbsent(qualifierName, types)) {
       enrichParentMatch();
       return false;
     }

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilderExtn.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilderExtn.java
@@ -34,8 +34,8 @@ final class DBuilderExtn extends DBuilder {
   }
 
   @Override
-  public boolean isBeanAbsent(String qualifierName, Type... types) {
-    if (!super.isBeanAbsent(qualifierName, types)) {
+  public boolean canRegister(String qualifierName, Type... types) {
+    if (!super.canRegister(qualifierName, types)) {
       enrichParentMatch();
       return false;
     }


### PR DESCRIPTION
I feel this rolls off the tongue a little better.

- deprecated the old methods for removal in 11
- change generation to use the new name