### PR TITLE
Fix ExternalProvider on JDT

### DIFF
--- a/inject-generator/pom.xml
+++ b/inject-generator/pom.xml
@@ -13,7 +13,7 @@
   <name>avaje inject generator</name>
   <description>annotation processor generating source code for avaje-inject dependency injection</description>
   <properties>
-    <avaje.prisms.version>1.39</avaje.prisms.version>
+    <avaje.prisms.version>1.40</avaje.prisms.version>
     <!-- valhalla-build-start ___
     <maven.compiler.enablePreview>false</maven.compiler.enablePreview>
     ____ valhalla-build-end -->
@@ -55,7 +55,7 @@
       <version>1.5</version>
       <scope>test</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-client</artifactId>

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -318,17 +318,16 @@ final class ExternalProvider {
         .filter(t -> types.isAssignable(t.asType(), extensionType));
 
     final var checkDirectives =
-        allModules.stream()
-            .flatMap(ExternalProvider::providesDirectives)
-            .filter(ExternalProvider::isInjectExtension)
-            .flatMap(p -> p.getImplementations().stream());
+      allModules.stream()
+        .flatMap(ExternalProvider::providesDirectives)
+        .filter(ExternalProvider::isInjectExtension)
+        .flatMap(p -> p.getImplementations().stream());
 
     return Stream.concat(checkEnclosing, checkDirectives);
   }
 
   // Automatic modules throw an NPE for getDirectives on JDT
   private static Stream<ProvidesDirective> providesDirectives(ModuleElement m) {
-
     try {
       return ElementFilter.providesIn(m.getDirectives()).stream();
     } catch (NullPointerException npe) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -24,6 +24,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.ModuleElement;
+import javax.lang.model.element.ModuleElement.ProvidesDirective;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.ElementFilter;
 
@@ -323,6 +324,16 @@ final class ExternalProvider {
         .flatMap(p -> p.getImplementations().stream());
 
     return Stream.concat(checkEnclosing, checkDirectives);
+  }
+
+  // Automatic modules throw an NPE for getDirectives on JDT
+  private static Stream<ProvidesDirective> providesDirectives(ModuleElement m) {
+
+    try {
+      return ElementFilter.providesIn(m.getDirectives()).stream();
+    } catch (NullPointerException npe) {
+      return Stream.of();
+    }
   }
 
   // when a project's module-info is misconfigured a certain way, getEnclosedElements throws an error

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -318,10 +318,10 @@ final class ExternalProvider {
         .filter(t -> types.isAssignable(t.asType(), extensionType));
 
     final var checkDirectives =
-      allModules.stream()
-        .flatMap(m -> ElementFilter.providesIn(m.getDirectives()).stream())
-        .filter(ExternalProvider::isInjectExtension)
-        .flatMap(p -> p.getImplementations().stream());
+        allModules.stream()
+            .flatMap(ExternalProvider::providesDirectives)
+            .filter(ExternalProvider::isInjectExtension)
+            .flatMap(p -> p.getImplementations().stream());
 
     return Stream.concat(checkEnclosing, checkDirectives);
   }


### PR DESCRIPTION
turns out getDirectives throws an NPE if it's an automatic module. Only happens with JDT though