### PR TITLE
Now can import `Prototype`/`Lazy` Beans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ build/
 inject-generator/avaje-inject
 inject-generator/avaje-inject-generator
 inject-generator/avaje-processors.txt
+inject-generator/avaje-module-dependencies.csv
+inject-generator/avaje-plugins.csv

--- a/blackbox-other/src/main/java/org/other/one/OtherComponent3.java
+++ b/blackbox-other/src/main/java/org/other/one/OtherComponent3.java
@@ -1,0 +1,3 @@
+package org.other.one;
+
+public class OtherComponent3 {}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/ConfigPropertiesPlugin.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/ConfigPropertiesPlugin.java
@@ -2,15 +2,18 @@ package org.example.myapp;
 
 import io.avaje.config.Config;
 import io.avaje.inject.Component;
+import io.avaje.inject.Component.Import.Kind;
 import io.avaje.inject.spi.ConfigPropertyPlugin;
 
 import io.avaje.spi.ServiceProvider;
 import org.other.one.OtherComponent2;
+import org.other.one.OtherComponent3;
 
 import java.util.Optional;
 
 @ServiceProvider
 @Component.Import(value = OtherComponent2.class)
+@Component.Import(value = OtherComponent3.class, kind = Kind.LAZY)
 public class ConfigPropertiesPlugin implements ConfigPropertyPlugin {
 
   @Override

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -59,7 +59,10 @@ final class BeanReader {
             || importedComponent && ProcessingContext.isImportedPrototype(beanType);
     this.primary = PrimaryPrism.isPresent(beanType);
     this.secondary = !primary && SecondaryPrism.isPresent(beanType);
-    this.lazy = !FactoryPrism.isPresent(beanType) && LazyPrism.isPresent(beanType);
+    this.lazy =
+        !FactoryPrism.isPresent(beanType)
+            && (LazyPrism.isPresent(beanType)
+                || importedComponent && ProcessingContext.isImportedLazy(beanType));
     final var beantypes = BeanTypesPrism.getOptionalOn(beanType);
     beantypes.ifPresent(p -> Util.validateBeanTypes(beanType, p.value()));
     this.typeReader =

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -54,7 +54,9 @@ final class BeanReader {
     this.beanType = beanType;
     this.type = beanType.getQualifiedName().toString();
     this.shortName = shortName(beanType);
-    this.prototype = PrototypePrism.isPresent(beanType);
+    this.prototype =
+        PrototypePrism.isPresent(beanType)
+            || importedComponent && ProcessingContext.isImportedPrototype(beanType);
     this.primary = PrimaryPrism.isPresent(beanType);
     this.secondary = !primary && SecondaryPrism.isPresent(beanType);
     this.lazy = !FactoryPrism.isPresent(beanType) && LazyPrism.isPresent(beanType);

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -1,6 +1,7 @@
 package io.avaje.inject.generator;
 
 import static io.avaje.inject.generator.APContext.logError;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -55,14 +56,14 @@ final class BeanReader {
     this.type = beanType.getQualifiedName().toString();
     this.shortName = shortName(beanType);
     this.prototype =
-        PrototypePrism.isPresent(beanType)
-            || importedComponent && ProcessingContext.isImportedPrototype(beanType);
+      PrototypePrism.isPresent(beanType)
+        || importedComponent && ProcessingContext.isImportedPrototype(beanType);
     this.primary = PrimaryPrism.isPresent(beanType);
     this.secondary = !primary && SecondaryPrism.isPresent(beanType);
     this.lazy =
-        !FactoryPrism.isPresent(beanType)
-            && (LazyPrism.isPresent(beanType)
-                || importedComponent && ProcessingContext.isImportedLazy(beanType));
+      !FactoryPrism.isPresent(beanType)
+        && (LazyPrism.isPresent(beanType)
+          || importedComponent && ProcessingContext.isImportedLazy(beanType));
     final var beantypes = BeanTypesPrism.getOptionalOn(beanType);
     beantypes.ifPresent(p -> Util.validateBeanTypes(beanType, p.value()));
     this.typeReader =
@@ -376,7 +377,7 @@ final class BeanReader {
       }
     }
     checkImports();
-    if (!suppressGeneratedImport){
+    if (!suppressGeneratedImport) {
       importTypes.add(Constants.GENERATED);
     }
     if (!suppressBuilderImport && !isGenerateProxy()) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
@@ -209,23 +209,23 @@ public final class InjectProcessor extends AbstractProcessor {
 
   private Set<TypeElement> importedElements(RoundEnvironment roundEnv) {
     return maybeElements(roundEnv, ImportPrism.PRISM_TYPE).stream()
-        .flatMap(Set::stream)
-        .map(ImportPrism::getInstanceOn)
-        .flatMap(
-            p -> {
-              var kind = p.kind();
-              return p.value().stream()
-                  .map(ProcessingContext::asElement)
-                  .filter(this::notAlreadyProvided)
-                  .map(
-                      e -> {
-                        if (!"SINGLETON".equals(kind)) {
-                          ProcessingContext.addImportedKind(e, kind);
-                        }
-                        return e;
-                      });
-            })
-        .collect(Collectors.toSet());
+      .flatMap(Set::stream)
+      .map(ImportPrism::getInstanceOn)
+      .flatMap(p -> {
+        var kind = p.kind();
+        return p.value().stream()
+          .map(ProcessingContext::asElement)
+          .filter(this::notAlreadyProvided)
+          .map(e -> registerImportedKind(e, kind));
+      })
+      .collect(Collectors.toSet());
+  }
+
+  private static TypeElement registerImportedKind(TypeElement e, String kind) {
+    if (!"SINGLETON".equals(kind)) {
+      ProcessingContext.addImportedKind(e, kind);
+    }
+    return e;
   }
 
   private boolean notAlreadyProvided(TypeElement e) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
@@ -209,12 +209,23 @@ public final class InjectProcessor extends AbstractProcessor {
 
   private Set<TypeElement> importedElements(RoundEnvironment roundEnv) {
     return maybeElements(roundEnv, ImportPrism.PRISM_TYPE).stream()
-      .flatMap(Set::stream)
-      .map(ImportPrism::getInstanceOn)
-      .flatMap(p -> p.value().stream())
-      .map(ProcessingContext::asElement)
-      .filter(this::notAlreadyProvided)
-      .collect(Collectors.toSet());
+        .flatMap(Set::stream)
+        .map(ImportPrism::getInstanceOn)
+        .flatMap(
+            p -> {
+              var prototype = p.prototype();
+              return p.value().stream()
+                  .map(ProcessingContext::asElement)
+                  .filter(this::notAlreadyProvided)
+                  .map(
+                      e -> {
+                        if (prototype) {
+                          ProcessingContext.addImportedPrototype(e);
+                        }
+                        return e;
+                      });
+            })
+        .collect(Collectors.toSet());
   }
 
   private boolean notAlreadyProvided(TypeElement e) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
@@ -213,14 +213,14 @@ public final class InjectProcessor extends AbstractProcessor {
         .map(ImportPrism::getInstanceOn)
         .flatMap(
             p -> {
-              var prototype = p.prototype();
+              var kind = p.kind();
               return p.value().stream()
                   .map(ProcessingContext::asElement)
                   .filter(this::notAlreadyProvided)
                   .map(
                       e -> {
-                        if (prototype) {
-                          ProcessingContext.addImportedPrototype(e);
+                        if (!"SINGLETON".equals(kind)) {
+                          ProcessingContext.addImportedKind(e, kind);
                         }
                         return e;
                       });

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -27,7 +27,7 @@ final class ProcessingContext {
   static final class Ctx {
     private final Set<String> uniqueModuleNames = new HashSet<>();
     private final Set<String> providedTypes = new HashSet<>();
-    private final Set<String> importedProtoTypes = new HashSet<>();
+    private final Map<String, String> importedProtoTypes = new HashMap<>();
     private final Set<String> optionalTypes = new LinkedHashSet<>();
     private final Map<String, AspectImportPrism> aspectImportPrisms = new HashMap<>();
     private final List<ModuleData> modules = new ArrayList<>();
@@ -155,12 +155,16 @@ final class ProcessingContext {
     }
   }
 
-  static void addImportedPrototype(TypeElement element) {
-    CTX.get().importedProtoTypes.add(element.getQualifiedName().toString());
+  static void addImportedKind(TypeElement element, String kind) {
+    CTX.get().importedProtoTypes.put(element.getQualifiedName().toString(), kind);
   }
 
   static boolean isImportedPrototype(TypeElement element) {
-    return CTX.get().importedProtoTypes.contains(element.getQualifiedName().toString());
+    return "prototype".equalsIgnoreCase(CTX.get().importedProtoTypes.get(element.getQualifiedName().toString()));
+  }
+
+  static boolean isImportedLazy(TypeElement element) {
+    return "lazy".equalsIgnoreCase(CTX.get().importedProtoTypes.get(element.getQualifiedName().toString()));
   }
 
   static void addImportedAspects(Map<String, AspectImportPrism> importedMap) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -27,6 +27,7 @@ final class ProcessingContext {
   static final class Ctx {
     private final Set<String> uniqueModuleNames = new HashSet<>();
     private final Set<String> providedTypes = new HashSet<>();
+    private final Set<String> importedProtoTypes = new HashSet<>();
     private final Set<String> optionalTypes = new LinkedHashSet<>();
     private final Map<String, AspectImportPrism> aspectImportPrisms = new HashMap<>();
     private final List<ModuleData> modules = new ArrayList<>();
@@ -152,6 +153,14 @@ final class ProcessingContext {
     if (!CTX.get().providedTypes.contains(paramType)) {
       CTX.get().optionalTypes.add(ProcessorUtils.trimAnnotations(Util.addQualifierSuffixTrim(name, paramType)));
     }
+  }
+
+  static void addImportedPrototype(TypeElement element) {
+    CTX.get().importedProtoTypes.add(element.getQualifiedName().toString());
+  }
+
+  static boolean isImportedPrototype(TypeElement element) {
+    return CTX.get().importedProtoTypes.contains(element.getQualifiedName().toString());
   }
 
   static void addImportedAspects(Map<String, AspectImportPrism> importedMap) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -160,11 +160,15 @@ final class ProcessingContext {
   }
 
   static boolean isImportedPrototype(TypeElement element) {
-    return "prototype".equalsIgnoreCase(CTX.get().importedProtoTypes.get(element.getQualifiedName().toString()));
+    return "prototype".equalsIgnoreCase(importedTypeKind(element));
   }
 
   static boolean isImportedLazy(TypeElement element) {
-    return "lazy".equalsIgnoreCase(CTX.get().importedProtoTypes.get(element.getQualifiedName().toString()));
+    return "lazy".equalsIgnoreCase(importedTypeKind(element));
+  }
+
+  private static String importedTypeKind(TypeElement element) {
+    return CTX.get().importedProtoTypes.get(element.getQualifiedName().toString());
   }
 
   static void addImportedAspects(Map<String, AspectImportPrism> importedMap) {

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/imported/ImportedProtoType.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/imported/ImportedProtoType.java
@@ -1,0 +1,6 @@
+package io.avaje.inject.generator.models.valid.imported;
+
+import io.avaje.inject.Component;
+
+@Component.Import(value = ImportedProtoType.class, prototype = true)
+public class ImportedProtoType {}

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/imported/ImportedProtoType.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/imported/ImportedProtoType.java
@@ -1,6 +1,7 @@
 package io.avaje.inject.generator.models.valid.imported;
 
 import io.avaje.inject.Component;
+import io.avaje.inject.Component.Import.Kind;
 
-@Component.Import(value = ImportedProtoType.class, prototype = true)
+@Component.Import(value = ImportedProtoType.class, kind =  Kind.PROTOTYPE)
 public class ImportedProtoType {}

--- a/inject/src/main/java/io/avaje/inject/Component.java
+++ b/inject/src/main/java/io/avaje/inject/Component.java
@@ -67,9 +67,10 @@ public @interface Component {
   @Target({TYPE, PACKAGE, MODULE})
   @interface Import {
 
-    /**
-     * Types to generate DI classes for.
-     */
+    /** Types to generate DI classes for. */
     Class<?>[] value();
+
+    /** Whether the imported types should have the prototype scope. */
+    boolean prototype() default false;
   }
 }

--- a/inject/src/main/java/io/avaje/inject/Component.java
+++ b/inject/src/main/java/io/avaje/inject/Component.java
@@ -4,8 +4,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.CLASS;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 /**
  * Identify a bean as component with singleton scope that avaje-inject will use.
@@ -63,14 +63,25 @@ public @interface Component {
    *
    * }</pre>
    */
-  @Retention(CLASS)
+  @Retention(SOURCE)
   @Target({TYPE, PACKAGE, MODULE})
   @interface Import {
 
     /** Types to generate DI classes for. */
     Class<?>[] value();
 
-    /** Whether the imported types should have the prototype scope. */
-    boolean prototype() default false;
+    /** What kind of bean */
+    Kind kind() default Kind.SINGLETON;
+
+    enum Kind { SINGLETON, PROTOTYPE, LAZY }
+  }
+
+  /**
+   * @see Import
+   */
+  @Retention(SOURCE)
+  @Target({TYPE, PACKAGE, MODULE})
+  @interface Imports {
+    Import[] value();
   }
 }

--- a/inject/src/main/java/io/avaje/inject/Component.java
+++ b/inject/src/main/java/io/avaje/inject/Component.java
@@ -1,5 +1,6 @@
 package io.avaje.inject;
 
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -65,6 +66,7 @@ public @interface Component {
    */
   @Retention(SOURCE)
   @Target({TYPE, PACKAGE, MODULE})
+  @Repeatable(Imports.class)
   @interface Import {
 
     /** Types to generate DI classes for. */


### PR DESCRIPTION
Adds an attribute to the `Component.Import` annotation to make imported types have the prototype/lazy scope