### PR TITLE
Fix duplicate short names in Module Generation

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/duplicate/SameType.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/duplicate/SameType.java
@@ -1,0 +1,9 @@
+package org.example.myapp.duplicate;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class SameType {
+  @Singleton
+  public static class Inner {}
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/duplicate/two/SameType.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/duplicate/two/SameType.java
@@ -1,0 +1,9 @@
+package org.example.myapp.duplicate.two;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class SameType {
+  @Singleton
+  public static class Inner {}
+}

--- a/blackbox-test-inject/src/test/java/org/example/myapp/duplicate/SameTypeTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/duplicate/SameTypeTest.java
@@ -1,0 +1,26 @@
+package org.example.myapp.duplicate;
+
+import io.avaje.inject.BeanScope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class SameTypeTest {
+
+  @Test
+  void testDuplicateShortName() {
+    try (BeanScope testScope = BeanScope.builder().build()) {
+
+      var sameType = testScope.get(SameType.class);
+      var sameTypeInner = testScope.get(SameType.Inner.class);
+      var sameType2 = testScope.get(org.example.myapp.duplicate.two.SameType.class);
+      var sameType2Inner = testScope.get(org.example.myapp.duplicate.two.SameType.Inner.class);
+
+      assertThat(sameType).isNotNull();
+      assertThat(sameTypeInner).isNotNull();
+      assertThat(sameType2).isNotNull();
+      assertThat(sameType2Inner).isNotNull();
+    }
+  }
+}

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaData.java
@@ -222,7 +222,7 @@ final class MetaData implements Comparable<MetaData> {
     }
   }
 
-  void buildMethod(Append append) {
+  void buildMethod(Append append, boolean fullyQualify) {
     if (generateProxy) {
       return;
     }
@@ -273,7 +273,7 @@ final class MetaData implements Comparable<MetaData> {
     if (hasMethod()) {
       append.append("    ").append(Util.shortMethod(method)).append("(builder");
     } else {
-      append.append("    ").append(shortType).append(Constants.DI).append(".build(builder");
+      append.append("    ").append(fullyQualify ? type : shortType).append(Constants.DI).append(".build(builder");
     }
     append.append(");").append(NEWLINE);
     append.append("  }").append(NEWLINE);

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
@@ -65,13 +65,13 @@ final class SimpleModuleWriter {
     this.modulePackage = scopeInfo.modulePackage();
     this.shortName = scopeInfo.moduleShortName();
     this.fullName = scopeInfo.moduleFullName();
-    Set<String> seen = new HashSet<>();
-    duplicateTypes =
-        ordering.ordered().stream()
-            .map(MetaData::type)
-            .filter(t -> !seen.add(ProcessorUtils.shortType(t)))
-            .flatMap(t -> Stream.of(t, t + "$DI"))
-            .collect(toSet());
+    final Set<String> seen = new HashSet<>();
+    this.duplicateTypes =
+      ordering.ordered().stream()
+        .map(MetaData::type)
+        .filter(t -> !seen.add(ProcessorUtils.shortType(t)))
+        .flatMap(t -> Stream.of(t, t + "$DI"))
+        .collect(toSet());
   }
 
   void write(ScopeInfo.Type scopeType) throws IOException {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleModuleWriter.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Stream;
 
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
@@ -69,6 +70,7 @@ final class SimpleModuleWriter {
         ordering.ordered().stream()
             .map(MetaData::type)
             .filter(t -> !seen.add(ProcessorUtils.shortType(t)))
+            .flatMap(t -> Stream.of(t, t + "$DI"))
             .collect(toSet());
   }
 

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/duplicate/SameType.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/duplicate/SameType.java
@@ -1,0 +1,9 @@
+package io.avaje.inject.generator.models.valid.duplicate;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class SameType {
+  @Singleton
+  static class Inner {}
+}

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/duplicate/SameType.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/duplicate/SameType.java
@@ -5,5 +5,5 @@ import jakarta.inject.Singleton;
 @Singleton
 public class SameType {
   @Singleton
-  static class Inner {}
+  public static class Inner {}
 }

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/duplicate/two/SameType.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/duplicate/two/SameType.java
@@ -5,5 +5,5 @@ import jakarta.inject.Singleton;
 @Singleton
 public class SameType {
   @Singleton
-  static class Inner {}
+  public static class Inner {}
 }

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/duplicate/two/SameType.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/duplicate/two/SameType.java
@@ -1,0 +1,9 @@
+package io.avaje.inject.generator.models.valid.duplicate.two;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class SameType {
+  @Singleton
+  static class Inner {}
+}


### PR DESCRIPTION
Now will fully qualify when a short name conflicts.

fixes #794 