### PR TITLE
Fix TYPE_USE annotated dependencies

### DIFF
--- a/blackbox-test-inject/pom.xml
+++ b/blackbox-test-inject/pom.xml
@@ -29,13 +29,13 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-jsonb</artifactId>
-      <version>3.4</version>
+      <version>3.5</version>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-config</artifactId>
-      <version>4.0</version>
+      <version>4.1</version>
     </dependency>
 
     <dependency>

--- a/blackbox-test-inject/src/main/java/org/example/myapp/assist/droid/ACar.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/assist/droid/ACar.java
@@ -2,9 +2,10 @@ package org.example.myapp.assist.droid;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import io.avaje.inject.AssistFactory;
 import io.avaje.inject.Assisted;
-import io.avaje.lang.Nullable;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 

--- a/blackbox-test-inject/src/main/java/org/example/myapp/assist/droid/Car.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/assist/droid/Car.java
@@ -2,9 +2,10 @@ package org.example.myapp.assist.droid;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import io.avaje.inject.AssistFactory;
 import io.avaje.inject.Assisted;
-import io.avaje.lang.Nullable;
 import jakarta.inject.Named;
 
 @Named("tomato")

--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/SomeOptionalUser.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/SomeOptionalUser.java
@@ -1,9 +1,9 @@
 package org.example.myapp.config;
 
+import org.jspecify.annotations.Nullable;
 import org.other.one.SomeOptionalDep;
 
 import io.avaje.inject.Component;
-import io.avaje.lang.Nullable;
 
 @Component
 public class SomeOptionalUser {

--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/SomeOptionalUser2.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/SomeOptionalUser2.java
@@ -1,11 +1,10 @@
 package org.example.myapp.config;
 
-import io.avaje.inject.Component;
-import io.avaje.lang.Nullable;
-
 import java.util.Optional;
 
 import org.other.one.SomeOptionalDep;
+
+import io.avaje.inject.Component;
 
 @Component
 public class SomeOptionalUser2 {

--- a/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyBean.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyBean.java
@@ -2,10 +2,11 @@ package org.example.myapp.lazy;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.jspecify.annotations.Nullable;
+
 import io.avaje.inject.BeanScope;
 import io.avaje.inject.Lazy;
 import io.avaje.inject.PostConstruct;
-import io.avaje.lang.Nullable;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;

--- a/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyFactory.java
@@ -2,10 +2,11 @@ package org.example.myapp.lazy;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.jspecify.annotations.Nullable;
+
 import io.avaje.inject.Bean;
 import io.avaje.inject.Factory;
 import io.avaje.inject.Lazy;
-import io.avaje.lang.Nullable;
 import jakarta.inject.Named;
 
 @Lazy

--- a/inject-aop/pom.xml
+++ b/inject-aop/pom.xml
@@ -8,6 +8,7 @@
     <version>11.6-RC1</version>
   </parent>
   <artifactId>avaje-inject-aop</artifactId>
+  <name>avaje inject aspect orient programming</name>
   <dependencies>
     <!-- test dependencies -->
     <dependency>

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -1,5 +1,13 @@
 package io.avaje.inject.generator;
 
+import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
@@ -8,14 +16,6 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-
-import static java.util.function.Predicate.not;
-import static java.util.stream.Collectors.toList;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 final class Util {
   static final String ASPECT_PROVIDER_PREFIX = "io.avaje.inject.aop.AspectProvider<";
@@ -150,7 +150,7 @@ final class Util {
         char firstChar = part.charAt(0);
         if (foundClass
           || Character.isUpperCase(firstChar)
-          || (!Character.isAlphabetic(firstChar) && Character.isJavaIdentifierStart(firstChar))) {
+          || !Character.isAlphabetic(firstChar) && Character.isJavaIdentifierStart(firstChar)) {
           foundClass = true;
           result += (result.isEmpty() ? "" : ".") + part;
         }
@@ -223,7 +223,7 @@ final class Util {
   }
 
   static UtilType determineType(TypeMirror rawType, boolean beanMap) {
-    return UtilType.of(rawType.toString(), beanMap, rawType);
+    return UtilType.of(beanMap, rawType);
   }
 
   /**

--- a/inject-generator/src/main/java/io/avaje/inject/generator/UtilType.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/UtilType.java
@@ -25,7 +25,7 @@ final class UtilType {
 
   static UtilType of(boolean beanMap, TypeMirror mirror) {
     var uType = UType.parse(mirror);
-    var rawType = uType.fullWithoutAnnotations();
+    var rawType = uType.fullWithoutAnnotations().replace(" ", "");
     if (rawType.startsWith("java.util.List<")) {
       return new UtilType(Type.LIST, rawType, uType.param0());
     } else if (rawType.startsWith("java.util.Set<")) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/UtilType.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/UtilType.java
@@ -23,8 +23,9 @@ final class UtilType {
     this.uType = uType;
   }
 
-  static UtilType of(String rawType, boolean beanMap, TypeMirror mirror) {
+  static UtilType of(boolean beanMap, TypeMirror mirror) {
     var uType = UType.parse(mirror);
+    var rawType = uType.fullWithoutAnnotations();
     if (rawType.startsWith("java.util.List<")) {
       return new UtilType(Type.LIST, rawType, uType.param0());
     } else if (rawType.startsWith("java.util.Set<")) {

--- a/inject-maven-plugin/pom.xml
+++ b/inject-maven-plugin/pom.xml
@@ -9,6 +9,7 @@
 
   <artifactId>avaje-inject-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
+  <name>avaje inject maven plugin</name>
 
   <dependencies>
     <dependency>

--- a/inject-test/pom.xml
+++ b/inject-test/pom.xml
@@ -111,7 +111,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-jsonb</artifactId>
-      <version>3.4</version>
+      <version>3.5</version>
       <scope>test</scope>
     </dependency>
 

--- a/inject/pom.xml
+++ b/inject/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-config</artifactId>
-      <version>4.0</version>
+      <version>4.1</version>
       <optional>true</optional>
     </dependency>
 


### PR DESCRIPTION
Fix issue where TYPE_USE annotations would cause the wrong type to be registered, causing errors like:

`No dependency provided for java.util.concurrent.atomic.@org.jspecify.annotations.Nullable AtomicBoolean on org.example.myapp.lazy.LazyBean`

