### PR TITLE
Graceful shutdown - defaults for io.ebean.Database to shutdown() last

### DIFF
--- a/blackbox-test-inject/src/main/java/io/ebean/Database.java
+++ b/blackbox-test-inject/src/main/java/io/ebean/Database.java
@@ -1,0 +1,15 @@
+package io.ebean;
+
+/**
+ * Simulate the Ebean io.ebean.Database interface with a shutdown() method.
+ * <p>
+ * For "Graceful Shutdown" we desire this to be shutdown last.
+ */
+public interface Database {
+
+  /** Shutdown including underlying DataSources. We want this to occur LAST. */
+  void shutdown();
+
+  /** Test only method */
+  boolean isShutdown();
+}

--- a/blackbox-test-inject/src/main/java/io/ebean/MyDatabase.java
+++ b/blackbox-test-inject/src/main/java/io/ebean/MyDatabase.java
@@ -1,0 +1,16 @@
+package io.ebean;
+
+public class MyDatabase implements Database {
+
+  public boolean shutdownCalled = false;
+
+  @Override
+  public void shutdown() {
+    shutdownCalled = true;
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return shutdownCalled;
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/AppConfig.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/AppConfig.java
@@ -1,6 +1,8 @@
 package org.example.myapp.config;
 
 import io.avaje.inject.*;
+import io.ebean.Database;
+import io.ebean.MyDatabase;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import org.example.myapp.HelloData;
@@ -13,6 +15,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class AppConfig {
 
   public static AtomicBoolean BEAN_AUTO_CLOSED = new AtomicBoolean();
+
+  /** Because this is a io.ebean.Database, we know it should be shutdown() last */
+  @Bean // Effectively default to  @Bean(destroyMethod = "shutdown", destroyPriority = Integer.MAX_VALUE)
+  Database database() {
+    return new MyDatabase();
+  }
 
   @PreDestroy(priority = 999)
   void close() {

--- a/blackbox-test-inject/src/test/java/org/example/myapp/DefaultDestroyTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/DefaultDestroyTest.java
@@ -1,0 +1,22 @@
+package org.example.myapp;
+
+import io.avaje.inject.BeanScope;
+import io.ebean.Database;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultDestroyTest {
+
+  @Test
+  void expect_ebeanDatabase_hasShutdownByDefault() {
+    try (BeanScope beanScope = BeanScope.builder().build()) {
+      Database database = beanScope.get(Database.class);
+
+      assertThat(database.isShutdown()).isFalse();
+      beanScope.close();
+
+      assertThat(database.isShutdown()).isTrue();
+    }
+  }
+}


### PR DESCRIPTION
For graceful shutdown, we desire components to shutdown in an appropriate order. For `io.ebean.Database` it should be shutdown last.

Adds a default shutdown method and shutdown priority for special components such that they default to doing "the right thing" wrt graceful shutdown.

For ebean:

```java
  @Bean
  Database database()
```
We desire that to effectively default to:
```java
  @Bean(destroyMethod = "shutdown", destroyPriority = Integer.MAX_VALUE)
  Database database()
```

... we want the generated code to have `addPreDestroy()` like:
```java
var bean = factory.database(builder.get(ConfigWrapper.class,"!config"));
var $bean = builder.register(bean);
builder.addPreDestroy($bean::shutdown, 2147483647);

```