### PR TITLE
Add test module blackbox-multi-scope

### DIFF
--- a/blackbox-multi-scope/pom.xml
+++ b/blackbox-multi-scope/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.avaje</groupId>
+    <artifactId>avaje-inject-parent</artifactId>
+    <version>11.5-RC1</version>
+  </parent>
+
+  <artifactId>blackbox-multi-scope</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-inject</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-inject-test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.5</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.avaje</groupId>
+              <artifactId>avaje-inject-generator</artifactId>
+              <version>${project.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>io.avaje</groupId>
+        <artifactId>avaje-inject-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <?m2e execute?>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>provides</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/blackbox-multi-scope/src/main/java/org/multi/crosscut/BeanCross.java
+++ b/blackbox-multi-scope/src/main/java/org/multi/crosscut/BeanCross.java
@@ -1,0 +1,12 @@
+package org.multi.crosscut;
+
+import org.multi.moda.BeanInModA;
+import org.multi.modb.BeanInModB;
+import org.multi.scope.CrossCutScope;
+
+@CrossCutScope
+public class BeanCross{
+  public BeanCross(final BeanInModA beanInModA, final BeanInModB beanInModB) {
+
+  }
+}

--- a/blackbox-multi-scope/src/main/java/org/multi/crosscut/BeanCross2.java
+++ b/blackbox-multi-scope/src/main/java/org/multi/crosscut/BeanCross2.java
@@ -1,0 +1,13 @@
+package org.multi.crosscut;
+
+import org.multi.moda.BeanInModA;
+import org.multi.modb.BeanInModB;
+import org.multi.modc.modb.BeanInModC;
+import org.multi.scope.CrossCutScope;
+
+@CrossCutScope
+public class BeanCross2 {
+  public BeanCross2(final BeanInModA beanInModA, final BeanInModC beanInModC) {
+
+  }
+}

--- a/blackbox-multi-scope/src/main/java/org/multi/crosscut/BeanCross3.java
+++ b/blackbox-multi-scope/src/main/java/org/multi/crosscut/BeanCross3.java
@@ -1,0 +1,11 @@
+package org.multi.crosscut;
+
+import org.multi.modc.modb.COther;
+import org.multi.scope.CrossCutScope;
+
+@CrossCutScope
+public class BeanCross3 {
+  public BeanCross3(final COther other) {
+
+  }
+}

--- a/blackbox-multi-scope/src/main/java/org/multi/main/CrossCutMain.java
+++ b/blackbox-multi-scope/src/main/java/org/multi/main/CrossCutMain.java
@@ -1,0 +1,31 @@
+package org.multi.main;
+
+import io.avaje.inject.BeanScope;
+import org.multi.crosscut.BeanCross;
+import org.multi.crosscut.BeanCross2;
+import org.multi.crosscut.BeanCross3;
+import org.multi.crosscut.CrossCutModule;
+import org.multi.moda.BeanInModA;
+import org.multi.moda.ModAModule;
+import org.multi.modb.BeanInModB;
+import org.multi.modb.ModBModule;
+import org.multi.modc.modb.ModCModule;
+
+public class CrossCutMain {
+
+  public static void main(String[] args) {
+    try (BeanScope beanScope = buildScope()) {
+      beanScope.get(BeanInModB.class);
+      beanScope.get(BeanInModA.class);
+      beanScope.get(BeanCross.class);
+      beanScope.get(BeanCross2.class);
+      beanScope.get(BeanCross3.class);
+    }
+  }
+
+  public static BeanScope buildScope() {
+    return BeanScope.builder()
+      .modules(new ModAModule(), new ModCModule(), new ModBModule(),  new CrossCutModule())
+      .build();
+  }
+}

--- a/blackbox-multi-scope/src/main/java/org/multi/moda/BeanInModA.java
+++ b/blackbox-multi-scope/src/main/java/org/multi/moda/BeanInModA.java
@@ -1,0 +1,7 @@
+package org.multi.moda;
+
+import org.multi.scope.ModAScope;
+
+@ModAScope
+public class BeanInModA {
+}

--- a/blackbox-multi-scope/src/main/java/org/multi/modb/BOther.java
+++ b/blackbox-multi-scope/src/main/java/org/multi/modb/BOther.java
@@ -1,0 +1,14 @@
+package org.multi.modb;
+
+import org.multi.modc.modb.COther;
+import org.multi.scope.ModBScope;
+
+@ModBScope
+public class BOther {
+
+  private final COther cOther;
+
+  public BOther(COther cOther) {
+    this.cOther = cOther;
+  }
+}

--- a/blackbox-multi-scope/src/main/java/org/multi/modb/BeanInModB.java
+++ b/blackbox-multi-scope/src/main/java/org/multi/modb/BeanInModB.java
@@ -1,0 +1,7 @@
+package org.multi.modb;
+
+import org.multi.scope.ModBScope;
+
+@ModBScope
+public class BeanInModB {
+}

--- a/blackbox-multi-scope/src/main/java/org/multi/modc/modb/BeanInModC.java
+++ b/blackbox-multi-scope/src/main/java/org/multi/modc/modb/BeanInModC.java
@@ -1,0 +1,7 @@
+package org.multi.modc.modb;
+
+import org.multi.scope.ModCScope;
+
+@ModCScope
+public class BeanInModC {
+}

--- a/blackbox-multi-scope/src/main/java/org/multi/modc/modb/COther.java
+++ b/blackbox-multi-scope/src/main/java/org/multi/modc/modb/COther.java
@@ -1,0 +1,7 @@
+package org.multi.modc.modb;
+
+import org.multi.scope.ModCScope;
+
+@ModCScope
+public class COther {
+}

--- a/blackbox-multi-scope/src/main/java/org/multi/scope/CrossCutScope.java
+++ b/blackbox-multi-scope/src/main/java/org/multi/scope/CrossCutScope.java
@@ -1,0 +1,10 @@
+package org.multi.scope;
+
+import io.avaje.inject.InjectModule;
+import jakarta.inject.Scope;
+import org.multi.modb.BeanInModB;
+
+@Scope
+@InjectModule(requires = {ModAScope.class, ModBScope.class}, strictWiring = true)
+public @interface CrossCutScope {
+}

--- a/blackbox-multi-scope/src/main/java/org/multi/scope/ModAScope.java
+++ b/blackbox-multi-scope/src/main/java/org/multi/scope/ModAScope.java
@@ -1,0 +1,9 @@
+package org.multi.scope;
+
+import io.avaje.inject.InjectModule;
+import jakarta.inject.Scope;
+
+@Scope
+@InjectModule(strictWiring = true)
+public @interface ModAScope {
+}

--- a/blackbox-multi-scope/src/main/java/org/multi/scope/ModBScope.java
+++ b/blackbox-multi-scope/src/main/java/org/multi/scope/ModBScope.java
@@ -1,0 +1,9 @@
+package org.multi.scope;
+
+import io.avaje.inject.InjectModule;
+import jakarta.inject.Scope;
+
+@Scope
+@InjectModule(requires = ModCScope.class, strictWiring = true)
+public @interface ModBScope {
+}

--- a/blackbox-multi-scope/src/main/java/org/multi/scope/ModCScope.java
+++ b/blackbox-multi-scope/src/main/java/org/multi/scope/ModCScope.java
@@ -1,0 +1,9 @@
+package org.multi.scope;
+
+import io.avaje.inject.InjectModule;
+import jakarta.inject.Scope;
+
+@Scope
+@InjectModule(strictWiring = true)
+public @interface ModCScope {
+}

--- a/blackbox-multi-scope/src/test/java/org/multi/crosscut/BeanCrossTest.java
+++ b/blackbox-multi-scope/src/test/java/org/multi/crosscut/BeanCrossTest.java
@@ -1,0 +1,24 @@
+package org.multi.crosscut;
+
+
+import io.avaje.inject.BeanScope;
+import org.junit.jupiter.api.Test;
+import org.multi.modb.BeanInModB;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BeanCrossTest {
+
+  @Test
+  void bootstrap() {
+
+    try (BeanScope beanScope = BeanScope.builder()
+//      .modules(new CrossCutModule())
+      .build()) {
+
+//      var beanInModB = beanScope.get(BeanInModB.class);
+//      assertThat(beanInModB).isNotNull();
+    }
+
+  }
+}

--- a/blackbox-multi-scope/src/test/java/org/multi/main/CrossCutMainTest.java
+++ b/blackbox-multi-scope/src/test/java/org/multi/main/CrossCutMainTest.java
@@ -1,0 +1,19 @@
+package org.multi.main;
+
+import io.avaje.inject.BeanScope;
+import org.junit.jupiter.api.Test;
+import org.multi.crosscut.BeanCross;
+import org.multi.moda.BeanInModA;
+import org.multi.modb.BeanInModB;
+
+class CrossCutMainTest {
+
+  @Test
+  void buildScope() {
+    try (BeanScope beanScope = CrossCutMain.buildScope()) {
+      beanScope.get(BeanInModB.class);
+      beanScope.get(BeanInModA.class);
+      beanScope.get(BeanCross.class);
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <module>blackbox-other</module>
         <module>blackbox-aspect</module>
         <module>blackbox-test-inject</module>
+        <module>blackbox-multi-scope</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
This is for testing out the multi-scope cases in a separate test module.

The guts is that to build the scope we currently need to order the modules:
```java
  public static BeanScope buildScope() {
    return BeanScope.builder()
      .modules(new ModAModule(), new ModCModule(), new ModBModule(),  new CrossCutModule())
      .build();
  }
```

- CrossCut requires ModA and ModB
- ModB requires ModC

The ordering of the modules should work off the `requires`.


