### PR TITLE
`PostConstruct` method Direct Injection

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/LifeFour.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/LifeFour.java
@@ -1,0 +1,18 @@
+package org.example.myapp.config;
+
+import io.avaje.inject.PostConstruct;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class LifeFour {
+
+  public String _state;
+
+  @PostConstruct
+  void post(@Named("foo") LifeOne one, LifeTwo two) {
+    _state = "post|"
+      + (one != null ? "one|" : "")
+      + (two != null ? "two" : "");
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/LifeOne.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/LifeOne.java
@@ -1,0 +1,17 @@
+package org.example.myapp.config;
+
+import io.avaje.inject.BeanScope;
+import io.avaje.inject.PostConstruct;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class LifeOne {
+
+  public String _state;
+
+  @PostConstruct
+  void post(BeanScope scope) {
+    _state = "post|"
+      + (scope != null ? "scope" : "");
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/LifeProtoTwo.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/LifeProtoTwo.java
@@ -1,0 +1,18 @@
+package org.example.myapp.config;
+
+import io.avaje.inject.BeanScope;
+import io.avaje.inject.PostConstruct;
+import io.avaje.inject.Prototype;
+
+@Prototype
+public class LifeProtoTwo {
+
+  public String _state;
+
+  @PostConstruct
+  void post(LifeOne one, BeanScope scope) {
+    _state = "post|"
+      + (one != null ? "one|" : "")
+      + (scope != null ? "scope" : "");
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/LifeThree.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/LifeThree.java
@@ -1,0 +1,16 @@
+package org.example.myapp.config;
+
+import io.avaje.inject.PostConstruct;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class LifeThree {
+
+  public String _state;
+
+  @PostConstruct
+  void post(LifeOne one) {
+    _state = "post|"
+      + (one != null ? "one" : "");
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/LifeTwo.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/LifeTwo.java
@@ -1,0 +1,18 @@
+package org.example.myapp.config;
+
+import io.avaje.inject.BeanScope;
+import io.avaje.inject.PostConstruct;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class LifeTwo {
+
+  public String _state;
+
+  @PostConstruct
+  void post(LifeOne one, BeanScope scope) {
+    _state = "post|"
+      + (one != null ? "one|" : "")
+      + (scope != null ? "scope" : "");
+  }
+}

--- a/blackbox-test-inject/src/test/java/org/example/myapp/config/PostConstructParametersTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/config/PostConstructParametersTest.java
@@ -14,11 +14,13 @@ class PostConstructParametersTest {
       var two = testScope.get(LifeTwo.class);
       var three = testScope.get(LifeThree.class);
       var four = testScope.get(LifeFour.class);
+      var protoTwo = testScope.get(LifeProtoTwo.class);
 
       assertThat(one._state).isEqualTo("post|scope");
       assertThat(two._state).isEqualTo("post|one|scope");
       assertThat(three._state).isEqualTo("post|one");
       assertThat(four._state).isEqualTo("post|one|two");
+      assertThat(protoTwo._state).isEqualTo("post|one|scope");
     }
   }
 

--- a/blackbox-test-inject/src/test/java/org/example/myapp/config/PostConstructParametersTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/config/PostConstructParametersTest.java
@@ -1,0 +1,25 @@
+package org.example.myapp.config;
+
+import io.avaje.inject.BeanScope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostConstructParametersTest {
+
+  @Test
+  void factorySecondaryAsProvider() {
+    try (BeanScope testScope = BeanScope.builder().build()) {
+      var one = testScope.get(LifeOne.class);
+      var two = testScope.get(LifeTwo.class);
+      var three = testScope.get(LifeThree.class);
+      var four = testScope.get(LifeFour.class);
+
+      assertThat(one._state).isEqualTo("post|scope");
+      assertThat(two._state).isEqualTo("post|one|scope");
+      assertThat(three._state).isEqualTo("post|one");
+      assertThat(four._state).isEqualTo("post|one|two");
+    }
+  }
+
+}

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -54,10 +54,15 @@ final class BeanReader {
     this.beanType = beanType;
     this.type = beanType.getQualifiedName().toString();
     this.shortName = shortName(beanType);
-    this.prototype = PrototypePrism.isPresent(beanType);
+    this.prototype =
+      PrototypePrism.isPresent(beanType)
+        || importedComponent && ProcessingContext.isImportedPrototype(beanType);
     this.primary = PrimaryPrism.isPresent(beanType);
     this.secondary = !primary && SecondaryPrism.isPresent(beanType);
-    this.lazy = !FactoryPrism.isPresent(beanType) && LazyPrism.isPresent(beanType);
+    this.lazy =
+      !FactoryPrism.isPresent(beanType)
+        && (LazyPrism.isPresent(beanType)
+          || importedComponent && ProcessingContext.isImportedLazy(beanType));
     final var beantypes = BeanTypesPrism.getOptionalOn(beanType);
     beantypes.ifPresent(p -> Util.validateBeanTypes(beanType, p.value()));
     this.typeReader =

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -353,8 +353,8 @@ final class BeanReader {
     if (params.isEmpty() || Constants.BEANSCOPE.equals(params.get(0).getFullUType().shortType())) {
       writer.append("$bean::%s);", methodName).eol();
     } else {
-      writer.append("b -> $bean.%s(", methodName);
-      writeLifeCycleGet(writer, params, "b", "b");
+      writer.append("beanScope -> $bean.%s(", methodName);
+      writeLifeCycleGet(writer, params, "beanScope", "beanScope");
       writer.append(");").eol();
     }
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsInjection.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsInjection.java
@@ -30,7 +30,7 @@ final class TypeExtendsInjection {
   private final TypeElement baseType;
   private final boolean factory;
   private final List<AspectPair> typeAspects;
-  private Element postConstructMethod;
+  private Optional<MethodReader> postConstructMethod = Optional.empty();
   private Element preDestroyMethod;
   private Integer preDestroyPriority;
 
@@ -125,7 +125,7 @@ final class TypeExtendsInjection {
       notInjectMethods.add(methodKey);
     }
     if (AnnotationUtil.hasAnnotationWithName(element, "PostConstruct")) {
-      postConstructMethod = element;
+      postConstructMethod = Optional.of(new MethodReader(methodElement, type, importTypes).read());
       checkAspect = false;
     }
     if (AnnotationUtil.hasAnnotationWithName(element, "PreDestroy")) {
@@ -206,7 +206,7 @@ final class TypeExtendsInjection {
     return observerMethods;
   }
 
-  Element postConstructMethod() {
+  Optional<MethodReader> postConstructMethod() {
     return postConstructMethod;
   }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -7,6 +7,7 @@ import static io.avaje.inject.generator.ProcessingContext.asElement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -101,7 +102,7 @@ final class TypeExtendsReader {
     return extendsInjection.observerMethods();
   }
 
-  Element postConstructMethod() {
+  Optional<MethodReader> postConstructMethod() {
     return extendsInjection.postConstructMethod();
   }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeReader.java
@@ -1,14 +1,14 @@
 package io.avaje.inject.generator;
 
-import javax.lang.model.element.Element;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
+import static java.util.stream.Collectors.toList;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import static java.util.stream.Collectors.toList;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
 
 final class TypeReader {
 
@@ -107,7 +107,7 @@ final class TypeReader {
     return extendsReader.observerMethods();
   }
 
-  Element postConstructMethod() {
+  Optional<MethodReader> postConstructMethod() {
     return extendsReader.postConstructMethod();
   }
 

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lifecycle/Minos.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lifecycle/Minos.java
@@ -1,0 +1,18 @@
+package io.avaje.inject.generator.models.valid.lifecycle;
+
+import java.util.function.Consumer;
+
+import io.avaje.inject.BeanScope;
+import io.avaje.inject.PostConstruct;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class Minos {
+
+  @PostConstruct
+  void prepareThyself(Serpent serpent, Consumer<String> c, BeanScope b) {}
+
+  //  @PreDestroy
+  //  void thyEndIsNow() {
+  //  }
+}

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lifecycle/Serpent.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lifecycle/Serpent.java
@@ -1,0 +1,15 @@
+package io.avaje.inject.generator.models.valid.lifecycle;
+
+import java.util.function.Consumer;
+
+import io.avaje.inject.BeanScope;
+import io.avaje.inject.PostConstruct;
+import io.avaje.inject.Prototype;
+
+@Prototype
+public class Serpent {
+
+  @PostConstruct
+  void hiss(Consumer<String> c, BeanScope b) {}
+
+}


### PR DESCRIPTION
generates the lookup and fetches beans for `PostConstruct ` lifecycle methods. (Before we could only inject the `BeanScope`)

Given:

```java
@Singleton
public class Minos {

  @PostConstruct
  void prepareThyself(Serpent serpent, Consumer<String> c, BeanScope b) {}
}
```

the following is generated:

```java
@Generated("io.avaje.inject.generator")
public final class Minos$DI  {

  public static final Type TYPE_ConsumerString =
      new GenericType<Consumer<String>>(){}.type();

  public static void build(Builder builder) {
    if (builder.isBeanAbsent(Minos.class)) {
      var bean = new Minos();
      var $bean = builder.register(bean);
      builder.addPostConstruct(b -> $bean.prepareThyself(b.get(Serpent.class,"!serpent"), b.get(TYPE_ConsumerString), b));
    }
  }
}