### PR TITLE
Validate only a single `@InjectModule` annotation

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
@@ -329,6 +329,7 @@ public final class InjectProcessor extends AbstractProcessor {
     var moduleList =
         maybeElements(roundEnv, InjectModulePrism.PRISM_TYPE).stream()
             .flatMap(Set::stream)
+            .filter(e -> !ScopePrism.isPresent(e))
             .filter(
                 e ->
                     (!(e instanceof TypeElement)
@@ -340,7 +341,7 @@ public final class InjectProcessor extends AbstractProcessor {
 
       for (var element : moduleList) {
         logError(
-            element, "There should only be one user provided @InjectModule annotation in a module");
+            element, "There should only be one default scope @InjectModule annotation in a module");
       }
     }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
@@ -330,7 +330,7 @@ public final class InjectProcessor extends AbstractProcessor {
         maybeElements(roundEnv, InjectModulePrism.PRISM_TYPE).stream()
             .flatMap(Set::stream)
             .filter(e -> !ScopePrism.isPresent(e))
-            .filter(e -> !GeneratedPrism.isPresent(getProjectModuleElement()))
+            .filter(e -> !GeneratedPrism.isPresent(e))
             .collect(toList());
 
     if (moduleList.size() > 1) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
@@ -325,19 +325,16 @@ public final class InjectProcessor extends AbstractProcessor {
    * Read the existing meta-data from InjectModule (if found) and the factory bean (if exists).
    */
   private void readModule(RoundEnvironment roundEnv) {
-
     var moduleList =
-        maybeElements(roundEnv, InjectModulePrism.PRISM_TYPE).stream()
-            .flatMap(Set::stream)
-            .filter(e -> !ScopePrism.isPresent(e))
-            .filter(e -> !GeneratedPrism.isPresent(e))
-            .collect(toList());
+      maybeElements(roundEnv, InjectModulePrism.PRISM_TYPE).stream()
+        .flatMap(Set::stream)
+        .filter(e -> !ScopePrism.isPresent(e))
+        .filter(e -> !GeneratedPrism.isPresent(e))
+        .collect(toList());
 
     if (moduleList.size() > 1) {
-
       for (var element : moduleList) {
-        logError(
-            element, "There should only be one default scope @InjectModule annotation in a module");
+        logError(element, "There should only be one default scope @InjectModule annotation in a module");
       }
     }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
@@ -15,6 +15,8 @@ import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
 
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
@@ -243,7 +245,7 @@ public final class InjectProcessor extends AbstractProcessor {
 
   private void readScopes(Set<? extends Element> scopes) {
     for (final Element element : scopes) {
-      if ((element.getKind() == ElementKind.ANNOTATION_TYPE) && (element instanceof TypeElement)) {
+      if (element.getKind() == ElementKind.ANNOTATION_TYPE && element instanceof TypeElement) {
         final var type = (TypeElement) element;
         allScopes.addScopeAnnotation(type);
       }
@@ -323,6 +325,25 @@ public final class InjectProcessor extends AbstractProcessor {
    * Read the existing meta-data from InjectModule (if found) and the factory bean (if exists).
    */
   private void readModule(RoundEnvironment roundEnv) {
+
+    var moduleList =
+        maybeElements(roundEnv, InjectModulePrism.PRISM_TYPE).stream()
+            .flatMap(Set::stream)
+            .filter(
+                e ->
+                    (!(e instanceof TypeElement)
+                        || !APContext.isAssignable(
+                            (TypeElement) e, "io.avaje.inject.spi.AvajeModule")))
+            .collect(toList());
+
+    if (moduleList.size() > 1) {
+
+      for (var element : moduleList) {
+        logError(
+            element, "There should only be one user provided @InjectModule annotation in a module");
+      }
+    }
+
     if (readModuleInfo) {
       // only read the module meta data once
       return;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
@@ -330,11 +330,7 @@ public final class InjectProcessor extends AbstractProcessor {
         maybeElements(roundEnv, InjectModulePrism.PRISM_TYPE).stream()
             .flatMap(Set::stream)
             .filter(e -> !ScopePrism.isPresent(e))
-            .filter(
-                e ->
-                    (!(e instanceof TypeElement)
-                        || !APContext.isAssignable(
-                            (TypeElement) e, "io.avaje.inject.spi.AvajeModule")))
+            .filter(e -> !GeneratedPrism.isPresent(getProjectModuleElement()))
             .collect(toList());
 
     if (moduleList.size() > 1) {


### PR DESCRIPTION
Saw some cases where users had multiple for whatever reason and it wasn't working right. (strict wiring was being overridden)

- validates that no extra `@InjectModule`s are lying around
- filter out generated classes from validation (we expect to read them)
- filter out custom scope annotations as well