### PR TITLE
Fix `cutAnnotations` Edge Case

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -151,9 +151,7 @@ final class ProcessingContext {
 
   static void addOptionalType(String paramType, String name) {
     if (!CTX.get().providedTypes.contains(paramType)) {
-      CTX.get()
-          .optionalTypes
-          .add(Util.addQualifierSuffixTrim(name, ProcessorUtils.trimAnnotations(paramType)));
+      CTX.get().optionalTypes.add(Util.addQualifierSuffixTrim(name, ProcessorUtils.trimAnnotations(paramType)));
     }
   }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ProcessingContext.java
@@ -151,7 +151,9 @@ final class ProcessingContext {
 
   static void addOptionalType(String paramType, String name) {
     if (!CTX.get().providedTypes.contains(paramType)) {
-      CTX.get().optionalTypes.add(ProcessorUtils.trimAnnotations(Util.addQualifierSuffixTrim(name, paramType)));
+      CTX.get()
+          .optionalTypes
+          .add(Util.addQualifierSuffixTrim(name, ProcessorUtils.trimAnnotations(paramType)));
     }
   }
 


### PR DESCRIPTION
It's hard to replicate, but in certain situations it is possible to get an OOM error when compiling. I've been seeing it occasionally when I debug the generator with eclipse.

this change causes the qualifier suffix to be appended after annotation stripping