### PR TITLE
#749 Add support for a @PreDestroy method on a factory, alternative to @Bean(destroyMethod)

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/MyNestedDestroy.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/MyNestedDestroy.java
@@ -4,16 +4,16 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class MyNestedDestroy {
 
-  public static AtomicInteger started = new AtomicInteger();
-  public static AtomicInteger stopped = new AtomicInteger();
+  public static AtomicInteger STARTED = new AtomicInteger();
+  public static AtomicInteger STOPPED = new AtomicInteger();
 
   public static void reset() {
-    started.set(0);
-    stopped.set(0);
+    STARTED.set(0);
+    STOPPED.set(0);
   }
 
   public void start() {
-    started.incrementAndGet();
+    STARTED.incrementAndGet();
   }
 
   public Reaper reaper() {
@@ -23,7 +23,7 @@ public class MyNestedDestroy {
   public static class Reaper {
 
     public void stop() {
-      stopped.incrementAndGet();
+      STOPPED.incrementAndGet();
     }
   }
 }

--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/AFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/AFactory.java
@@ -2,16 +2,47 @@ package org.example.myapp.config;
 
 import io.avaje.inject.Bean;
 import io.avaje.inject.Factory;
+import io.avaje.inject.PreDestroy;
 import org.example.myapp.MyNestedDestroy;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Factory
-class AFactory {
+public class AFactory {
+
+  public static AtomicInteger DESTROY_COUNT_BEAN = new AtomicInteger();
+  public static AtomicInteger DESTROY_COUNT_COMPONENT = new AtomicInteger();
+  public static AtomicInteger DESTROY_COUNT_AFOO = new AtomicInteger();
+
+  public static void reset() {
+    DESTROY_COUNT_BEAN.set(0);
+    DESTROY_COUNT_AFOO.set(0);
+    DESTROY_COUNT_COMPONENT.set(0);
+  }
 
   @Bean(initMethod = "start", destroyMethod = "reaper().stop()")
   MyNestedDestroy lifecycle2() {
     return new MyNestedDestroy();
+  }
+
+  @PreDestroy(priority = 3000)
+  void dest2(MyNestedDestroy bean) {
+    DESTROY_COUNT_BEAN.incrementAndGet();
+  }
+
+//  // compiler error when type does not match any @Bean method
+//  @PreDestroy(priority = 3001)
+//  void destErr(Object bean) {
+//
+//  }
+
+  /**
+   * NO args so this is the normal factory component destroy method.
+   */
+  @PreDestroy
+  void factoryDestroy() {
+    DESTROY_COUNT_COMPONENT.incrementAndGet();
   }
 
   @Bean
@@ -38,6 +69,11 @@ class AFactory {
   @Bean
   AFoo buildAfoo() throws IOException {
     return new AFoo();
+  }
+
+  @PreDestroy
+  void destAfoo(AFoo bean) {
+    DESTROY_COUNT_AFOO.incrementAndGet();
   }
 
   static class I0 implements A0.Builder {

--- a/blackbox-test-inject/src/test/java/org/example/myapp/HelloServiceTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/HelloServiceTest.java
@@ -4,6 +4,7 @@ import io.avaje.inject.BeanScope;
 import io.avaje.inject.aop.InvocationException;
 import org.example.myapp.aspect.MyAroundAspect;
 import org.example.myapp.aspect.MyMultiInvokeAspect;
+import org.example.myapp.config.AFactory;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -17,12 +18,19 @@ class HelloServiceTest {
   @Test
   void lifecycles() {
     MyNestedDestroy.reset();
+    AFactory.reset();
     try (BeanScope beanScope = BeanScope.builder().build()) {
       assertThat(beanScope.get(MyNestedDestroy.class)).isNotNull();
-      assertThat(MyNestedDestroy.started.get()).isEqualTo(1);
-      assertThat(MyNestedDestroy.stopped.get()).isEqualTo(0);
+      assertThat(MyNestedDestroy.STARTED.get()).isEqualTo(1);
+      assertThat(MyNestedDestroy.STOPPED.get()).isEqualTo(0);
+      assertThat(AFactory.DESTROY_COUNT_BEAN.get()).isEqualTo(0);
+      assertThat(AFactory.DESTROY_COUNT_AFOO.get()).isEqualTo(0);
+      assertThat(AFactory.DESTROY_COUNT_COMPONENT.get()).isEqualTo(0);
     }
-    assertThat(MyNestedDestroy.stopped.get()).isEqualTo(1);
+    assertThat(MyNestedDestroy.STOPPED.get()).isEqualTo(1);
+    assertThat(AFactory.DESTROY_COUNT_BEAN.get()).isEqualTo(1);
+    assertThat(AFactory.DESTROY_COUNT_AFOO.get()).isEqualTo(1);
+    assertThat(AFactory.DESTROY_COUNT_COMPONENT.get()).isEqualTo(1);
   }
 
   /**

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -541,4 +541,8 @@ final class BeanReader {
   boolean isDelayed() {
     return delayed;
   }
+
+  void validate() {
+    typeReader.validate();
+  }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/DestroyMethods.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/DestroyMethods.java
@@ -1,0 +1,77 @@
+package io.avaje.inject.generator;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Holds extra PreDestroy methods for a factory.
+ * <p>
+ * These methods are expected to relate back to a {@code @Bean} method
+ * on the same factory.
+ */
+final class DestroyMethods {
+
+  private final Map<String, DestroyMethod> methods = new HashMap<>();
+  private final Set<String> matchedTypes = new HashSet<>();
+
+  void add(ExecutableElement element) {
+    Integer priority = PreDestroyPrism.getOptionalOn(element)
+      .map(PreDestroyPrism::priority)
+      .orElse(null);
+
+    var destroyMethod = new DestroyMethod(element, priority);
+    methods.put(destroyMethod.matchType, destroyMethod);
+  }
+
+  DestroyMethod match(String returnTypeRaw) {
+    var match = methods.get(returnTypeRaw);
+    if (match != null) {
+      matchedTypes.add(returnTypeRaw);
+    }
+    return match;
+  }
+
+  /**
+   * Return PreDestroy methods that were not matched to a {@code @Bean} method
+   * on the same factory.
+   */
+  List<DestroyMethod> unmatched() {
+    return methods.values()
+      .stream()
+      .filter(entry -> !matchedTypes.contains(entry.matchType()))
+      .collect(Collectors.toList());
+  }
+
+  static final class DestroyMethod {
+
+    private final String method;
+    private final Integer priority;
+    private final String matchType;
+    private final ExecutableElement element;
+
+    DestroyMethod(ExecutableElement element, Integer priority) {
+      this.element = element;
+      this.method = element.getSimpleName().toString();
+      this.matchType = element.getParameters().get(0).asType().toString();
+      this.priority = priority;
+    }
+
+    String method() {
+      return method;
+    }
+
+    Integer priority() {
+      return priority;
+    }
+
+    String matchType() {
+      return matchType;
+    }
+
+    Element element() {
+      return element;
+    }
+  }
+}

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
@@ -135,6 +135,7 @@ final class SimpleBeanWriter {
     for (MethodReader factoryMethod : beanReader.factoryMethods()) {
       writeFactoryBeanMethod(factoryMethod);
     }
+    beanReader.validate();
   }
 
   private void writeFactoryBeanMethod(MethodReader method) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsReader.java
@@ -262,4 +262,8 @@ final class TypeExtendsReader {
   private boolean isPublic(Element element) {
     return element != null && element.getModifiers().contains(Modifier.PUBLIC);
   }
+
+  void validate() {
+    extendsInjection.validate();
+  }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeReader.java
@@ -165,4 +165,8 @@ final class TypeReader {
       genericTypes.forEach(t -> importTypes.addAll(t.importTypes()));
     }
   }
+
+  void validate() {
+    extendsReader.validate();
+  }
 }

--- a/inject-generator/src/test/java/io/avaje/inject/generator/MethodReaderTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/MethodReaderTest.java
@@ -16,4 +16,11 @@ class MethodReaderTest {
   void addPreDestroyNested() {
     assertThat(MethodReader.addPreDestroy("foo().bar()")).isEqualTo("() -> $bean.foo().bar()");
   }
+
+  @Test
+  void priority() {
+    assertThat(MethodReader.priority(null)).isEqualTo("");
+    assertThat(MethodReader.priority(1000)).isEqualTo("");
+    assertThat(MethodReader.priority(52)).isEqualTo(", 52");
+  }
 }


### PR DESCRIPTION
Example:
```java
@Factory
final class MyFactory {

  @Bean
  MyComponent myComponent() {
   ...
  }

  @PreDestroy(priority = 3000)
  void destroyMyComponent(MyComponent bean) {
    ...
  }
```

- ONLY valid on factory components
- An alternative to @Bean(destroyMethod)
- The @PreDestroy method matches to a @Bean by type only (ignores qualifiers, only 1 argument to the destroy method)