### PR TITLE
Test only followup for #826, add test to blackbox-test-inject

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/generic/GenericImpl.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/generic/GenericImpl.java
@@ -1,4 +1,4 @@
-package io.avaje.inject.generator.models.valid.generic;
+package org.example.myapp.generic;
 
 import jakarta.inject.Singleton;
 import java.util.concurrent.Flow;
@@ -7,6 +7,6 @@ import java.util.concurrent.SubmissionPublisher;
 @Singleton
 public class GenericImpl implements GenericInterfaceObject<Flow.Publisher<Object>> {
     public Flow.Publisher<Object> get() {
-        return new SubmissionPublisher();
+        return new SubmissionPublisher<>();
     }
 }

--- a/blackbox-test-inject/src/main/java/org/example/myapp/generic/GenericInterfaceObject.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/generic/GenericInterfaceObject.java
@@ -1,4 +1,4 @@
-package io.avaje.inject.generator.models.valid.generic;
+package org.example.myapp.generic;
 
 public interface GenericInterfaceObject<T> {
     T get();

--- a/blackbox-test-inject/src/test/java/org/example/myapp/generic/GenericImplTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/generic/GenericImplTest.java
@@ -1,0 +1,24 @@
+package org.example.myapp.generic;
+
+import io.avaje.inject.test.InjectTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Flow;
+import java.util.concurrent.SubmissionPublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@InjectTest
+class GenericImplTest {
+
+  @Inject
+  GenericInterfaceObject<Flow.Publisher<Object>> flow;
+
+  @Test
+  void test() {
+    Flow.Publisher<Object> publisher = flow.get();
+    assertThat(publisher).isNotNull();
+    assertThat(publisher).isInstanceOf(SubmissionPublisher.class);
+  }
+}

--- a/inject-generator/src/test/java/io/avaje/inject/generator/UtilTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/UtilTest.java
@@ -21,11 +21,6 @@ class UtilTest {
   }
 
   @Test
-  void nestedShortName() {
-    assertEquals(Util.shortName("com.example.Foo.Bar"), "Foo.Bar");
-  }
-
-  @Test
   void nestedPackageOf() {
     assertEquals(Util.nestedPackageOf("com.example.Foo.Bar"), "com.example");
     assertEquals(Util.nestedPackageOf("com.example.other.foo.Bar"), "com.example.other");
@@ -146,10 +141,13 @@ class UtilTest {
   }
 
   @Test
-  void testShortName_nestedTypes() {
+  void nestedShortName() {
+    assertEquals("Foo.Bar", Util.shortName("com.example.Foo.Bar") );
     assertEquals("Flow.Publisher", Util.shortName("java.util.concurrent.Flow.Publisher"));
     assertEquals("Outer.Inner", Util.shortName("com.foo.Outer.Inner"));
     assertEquals("Only", Util.shortName("a.b.c.Only"));
     assertEquals("simple", Util.shortName("simple"));
+    assertEquals("Math", Util.shortName("java.lang.Math"));
+    assertEquals("BigDecimal", Util.shortName("java.math.BigDecimal"));
   }
 }


### PR DESCRIPTION
- Move the test objects GenericImpl, GenericInterfaceObject to blackbox-test-inject
- Long term it is not sufficient to compile but actually have a test that confirms it wires
- Also tidy UtilTest to merge the tests for shortName() + add some java types to that test