### PR TITLE
BeanScope PreDestroy

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/HelloService.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/HelloService.java
@@ -92,7 +92,7 @@ public class HelloService {
   }
 
   @PreDestroy(priority = 100)
-  void preDest() {
+  void preDest(BeanScope scope) {
     MyDestroyOrder.add("HelloService");
   }
 }

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -1,6 +1,7 @@
 package io.avaje.inject.spi;
 
 import io.avaje.inject.BeanScope;
+import io.avaje.inject.BeanScopeBuilder;
 import jakarta.inject.Provider;
 
 import java.lang.reflect.Type;
@@ -94,10 +95,10 @@ public interface Builder {
    */
   <T> void withBean(Class<T> type, T bean);
 
-  /**
-   * Add lifecycle PostConstruct method.
-   */
-  void addPostConstruct(Runnable runnable);
+  /** Add lifecycle PostConstruct method. */
+  default void addPostConstruct(Runnable runnable) {
+    addPostConstruct(b -> runnable.run());
+  }
 
   /**
    * Add lifecycle PostConstruct method.
@@ -107,12 +108,27 @@ public interface Builder {
   /**
    * Add lifecycle PreDestroy method.
    */
-  void addPreDestroy(AutoCloseable closeable);
+  default void addPreDestroy(AutoCloseable closeable) {
+    addPreDestroy(closeable, 1000);
+  }
+
+  /** Add lifecycle PreDestroy method with a given priority. */
+  default void addPreDestroy(AutoCloseable closeable, int priority) {
+
+    addPreDestroy(b -> closeable.close(), priority);
+  }
+
+  /**
+   * Add lifecycle PreDestroy method.
+   */
+  default void addPreDestroy(PreDestroyHook preDestroyHook) {
+    addPreDestroy(preDestroyHook, 1000);
+  }
 
   /**
    * Add lifecycle PreDestroy method with a given priority.
    */
-  void addPreDestroy(AutoCloseable closeable, int priority);
+  void addPreDestroy(PreDestroyHook preDestroyHook, int priority);
 
   /**
    * Check if the instance is AutoCloseable and if so register it with PreDestroy.

--- a/inject/src/main/java/io/avaje/inject/spi/ClosePair.java
+++ b/inject/src/main/java/io/avaje/inject/spi/ClosePair.java
@@ -3,9 +3,9 @@ package io.avaje.inject.spi;
 public final /*value*/ class ClosePair implements Comparable<ClosePair> {
 
   private final int priority;
-  private final AutoCloseable closeable;
+  private final PreDestroyHook closeable;
 
-  public ClosePair(int priority, AutoCloseable closeable) {
+  public ClosePair(int priority, PreDestroyHook closeable) {
     this.priority = priority;
     this.closeable = closeable;
   }
@@ -14,7 +14,7 @@ public final /*value*/ class ClosePair implements Comparable<ClosePair> {
     return priority;
   }
 
-  public AutoCloseable closeable() {
+  public PreDestroyHook hook() {
     return closeable;
   }
 

--- a/inject/src/main/java/io/avaje/inject/spi/PreDestroyHook.java
+++ b/inject/src/main/java/io/avaje/inject/spi/PreDestroyHook.java
@@ -1,0 +1,15 @@
+package io.avaje.inject.spi;
+
+import io.avaje.inject.BeanScope;
+
+/** Hook to run an action during beanScope closing. */
+@FunctionalInterface
+public interface PreDestroyHook {
+
+  /**
+   * Run an action to cleanup a bean during beanScope closing.
+   *
+   * @param beanScope the current bean scope
+   */
+  void destroy(BeanScope beanScope) throws Exception;
+}


### PR DESCRIPTION
Now can do 
```java
  @PreDestroy(priority = 100)
  void preDestroy(BeanScope scope) {
  
   // use the beanscope to close tricky beans

  }
```

- Adds a new interface for pre-destroy hooks that accept the current BeanScope
- refactor internals to convert `AutoCloseable` Interfaces for compatibility
- refactor postConstruct internals to convert `Runnable` to `Consumer<BeanScope>` instead of having two separate lists

Solves #749 
