### PR TITLE
Fix Repeatable Annotation Name Collision

### DIFF
--- a/inject-aop/src/main/java/io/avaje/inject/aop/Aspect.java
+++ b/inject-aop/src/main/java/io/avaje/inject/aop/Aspect.java
@@ -4,7 +4,7 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
 import java.lang.annotation.*;
 
-import io.avaje.inject.aop.Aspect.Import.List;
+import io.avaje.inject.aop.Aspect.Import.Imports;
 
 /**
  * Meta annotation used to define an Aspect.
@@ -38,7 +38,7 @@ public @interface Aspect {
    * Marks an External Annotation as being used for aspects
    */
   @Retention(SOURCE)
-  @Repeatable(List.class)
+  @Repeatable(Imports.class)
   @Target({PACKAGE, TYPE, MODULE})
   @interface Import {
 
@@ -56,7 +56,7 @@ public @interface Aspect {
 
     @Retention(SOURCE)
     @Target({TYPE, PACKAGE, MODULE})
-    @interface List {
+    @interface Imports {
 
       Import[] value();
     }


### PR DESCRIPTION
When using JDK 23+ module imports, the `List` type from `java.base`  and `io.avaje.inject.aop` have a name collision.

```java
import module java.base;
import module io.avaje.inject;

public class Example {

  void main() {
    List.of(); // this fails to resolve the import
  }
}
```