### PR TITLE
[inject-test] Can inject the BeanScope into `@InjectTest` tests.

### DIFF
--- a/inject-test/src/main/java/io/avaje/inject/test/MetaReader.java
+++ b/inject-test/src/main/java/io/avaje/inject/test/MetaReader.java
@@ -350,7 +350,12 @@ final class MetaReader {
 
     void setFromScope(BeanScope beanScope, Object testInstance) throws IllegalAccessException {
       if (!valueAlreadyProvided) {
-        set(field, beanScope.get(type(), name), testInstance);
+        final var type = type();
+        if (type.equals(BeanScope.class)) {
+          set(field, beanScope, testInstance);
+        } else {
+          set(field, beanScope.get(type, name), testInstance);
+        }
       }
     }
 

--- a/inject-test/src/test/java/org/example/beanscope/BeanScopeInject.java
+++ b/inject-test/src/test/java/org/example/beanscope/BeanScopeInject.java
@@ -1,0 +1,20 @@
+package org.example.beanscope;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.inject.BeanScope;
+import io.avaje.inject.test.InjectTest;
+import jakarta.inject.Inject;
+
+@InjectTest
+class BeanScopeInjectTest {
+
+  @Inject BeanScope beanScope;
+
+  @Test
+  void test() {
+    assertThat(beanScope.all()).isNotEmpty();
+  }
+}


### PR DESCRIPTION
Now tests using `@InjectTest` are able to inject the full `BeanScope` into the test.