### PR TITLE
Detect clash with multiple @Bean methods returning same type

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/BFace.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/BFace.java
@@ -1,0 +1,6 @@
+package org.example.myapp.config;
+
+public interface BFace {
+
+  String hi();
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/BFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/BFactory.java
@@ -1,0 +1,44 @@
+package org.example.myapp.config;
+
+import io.avaje.inject.Bean;
+import io.avaje.inject.Factory;
+import jakarta.inject.Named;
+
+import java.util.Optional;
+
+@Factory
+public class BFactory {
+
+  @Named
+  @Bean
+  BFace one() {
+    return new TheBFace("one");
+  }
+
+  @Named
+  @Bean
+  BFace two() {
+    return new TheBFace("two");
+  }
+
+  @Named
+  @Bean
+  Optional<BFace> three() {
+    return Optional.of(new TheBFace("three"));
+  }
+
+
+  static class TheBFace implements BFace {
+
+    private final String msg;
+
+    TheBFace(String msg) {
+      this.msg = msg;
+    }
+
+    @Override
+    public String hi() {
+      return msg;
+    }
+  }
+}

--- a/blackbox-test-inject/src/test/java/org/example/myapp/config/BFactoryTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/config/BFactoryTest.java
@@ -1,0 +1,31 @@
+package org.example.myapp.config;
+
+import io.avaje.inject.BeanScope;
+import io.avaje.inject.test.TestBeanScope;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BFactoryTest {
+
+  @Test
+  void beanMethodsOfSameType() {
+    try (BeanScope scope = TestBeanScope.builder().build()) {
+      BFace one = scope.get(BFace.class, "one");
+      BFace two = scope.get(BFace.class, "two");
+      BFace three = scope.get(BFace.class, "three");
+      assertThat(one).isNotNull();
+      assertThat(two).isNotNull();
+      assertThat(three).isNotNull();
+
+      List<BFace> list = scope.list(BFace.class);
+      assertThat(list).hasSize(3);
+
+      List<String> hi = list.stream().map(BFace::hi).collect(Collectors.toList());
+      assertThat(hi).containsOnly("one", "two", "three");
+    }
+  }
+}

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -499,6 +499,14 @@ final class MethodReader {
     return observeParameter;
   }
 
+  String qualifiedKey() {
+    return name + ':' + genericType.full();
+  }
+
+  boolean isVoid() {
+    return isVoid;
+  }
+
   static class MethodParam {
 
     private final VariableElement element;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -294,7 +294,12 @@ final class Util {
   static String named(Element p) {
     final NamedPrism named = NamedPrism.getInstanceOn(p);
     if (named != null) {
-      return named.value().replace("\"", "\\\"");
+      String raw = named.value();
+      if (raw.isEmpty()) {
+        // default to the method name
+        raw = p.getSimpleName().toString();
+      }
+      return raw.replace("\"", "\\\"");
     }
     for (final AnnotationMirror annotationMirror : p.getAnnotationMirrors()) {
       final DeclaredType annotationType = annotationMirror.getAnnotationType();


### PR DESCRIPTION
Given a `@Factory` with 2 or more bean methods that return the same type, and effectively clash on qualifier name (typically missing) then make this a compilation error.

The error suggests to add a `@Named` or qualifier annotation to resolve the issue.

Example:
```java
@Factory
class MyFactory {

  @Bean
  BFace one() {
    ...
  }

  @Bean
  BFace two() {
    ...
  }
```