### PR TITLE
Cancel Generation on errors

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
@@ -129,6 +129,10 @@ public final class InjectProcessor extends AbstractProcessor {
 
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+    if (roundEnv.errorRaised()) {
+      return false;
+    }
+
     APContext.setProjectModuleElement(annotations, roundEnv);
     readModule(roundEnv);
 


### PR DESCRIPTION
APT Errors tend to spiral, this ensures that a user can more clearly identify generation errors