### PR TITLE
Fix Lazy Checked Exceptions

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyBean.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyBean.java
@@ -17,6 +17,8 @@ public class LazyBean {
 
   @Inject @Nullable AtomicBoolean initialized;
 
+  public LazyBean() throws Exception {}
+
   @PostConstruct
   void init(BeanScope scope) {
     // note that nested test scopes will not be lazy

--- a/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyFactory.java
@@ -14,7 +14,7 @@ public class LazyFactory {
 
   @Bean
   @Named("factory")
-  LazyBean lazyInt(@Nullable AtomicBoolean initialized) {
+  LazyBean lazyInt(@Nullable AtomicBoolean initialized) throws Exception {
 
     // note that nested test scopes will not be lazy
     if (initialized != null) initialized.set(true);

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -337,7 +337,7 @@ final class BeanReader {
   void prototypePostConstruct(Append writer, String indent) {
     if (postConstructMethod != null) {
       var postConstruct = (ExecutableElement) postConstructMethod;
-      writer.append("%s bean.%s(", indent, postConstructMethod.getSimpleName());
+      writer.indent(indent).append(" bean.%s(", postConstructMethod.getSimpleName());
       if (postConstruct.getParameters().isEmpty()) {
         writer.append(");").eol();
       } else {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
@@ -208,7 +208,6 @@ final class SimpleBeanWriter {
     }
 
     writer.append("    }");
-
     writer.eol();
   }
 
@@ -226,13 +225,13 @@ final class SimpleBeanWriter {
 
   private void writeExtraInjection() {
     if (!beanReader.registerProvider()) {
-      writer.indent("      ").append("builder.addInjector(b -> {").eol();
-      writer.indent("      ").append("  // field and method injection").eol();
+      writer.indent(indent).append(" builder.addInjector(b -> {").eol();
+      writer.indent(indent).append("   // field and method injection").eol();
     }
     injectFields();
     injectMethods();
     if (!beanReader.registerProvider()) {
-      writer.indent("      });").eol();
+      writer.indent(indent).append(" });").eol();
     }
   }
 

--- a/inject-generator/src/test/java/io/avaje/inject/generator/InjectProcessorTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/InjectProcessorTest.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import javax.tools.JavaCompiler;
@@ -23,16 +24,17 @@ import javax.tools.ToolProvider;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 
 class InjectProcessorTest {
 
   @AfterEach
   void deleteGeneratedFiles() {
     try {
-      Stream.concat(
+      Stream.of(
               Files.walk(Paths.get("io").toAbsolutePath()),
-              Files.walk(Paths.get("lang").toAbsolutePath()))
+              Files.walk(Paths.get("lang").toAbsolutePath()),
+              Files.walk(Paths.get("util").toAbsolutePath()))
+          .flatMap(Function.identity())
           .sorted(Comparator.reverseOrder())
           .map(Path::toFile)
           .forEach(File::delete);
@@ -41,7 +43,7 @@ class InjectProcessorTest {
     }
   }
 
-  @Disabled
+  //@Disabled
   @Test
   void testGeneration() throws Exception {
     final String source =

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lazy/LazyBean.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lazy/LazyBean.java
@@ -9,4 +9,6 @@ import jakarta.inject.Singleton;
 @Singleton
 public class LazyBean {
   @Inject Provider<Integer> intProvider;
+
+  public LazyBean() throws Exception {}
 }


### PR DESCRIPTION
Currently, this generates invalid code:
```java
@Singleton
public class LazyBean {
  @Inject Provider<Integer> intProvider;

  public LazyBean() throws Exception {}
}
```

Now properly generates code:

```java
@Generated("io.avaje.inject.generator")
public final class LazyBean$DI  {

  public static void build(Builder builder) {
    if (builder.isAddBeanFor(LazyBean.class)) {
      builder.registerProvider(() -> {
      try {
          var bean = new LazyBean();
          bean.intProvider = builder.getProvider(Integer.class);
          return bean;
      } catch (Throwable e) {
        throw new RuntimeException("Error during wiring", e);
      }
     });
    }
  }

}
```