### PR TITLE
Generate Compile Time Proxies for certain `@Lazy` beans

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyBean.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyBean.java
@@ -25,4 +25,6 @@ public class LazyBean {
   }
 
   void something() {}
+
+  public void other() {}
 }

--- a/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyBeanAOP.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyBeanAOP.java
@@ -2,6 +2,7 @@ package org.example.myapp.lazy;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.example.myapp.aspect.MyTimed;
 import org.jspecify.annotations.Nullable;
 
 import io.avaje.inject.BeanScope;
@@ -14,7 +15,8 @@ import jakarta.inject.Singleton;
 @Lazy
 @Singleton
 @Named("single")
-public class LazyBean {
+@MyTimed(name = "AOP")
+public class LazyBeanAOP {
 
   @Inject @Nullable AtomicBoolean initialized;
 

--- a/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyFactory.java
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.jspecify.annotations.Nullable;
 
 import io.avaje.inject.Bean;
+import io.avaje.inject.BeanTypes;
 import io.avaje.inject.Factory;
 import io.avaje.inject.Lazy;
 import jakarta.inject.Named;
@@ -20,6 +21,25 @@ public class LazyFactory {
     // note that nested test scopes will not be lazy
     if (initialized != null) initialized.set(true);
     return new LazyBean();
+  }
+
+  @Bean
+  @Named("factory")
+  LazyInterface lazyInterFace(@Nullable AtomicBoolean initialized) throws Exception {
+
+    // note that nested test scopes will not be lazy
+    if (initialized != null) initialized.set(true);
+    return new LazyImpl(initialized);
+  }
+
+  @Bean
+  @BeanTypes(LazyInterface.class)
+  @Named("factoryBeanType")
+  LazyImpl factoryBeanType(@Nullable AtomicBoolean initialized) throws Exception {
+
+    // note that nested test scopes will not be lazy
+    if (initialized != null) initialized.set(true);
+    return new LazyImpl(initialized);
   }
 
   @Bean

--- a/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyImpl.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyImpl.java
@@ -2,21 +2,25 @@ package org.example.myapp.lazy;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.jspecify.annotations.Nullable;
-
 import io.avaje.inject.BeanScope;
+import io.avaje.inject.BeanTypes;
 import io.avaje.inject.Lazy;
 import io.avaje.inject.PostConstruct;
-import jakarta.inject.Inject;
+import io.github.resilience4j.core.lang.Nullable;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
 @Lazy
 @Singleton
 @Named("single")
-public class LazyBean {
+@BeanTypes(LazyInterface.class)
+public class LazyImpl implements LazyInterface {
 
-  @Inject @Nullable AtomicBoolean initialized;
+  AtomicBoolean initialized;
+
+  public LazyImpl(@Nullable AtomicBoolean initialized) {
+    this.initialized = initialized;
+  }
 
   @PostConstruct
   void init(BeanScope scope) {
@@ -24,5 +28,6 @@ public class LazyBean {
     if (initialized != null) initialized.set(true);
   }
 
-  void something() {}
+  @Override
+  public void something() {}
 }

--- a/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyImpl.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyImpl.java
@@ -30,4 +30,7 @@ public class LazyImpl implements LazyInterface {
 
   @Override
   public void something() {}
+
+  @Override
+  public void otherThing() {}
 }

--- a/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyInterface.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyInterface.java
@@ -1,0 +1,6 @@
+package org.example.myapp.lazy;
+
+public interface LazyInterface {
+
+  void something();
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyInterface.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/lazy/LazyInterface.java
@@ -3,4 +3,6 @@ package org.example.myapp.lazy;
 public interface LazyInterface {
 
   void something();
+
+  void otherThing();
 }

--- a/blackbox-test-inject/src/main/java/org/example/myapp/lazy/OldLazy.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/lazy/OldLazy.java
@@ -2,21 +2,23 @@ package org.example.myapp.lazy;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.jspecify.annotations.Nullable;
-
 import io.avaje.inject.BeanScope;
 import io.avaje.inject.Lazy;
 import io.avaje.inject.PostConstruct;
-import jakarta.inject.Inject;
+import io.github.resilience4j.core.lang.Nullable;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
 @Lazy
 @Singleton
 @Named("single")
-public class LazyBean {
+public class OldLazy {
 
-  @Inject @Nullable AtomicBoolean initialized;
+  AtomicBoolean initialized;
+
+  public OldLazy(@Nullable AtomicBoolean initialized) {
+    this.initialized = initialized;
+  }
 
   @PostConstruct
   void init(BeanScope scope) {

--- a/blackbox-test-inject/src/test/java/org/example/myapp/lazy/LazyTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/lazy/LazyTest.java
@@ -15,11 +15,13 @@ class LazyTest {
     var initialized = new AtomicBoolean();
     try (var scope = BeanScope.builder().beans(initialized).build()) {
       assertThat(initialized).isFalse();
-      LazyBean lazy = scope.get(LazyBean.class, "single");
-      assertThat(initialized).isTrue();
+      var lazy = scope.get(LazyBean.class, "single");
       assertThat(lazy).isNotNull();
+      assertThat(initialized).isFalse();
+      lazy.something();
+      assertThat(initialized).isTrue();
 
-      LazyBean lazyAgain = scope.get(LazyBean.class, "single");
+      var lazyAgain = scope.get(LazyBean.class, "single");
       assertThat(lazyAgain).isSameAs(lazy);
     }
   }
@@ -29,9 +31,84 @@ class LazyTest {
     var initialized = new AtomicBoolean();
     try (var scope = BeanScope.builder().beans(initialized).build()) {
       assertThat(initialized).isFalse();
-      LazyBean prov = scope.get(LazyBean.class, "factory");
+      var prov = scope.get(LazyBean.class, "factory");
+      assertThat(initialized).isFalse();
+      prov.something();
       assertThat(initialized).isTrue();
       assertThat(prov).isNotNull();
+    }
+  }
+
+  @Test
+  void testInterface() {
+    var initialized = new AtomicBoolean();
+    try (var scope = BeanScope.builder().beans(initialized).build()) {
+      assertThat(initialized).isFalse();
+      var lazy = scope.get(LazyInterface.class, "single");
+      assertThat(lazy).isNotNull();
+      assertThat(initialized).isFalse();
+      lazy.something();
+      assertThat(initialized).isTrue();
+
+      var lazyAgain = scope.get(LazyInterface.class, "single");
+      assertThat(lazyAgain).isSameAs(lazy);
+    }
+  }
+
+  @Test
+  void testFactoryInterface() {
+    var initialized = new AtomicBoolean();
+    try (var scope = BeanScope.builder().beans(initialized).build()) {
+      assertThat(initialized).isFalse();
+      var prov = scope.get(LazyInterface.class, "factory");
+      assertThat(initialized).isFalse();
+      prov.something();
+      assertThat(initialized).isTrue();
+      assertThat(prov).isNotNull();
+    }
+  }
+
+  @Test
+  void factoryBeanType() {
+    var initialized = new AtomicBoolean();
+    try (var scope = BeanScope.builder().beans(initialized).build()) {
+      assertThat(initialized).isFalse();
+      var prov = scope.get(LazyInterface.class, "factoryBeanType");
+      assertThat(initialized).isFalse();
+      prov.something();
+      assertThat(initialized).isTrue();
+      assertThat(prov).isNotNull();
+    }
+  }
+
+  @Test
+  void testAOP() {
+    var initialized = new AtomicBoolean();
+    try (var scope = BeanScope.builder().beans(initialized).build()) {
+      assertThat(initialized).isFalse();
+      var lazy = scope.get(LazyBeanAOP.class, "single");
+      assertThat(lazy).isNotNull();
+      assertThat(initialized).isFalse();
+      lazy.something();
+      assertThat(initialized).isTrue();
+
+      var lazyAgain = scope.get(LazyBeanAOP.class, "single");
+      assertThat(lazyAgain).isSameAs(lazy);
+    }
+  }
+
+  @Test
+  void testOldLazyBehavior() {
+    var initialized = new AtomicBoolean();
+    try (var scope = BeanScope.builder().beans(initialized).build()) {
+      assertThat(initialized).isFalse();
+      var lazy = scope.get(OldLazy.class, "single");
+      assertThat(lazy).isNotNull();
+      assertThat(initialized).isTrue();
+      lazy.something();
+
+      var lazyAgain = scope.get(OldLazy.class, "single");
+      assertThat(lazyAgain).isSameAs(lazy);
     }
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/AspectMethod.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/AspectMethod.java
@@ -168,11 +168,12 @@ final class AspectMethod {
     writer.append(")");
   }
 
-  void writeSetupFields(Append writer) {
-    writer.append("  private final Method %s;", localName).eol();
+  void writeSetupFields(Append writer, boolean lazy) {
+    var isFinal = lazy ? "" : "final ";
+    writer.append("  private %sMethod %s;", isFinal, localName).eol();
     for (AspectPair aspectPair : aspectPairs) {
       String sn = aspectPair.annotationShortName();
-      writer.append("  private final MethodInterceptor %s%s;", localName, sn).eol();
+      writer.append("  private %sMethodInterceptor %s%s;", isFinal, localName, sn).eol();
     }
   }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/AssistBeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/AssistBeanReader.java
@@ -1,17 +1,22 @@
 package io.avaje.inject.generator;
 
-import io.avaje.inject.generator.MethodReader.MethodParam;
+import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
 
-import javax.lang.model.element.*;
-import javax.lang.model.util.ElementFilter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static java.util.function.Predicate.not;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toSet;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.util.ElementFilter;
+
+import io.avaje.inject.generator.MethodReader.MethodParam;
 
 final class AssistBeanReader {
 
@@ -34,12 +39,7 @@ final class AssistBeanReader {
     this.beanType = beanType;
     this.type = beanType.getQualifiedName().toString();
     this.typeReader =
-      new TypeReader(
-        Optional.empty(),
-        UType.parse(beanType.asType()),
-        beanType,
-        importTypes,
-        false);
+        new TypeReader(List.of(), UType.parse(beanType.asType()), beanType, importTypes, false);
 
     typeReader.process();
     qualifierName = typeReader.name();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/AssistBeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/AssistBeanReader.java
@@ -39,7 +39,7 @@ final class AssistBeanReader {
     this.beanType = beanType;
     this.type = beanType.getQualifiedName().toString();
     this.typeReader =
-        new TypeReader(List.of(), UType.parse(beanType.asType()), beanType, importTypes, false);
+      new TypeReader(List.of(), UType.parse(beanType.asType()), beanType, importTypes, false);
 
     typeReader.process();
     qualifierName = typeReader.name();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -68,10 +68,18 @@ final class BeanReader {
             || importedComponent && ProcessingContext.isImportedPrototype(actualType);
     this.primary = PrimaryPrism.isPresent(actualType);
     this.secondary = !primary && SecondaryPrism.isPresent(actualType);
-    final var beantypes = BeanTypesPrism.getOptionalOn(actualType);
-    beantypes.ifPresent(p -> Util.validateBeanTypes(actualType, p.value()));
+    var beantypes =
+        BeanTypesPrism.getOptionalOn(actualType)
+            .map(BeanTypesPrism::value)
+            .or(() -> proxy ? Optional.of(List.of(actualType.asType())) : Optional.empty());
+    beantypes.ifPresent(t -> Util.validateBeanTypes(actualType, t));
     this.typeReader =
-        new TypeReader(beantypes, UType.parse(beanType.asType()), beanType, importTypes, factory);
+        new TypeReader(
+            beantypes.orElse(List.of()),
+            UType.parse(beanType.asType()),
+            beanType,
+            importTypes,
+            factory);
 
     typeReader.process();
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -64,29 +64,28 @@ final class BeanReader {
     TypeElement actualType = proxy ? APContext.asTypeElement(beanType.getSuperclass()) : beanType;
 
     this.prototype =
-        PrototypePrism.isPresent(actualType)
-            || importedComponent && ProcessingContext.isImportedPrototype(actualType);
+      PrototypePrism.isPresent(actualType)
+        || importedComponent && ProcessingContext.isImportedPrototype(actualType);
     this.primary = PrimaryPrism.isPresent(actualType);
     this.secondary = !primary && SecondaryPrism.isPresent(actualType);
-    var beantypes =
-        BeanTypesPrism.getOptionalOn(actualType)
-            .map(BeanTypesPrism::value)
-            .or(() -> proxy ? Optional.of(List.of(actualType.asType())) : Optional.empty());
-    beantypes.ifPresent(t -> Util.validateBeanTypes(actualType, t));
+    var beanTypes =
+      BeanTypesPrism.getOptionalOn(actualType)
+        .map(BeanTypesPrism::value)
+        .or(() -> proxy ? Optional.of(List.of(actualType.asType())) : Optional.empty());
+    beanTypes.ifPresent(t -> Util.validateBeanTypes(actualType, t));
     this.typeReader =
-        new TypeReader(
-            beantypes.orElse(List.of()),
-            UType.parse(beanType.asType()),
-            beanType,
-            importTypes,
-            factory);
+      new TypeReader(
+        beanTypes.orElse(List.of()),
+        UType.parse(beanType.asType()),
+        beanType,
+        importTypes,
+        factory);
 
     typeReader.process();
-
     this.lazy =
-        !FactoryPrism.isPresent(actualType)
-            && (LazyPrism.isPresent(actualType)
-                || importedComponent && ProcessingContext.isImportedLazy(actualType));
+      !FactoryPrism.isPresent(actualType)
+        && (LazyPrism.isPresent(actualType)
+        || importedComponent && ProcessingContext.isImportedLazy(actualType));
 
     this.requestParams = new BeanRequestParams(type);
     this.name = typeReader.name();
@@ -192,7 +191,6 @@ final class BeanReader {
     }
 
     postConstructMethod.ifPresent(m -> m.addImports(importTypes));
-
     conditions.addImports(importTypes);
     if (proxyLazy) {
       SimpleBeanLazyWriter.write(APContext.elements().getPackageOf(beanType), lazyProxyType);
@@ -619,7 +617,7 @@ final class BeanReader {
     typeReader.validate();
   }
 
-  public TypeElement getLazyProxyType() {
+  TypeElement lazyProxyType() {
     return lazyProxyType;
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/InjectProcessor.java
@@ -1,10 +1,32 @@
 package io.avaje.inject.generator;
 
-import io.avaje.prism.GenerateAPContext;
-import io.avaje.prism.GenerateModuleInfoReader;
-import io.avaje.prism.GenerateUtils;
+import static io.avaje.inject.generator.APContext.logError;
+import static io.avaje.inject.generator.APContext.typeElement;
+import static io.avaje.inject.generator.ProcessingContext.addImportedAspects;
+import static io.avaje.inject.generator.ProcessingContext.delayedElements;
+import static io.avaje.inject.generator.ProcessingContext.loadMetaInfCustom;
+import static io.avaje.inject.generator.ProcessingContext.loadMetaInfServices;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
 
-import javax.annotation.processing.*;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
@@ -14,18 +36,9 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
 
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.StandardOpenOption;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static io.avaje.inject.generator.APContext.*;
-import static io.avaje.inject.generator.ProcessingContext.*;
+import io.avaje.prism.GenerateAPContext;
+import io.avaje.prism.GenerateModuleInfoReader;
+import io.avaje.prism.GenerateUtils;
 
 @GenerateUtils
 @GenerateAPContext
@@ -158,7 +171,6 @@ public final class InjectProcessor extends AbstractProcessor {
     readImported(importedElements(roundEnv));
 
     maybeElements(roundEnv, ControllerPrism.PRISM_TYPE).ifPresent(this::readBeans);
-    maybeElements(roundEnv, ProxyPrism.PRISM_TYPE).ifPresent(this::readBeans);
     maybeElements(roundEnv, AssistFactoryPrism.PRISM_TYPE).ifPresent(this::readAssisted);
 
     maybeElements(roundEnv, ExternalPrism.PRISM_TYPE).stream()

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -287,15 +287,11 @@ final class MethodReader {
     endTry(writer, "  ");
     writer.indent(indent);
     if (proxyLazy) {
-      writer.append("  }, %s$Lazy::new);", lazyProxyShortName()).eol();
+      writer.append("  }, %s$Lazy::new);", Util.shortNameLazyProxy(lazyProxyType)).eol();
     } else {
       writer.indent(indent).append("  });").eol();
     }
     writer.indent(indent).append("}").eol();
-  }
-
-  private String lazyProxyShortName() {
-    return Util.shortName(lazyProxyType.getQualifiedName().toString()).replace(".", "_");
   }
 
   void builderBuildAddBean(Append writer) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -59,7 +59,7 @@ final class MethodReader {
       secondary = SecondaryPrism.isPresent(element);
       lazy = LazyPrism.isPresent(element) || LazyPrism.isPresent(element.getEnclosingElement());
       conditions.readAll(element);
-      this.lazyProxyType = Util.lazyProxy(element);
+      this.lazyProxyType = lazy ? Util.lazyProxy(element) : null;
       this.proxyLazy = lazy && lazyProxyType != null;
     } else {
       prototype = false;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -119,10 +119,10 @@ final class MethodReader {
       this.initMethod = initMethod;
       this.destroyMethod = destroyMethod;
     } else {
-      var beantypes = BeanTypesPrism.getOptionalOn(element).map(BeanTypesPrism::value);
-      beantypes.ifPresent(t -> Util.validateBeanTypes(element, t));
+      var beanTypes = BeanTypesPrism.getOptionalOn(element).map(BeanTypesPrism::value);
+      beanTypes.ifPresent(t -> Util.validateBeanTypes(element, t));
       this.typeReader =
-          new TypeReader(beantypes.orElse(List.of()), genericType, returnElement, importTypes);
+        new TypeReader(beanTypes.orElse(List.of()), genericType, returnElement, importTypes);
       typeReader.process();
       MethodLifecycleReader lifecycleReader = new MethodLifecycleReader(returnElement, initMethod, destroyMethod);
       this.initMethod = lifecycleReader.initMethod();
@@ -287,15 +287,15 @@ final class MethodReader {
     endTry(writer, "  ");
     writer.indent(indent);
     if (proxyLazy) {
-      writer
-          .append(
-              "  }, %s$Lazy::new);",
-              Util.shortName(lazyProxyType.getQualifiedName().toString()).replace(".", "_"))
-          .eol();
+      writer.append("  }, %s$Lazy::new);", lazyProxyShortName()).eol();
     } else {
       writer.indent(indent).append("  });").eol();
     }
     writer.indent(indent).append("}").eol();
+  }
+
+  private String lazyProxyShortName() {
+    return Util.shortName(lazyProxyType.getQualifiedName().toString()).replace(".", "_");
   }
 
   void builderBuildAddBean(Append writer) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanLazyWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanLazyWriter.java
@@ -154,8 +154,12 @@ final class SimpleBeanLazyWriter {
                 .collect(Collectors.joining(", ")));
       }
 
-      sb.append(" {\n");
-      sb.append("    onceProvider.get().").append(methodName);
+      sb.append(" {\n    ");
+      if (!"void".equals(returnType.full())) {
+        sb.append("return ");
+      }
+
+      sb.append("onceProvider.get().").append(methodName);
       sb.append("(");
       for (int i = 0; i < parameters.size(); i++) {
         sb.append(parameters.get(i).getSimpleName().toString());

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanLazyWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanLazyWriter.java
@@ -41,8 +41,8 @@ final class SimpleBeanLazyWriter {
   }
 
   private final String shortName;
-  private boolean isInterface;
-  private TypeElement element;
+  private final boolean isInterface;
+  private final TypeElement element;
 
   SimpleBeanLazyWriter(PackageElement pkg, TypeElement element) {
     this.element = element;
@@ -62,14 +62,11 @@ final class SimpleBeanLazyWriter {
 
   void write() {
     try {
-      var writer = new Append(APContext.createSourceFile(originName, element).openWriter());
+      final var writer = new Append(APContext.createSourceFile(originName, element).openWriter());
 
       var typeString = isInterface ? "implements" : "extends";
-
       String methodString = methods();
-      writer.append(
-          MessageFormat.format(
-              TEMPLATE, packageName, imports(), shortName, typeString, methodString));
+      writer.append(MessageFormat.format(TEMPLATE, packageName, imports(), shortName, typeString, methodString));
       writer.close();
     } catch (Exception e) {
       logError("Failed to write Proxy class %s", e);
@@ -91,16 +88,13 @@ final class SimpleBeanLazyWriter {
   }
 
   private String methods() {
-
     var sb = new StringBuilder();
-
     for (var methodElement : ElementFilter.methodsIn(APContext.elements().getAllMembers(element))) {
 
       Set<Modifier> modifiers = methodElement.getModifiers();
       if (modifiers.contains(Modifier.PRIVATE)
           || modifiers.contains(Modifier.STATIC)
           || methodElement.getEnclosingElement().getSimpleName().contentEquals("Object")) continue;
-      sb.append("");
       // Access modifiers
       if (modifiers.contains(Modifier.PUBLIC)) {
         sb.append("  public ");
@@ -114,9 +108,9 @@ final class SimpleBeanLazyWriter {
       if (!typeParameters.isEmpty()) {
         sb.append("<");
         sb.append(
-            typeParameters.stream()
-                .map(tp -> tp.getSimpleName().toString())
-                .collect(Collectors.joining(", ")));
+          typeParameters.stream()
+            .map(tp -> tp.getSimpleName().toString())
+            .collect(Collectors.joining(", ")));
         sb.append("> ");
       }
       var returnType = UType.parse(methodElement.getReturnType());
@@ -149,9 +143,9 @@ final class SimpleBeanLazyWriter {
       if (!thrownTypes.isEmpty()) {
         sb.append(" throws ");
         sb.append(
-            thrownTypes.stream()
-                .map(t -> UType.parse(t).shortType())
-                .collect(Collectors.joining(", ")));
+          thrownTypes.stream()
+            .map(t -> UType.parse(t).shortType())
+            .collect(Collectors.joining(", ")));
       }
 
       sb.append(" {\n    ");

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanLazyWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanLazyWriter.java
@@ -1,0 +1,172 @@
+package io.avaje.inject.generator;
+
+import static io.avaje.inject.generator.APContext.logError;
+
+import java.text.MessageFormat;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.util.ElementFilter;
+
+final class SimpleBeanLazyWriter {
+  private static final Set<String> GENERATED_PUBLISHERS = new HashSet<>();
+  private static final String TEMPLATE =
+      "package {0};\n\n"
+          + "{1}"
+          + "@Proxy\n"
+          + "@Generated(\"avaje-inject-generator\")\n"
+          + "public final class {2}$Lazy {3} {2} '{'\n"
+          + "\n"
+          + "  private final Provider<{2}> onceProvider;\n"
+          + "\n"
+          + "  public {2}$Lazy(Provider<{2}> onceProvider) '{'\n"
+          + "    this.onceProvider = onceProvider;\n"
+          + "  '}'\n\n"
+          + "  {4}"
+          + "'}'\n";
+
+  private final String originName;
+  private final ImportTypeMap importTypes = new ImportTypeMap();
+  private final String packageName;
+
+  static void write(PackageElement pkg, TypeElement element) {
+    new SimpleBeanLazyWriter(pkg, element);
+  }
+
+  private final String shortName;
+  private boolean isInterface;
+  private TypeElement element;
+
+  SimpleBeanLazyWriter(PackageElement pkg, TypeElement element) {
+    this.element = element;
+    this.isInterface = element.getKind().isInterface();
+    this.shortName = Util.shortName(element.getQualifiedName().toString()).replace(".", "_");
+    this.packageName = pkg.getQualifiedName().toString();
+    this.originName = packageName + "." + shortName + "$Lazy";
+
+    if (GENERATED_PUBLISHERS.contains(originName)) {
+      return;
+    }
+
+    importTypes.addAll(UType.parse(element.asType()).importTypes());
+    write();
+    GENERATED_PUBLISHERS.add(originName);
+  }
+
+  void write() {
+    try {
+      var writer = new Append(APContext.createSourceFile(originName, element).openWriter());
+
+      var typeString = isInterface ? "implements" : "extends";
+
+      String methodString = methods();
+      writer.append(
+          MessageFormat.format(
+              TEMPLATE, packageName, imports(), shortName, typeString, methodString));
+      writer.close();
+    } catch (Exception e) {
+      logError("Failed to write Proxy class %s", e);
+    }
+  }
+
+  String imports() {
+    importTypes.add("io.avaje.inject.spi.Proxy");
+    importTypes.add("io.avaje.inject.spi.Generated");
+    importTypes.add("jakarta.inject.Provider");
+
+    StringBuilder writer = new StringBuilder();
+    for (String importType : importTypes.forImport()) {
+      if (Util.validImportType(importType, packageName)) {
+        writer.append(String.format("import %s;\n", Util.sanitizeImports(importType)));
+      }
+    }
+    return writer.append("\n").toString();
+  }
+
+  private String methods() {
+
+    var sb = new StringBuilder();
+
+    for (var methodElement : ElementFilter.methodsIn(APContext.elements().getAllMembers(element))) {
+
+      Set<Modifier> modifiers = methodElement.getModifiers();
+      if (modifiers.contains(Modifier.PRIVATE)
+          || modifiers.contains(Modifier.STATIC)
+          || methodElement.getEnclosingElement().getSimpleName().contentEquals("Object")) continue;
+      sb.append("");
+      // Access modifiers
+      if (modifiers.contains(Modifier.PUBLIC)) {
+        sb.append("  public ");
+      } else if (modifiers.contains(Modifier.PROTECTED)) {
+        sb.append("  protected ");
+      } else {
+        sb.append(" ");
+      }
+      // Generic type parameters
+      List<? extends TypeParameterElement> typeParameters = methodElement.getTypeParameters();
+      if (!typeParameters.isEmpty()) {
+        sb.append("<");
+        sb.append(
+            typeParameters.stream()
+                .map(tp -> tp.getSimpleName().toString())
+                .collect(Collectors.joining(", ")));
+        sb.append("> ");
+      }
+      var returnType = UType.parse(methodElement.getReturnType());
+      importTypes.addAll(returnType.importTypes());
+      sb.append(returnType.shortType()).append(" ");
+
+      // Method name
+      String methodName = methodElement.getSimpleName().toString();
+      sb.append(methodName);
+
+      // Parameters
+      sb.append("(");
+      var parameters = methodElement.getParameters();
+      for (int i = 0; i < parameters.size(); i++) {
+        VariableElement param = parameters.get(i);
+
+        var type = UType.parse(param.asType());
+        importTypes.addAll(type.importTypes());
+        sb.append(type.shortType());
+        sb.append(" ");
+        sb.append(param.getSimpleName().toString());
+        if (i < parameters.size() - 1) {
+          sb.append(", ");
+        }
+      }
+      sb.append(")");
+
+      // Thrown exceptions
+      var thrownTypes = methodElement.getThrownTypes();
+      if (!thrownTypes.isEmpty()) {
+        sb.append(" throws ");
+        sb.append(
+            thrownTypes.stream()
+                .map(t -> UType.parse(t).shortType())
+                .collect(Collectors.joining(", ")));
+      }
+
+      sb.append(" {\n");
+      sb.append("    onceProvider.get().").append(methodName);
+      sb.append("(");
+      for (int i = 0; i < parameters.size(); i++) {
+        sb.append(parameters.get(i).getSimpleName().toString());
+        if (i < parameters.size() - 1) {
+          sb.append(", ");
+        }
+      }
+      sb.append(");\n");
+      sb.append("  }\n\n");
+    }
+
+    return sb.toString();
+  }
+}

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanLazyWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanLazyWriter.java
@@ -29,7 +29,7 @@ final class SimpleBeanLazyWriter {
           + "  public {2}$Lazy(Provider<{2}> onceProvider) '{'\n"
           + "    this.onceProvider = onceProvider;\n"
           + "  '}'\n\n"
-          + "  {4}"
+          + "{4}"
           + "'}'\n";
 
   private final String originName;
@@ -96,12 +96,13 @@ final class SimpleBeanLazyWriter {
           || modifiers.contains(Modifier.STATIC)
           || methodElement.getEnclosingElement().getSimpleName().contentEquals("Object")) continue;
       // Access modifiers
+      sb.append("  @Override\n");
       if (modifiers.contains(Modifier.PUBLIC)) {
         sb.append("  public ");
       } else if (modifiers.contains(Modifier.PROTECTED)) {
         sb.append("  protected ");
       } else {
-        sb.append(" ");
+        sb.append("  ");
       }
       // Generic type parameters
       List<? extends TypeParameterElement> typeParameters = methodElement.getTypeParameters();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanProxyWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanProxyWriter.java
@@ -55,9 +55,6 @@ final class SimpleBeanProxyWriter {
   }
 
   private void writeConstructor() {
-    if (beanReader.proxyLazy()) {
-      writer.append("  public %s%s(){}", shortName, suffix).eol().eol();
-    }
     writer.append("  @Inject\n");
     writer.append("  public %s%s(", shortName, suffix);
     int count = 0;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanProxyWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanProxyWriter.java
@@ -94,6 +94,7 @@ final class SimpleBeanProxyWriter {
     writer.append("import %s;", Constants.INVOCATION).eol();
     writer.append("import %s;", Constants.INVOCATION_EXCEPTION).eol();
     writer.append("import %s;", Constants.METHOD_INTERCEPTOR).eol();
+    writer.append("import %s;", Constants.COMPONENT).eol();
     writer.append("import %s;", Constants.PROXY).eol();
     beanReader.writeImports(writer, packageName);
   }
@@ -104,6 +105,7 @@ final class SimpleBeanProxyWriter {
 
   private void writeClassStart() {
     writer.append(Constants.AT_PROXY).eol();
+    writer.append("@Component").eol();
     writer.append(Constants.AT_GENERATED).eol();
     writer.append("public final class %s%s extends %s {", shortName, suffix, shortName).eol().eol();
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanProxyWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanProxyWriter.java
@@ -49,12 +49,16 @@ final class SimpleBeanProxyWriter {
 
   private void writeFields() {
     for (AspectMethod method : aspects.methods()) {
-      method.writeSetupFields(writer);
+      method.writeSetupFields(writer, beanReader.proxyLazy());
     }
     writer.eol();
   }
 
   private void writeConstructor() {
+    if (beanReader.proxyLazy()) {
+      writer.append("  public %s%s(){}", shortName, suffix).eol().eol();
+    }
+    writer.append("  @Inject\n");
     writer.append("  public %s%s(", shortName, suffix);
     int count = 0;
     for (final String aspectName : aspects.aspectNames()) {
@@ -95,6 +99,7 @@ final class SimpleBeanProxyWriter {
     writer.append("import %s;", Constants.INVOCATION_EXCEPTION).eol();
     writer.append("import %s;", Constants.METHOD_INTERCEPTOR).eol();
     writer.append("import %s;", Constants.COMPONENT).eol();
+    writer.append("import %s;", Constants.INJECT).eol();
     writer.append("import %s;", Constants.PROXY).eol();
     beanReader.writeImports(writer, packageName);
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
@@ -205,7 +205,7 @@ final class SimpleBeanWriter {
               .append(", ")
               .append(
                   "%s$Lazy::new",
-                  Util.shortName(beanReader.getLazyProxyType().getQualifiedName().toString())
+                  Util.shortName(beanReader.lazyProxyType().getQualifiedName().toString())
                       .replace(".", "_"));
         }
         writer.append(");").eol();
@@ -221,7 +221,7 @@ final class SimpleBeanWriter {
             .append(", ")
             .append(
                 " %s$Lazy::new",
-                Util.shortName(beanReader.getLazyProxyType().getQualifiedName().toString())
+                Util.shortName(beanReader.lazyProxyType().getQualifiedName().toString())
                     .replace(".", "_"));
       }
       writer.append(");").eol();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
@@ -178,7 +178,9 @@ final class SimpleBeanWriter {
       indent += "  ";
 
       final String registerProvider;
-      if (beanReader.lazy()) {
+      if (beanReader.proxyLazy()) {
+        registerProvider = "registerLazy";
+      } else if (beanReader.lazy()) {
         registerProvider = "registerProvider";
       } else {
         registerProvider = "asPrototype().registerProvider";
@@ -197,7 +199,16 @@ final class SimpleBeanWriter {
       beanReader.prototypePostConstruct(writer, indent);
       writer.indent("        return bean;").eol();
       if (!constructor.methodThrows()) {
-        writer.indent("      });").eol();
+        writer.append("     }");
+        if (beanReader.proxyLazy()) {
+          writer
+              .append(", ")
+              .append(
+                  "%s$Lazy::new",
+                  Util.shortName(beanReader.getLazyProxyType().getQualifiedName().toString())
+                      .replace(".", "_"));
+        }
+        writer.append(");").eol();
       }
     }
     writeObserveMethods();
@@ -205,6 +216,14 @@ final class SimpleBeanWriter {
 
     if (beanReader.registerProvider() && constructor.methodThrows()) {
       writer.append("     }");
+      if (beanReader.proxyLazy()) {
+        writer
+            .append(", ")
+            .append(
+                " %s$Lazy::new",
+                Util.shortName(beanReader.getLazyProxyType().getQualifiedName().toString())
+                    .replace(".", "_"));
+      }
       writer.append(");").eol();
     }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
@@ -201,12 +201,7 @@ final class SimpleBeanWriter {
       if (!constructor.methodThrows()) {
         writer.append("     }");
         if (beanReader.proxyLazy()) {
-          writer
-              .append(", ")
-              .append(
-                  "%s$Lazy::new",
-                  Util.shortName(beanReader.lazyProxyType().getQualifiedName().toString())
-                      .replace(".", "_"));
+          writer.append(", %s$Lazy::new", Util.shortNameLazyProxy(beanReader.lazyProxyType()));
         }
         writer.append(");").eol();
       }
@@ -217,12 +212,7 @@ final class SimpleBeanWriter {
     if (beanReader.registerProvider() && constructor.methodThrows()) {
       writer.append("     }");
       if (beanReader.proxyLazy()) {
-        writer
-            .append(", ")
-            .append(
-                " %s$Lazy::new",
-                Util.shortName(beanReader.lazyProxyType().getQualifiedName().toString())
-                    .replace(".", "_"));
+        writer.append(", %s$Lazy::new", Util.shortNameLazyProxy(beanReader.lazyProxyType()));
       }
       writer.append(");").eol();
     }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeReader.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
 
 final class TypeReader {
 
@@ -22,7 +23,7 @@ final class TypeReader {
   private final List<UType> injectsTypes;
 
   TypeReader(
-      Optional<BeanTypesPrism> injectsTypes,
+      List<TypeMirror> injectsTypes,
       UType genericType,
       TypeElement beanType,
       ImportTypeMap importTypes,
@@ -31,7 +32,7 @@ final class TypeReader {
   }
 
   TypeReader(
-      Optional<BeanTypesPrism> injectsTypes,
+      List<TypeMirror> injectsTypes,
       UType genericType,
       TypeElement returnElement,
       ImportTypeMap importTypes) {
@@ -39,17 +40,13 @@ final class TypeReader {
   }
 
   private TypeReader(
-      Optional<BeanTypesPrism> injectsTypes,
+      List<TypeMirror> injectsTypes,
       UType genericType,
       boolean forBean,
       TypeElement beanType,
       ImportTypeMap importTypes,
       boolean factory) {
-    this.injectsTypes =
-      injectsTypes.map(BeanTypesPrism::value).stream()
-        .flatMap(List::stream)
-        .map(UType::parse)
-        .collect(toList());
+    this.injectsTypes = injectsTypes.stream().map(UType::parse).collect(toList());
     this.forBean = forBean;
     this.beanType = beanType;
     this.importTypes = importTypes;

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -432,4 +432,8 @@ final class Util {
     return ElementFilter.constructorsIn(beanType.getEnclosedElements()).stream()
         .anyMatch(e -> e.getParameters().isEmpty() && !e.getModifiers().contains(Modifier.PRIVATE));
   }
+
+  public static String shortNameLazyProxy(TypeElement lazyProxyType) {
+    return shortName(lazyProxyType.getQualifiedName().toString())
+      .replace(".", "_");  }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -416,7 +416,11 @@ final class Util {
           .map(BeanTypesPrism::value)
           .filter(v -> v.size() == 1)
           .map(v -> APContext.asTypeElement(v.get(0)))
-          .filter(v -> v.getKind().isInterface() || hasNoArgConstructor(v))
+          // figure out generics later
+          .filter(
+              v ->
+                  v.getTypeParameters().isEmpty()
+                      && (v.getKind().isInterface() || hasNoArgConstructor(v)))
           .orElse(null);
     }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -409,7 +409,8 @@ final class Util {
             ? (TypeElement) element
             : APContext.asTypeElement(((ExecutableElement) element).getReturnType());
 
-    if (type.getModifiers().contains(Modifier.FINAL)
+    if (!type.getTypeParameters().isEmpty()
+        || type.getModifiers().contains(Modifier.FINAL)
         || !type.getKind().isInterface() && !Util.hasNoArgConstructor(type)) {
 
       return BeanTypesPrism.getOptionalOn(element)

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -403,12 +403,16 @@ final class Util {
         });
   }
 
-  static TypeElement lazyProxy(TypeElement beanType) {
+  static TypeElement lazyProxy(Element element) {
+    TypeElement type =
+        element instanceof TypeElement
+            ? (TypeElement) element
+            : APContext.asTypeElement(((ExecutableElement) element).getReturnType());
 
-    if (beanType.getModifiers().contains(Modifier.FINAL)
-        || !beanType.getKind().isInterface() && !Util.hasNoArgConstructor(beanType)) {
+    if (type.getModifiers().contains(Modifier.FINAL)
+        || !type.getKind().isInterface() && !Util.hasNoArgConstructor(type)) {
 
-      return BeanTypesPrism.getOptionalOn(beanType)
+      return BeanTypesPrism.getOptionalOn(element)
           .map(BeanTypesPrism::value)
           .filter(v -> v.size() == 1)
           .map(v -> APContext.asTypeElement(v.get(0)))
@@ -416,7 +420,7 @@ final class Util {
           .orElse(null);
     }
 
-    return beanType;
+    return type;
   }
 
   static boolean hasNoArgConstructor(TypeElement beanType) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -392,37 +392,35 @@ final class Util {
 
   static void validateBeanTypes(Element origin, List<TypeMirror> beanType) {
     TypeMirror targetType =
-        origin instanceof TypeElement
-            ? origin.asType()
-            : ((ExecutableElement) origin).getReturnType();
-    beanType.forEach(
-        type -> {
-          if (!APContext.types().isAssignable(targetType, type)) {
-            APContext.logError(origin, "%s does not extend type %s", targetType, beanType);
-          }
-        });
+      origin instanceof TypeElement
+        ? origin.asType()
+        : ((ExecutableElement) origin).getReturnType();
+    beanType.forEach(type -> {
+      if (!APContext.types().isAssignable(targetType, type)) {
+        APContext.logError(origin, "%s does not extend type %s", targetType, beanType);
+      }
+    });
   }
 
   static TypeElement lazyProxy(Element element) {
     TypeElement type =
-        element instanceof TypeElement
-            ? (TypeElement) element
-            : APContext.asTypeElement(((ExecutableElement) element).getReturnType());
+      element instanceof TypeElement
+        ? (TypeElement) element
+        : APContext.asTypeElement(((ExecutableElement) element).getReturnType());
 
     if (!type.getTypeParameters().isEmpty()
-        || type.getModifiers().contains(Modifier.FINAL)
-        || !type.getKind().isInterface() && !Util.hasNoArgConstructor(type)) {
+      || type.getModifiers().contains(Modifier.FINAL)
+      || !type.getKind().isInterface() && !Util.hasNoArgConstructor(type)) {
 
       return BeanTypesPrism.getOptionalOn(element)
-          .map(BeanTypesPrism::value)
-          .filter(v -> v.size() == 1)
-          .map(v -> APContext.asTypeElement(v.get(0)))
-          // figure out generics later
-          .filter(
-              v ->
-                  v.getTypeParameters().isEmpty()
-                      && (v.getKind().isInterface() || hasNoArgConstructor(v)))
-          .orElse(null);
+        .map(BeanTypesPrism::value)
+        .filter(v -> v.size() == 1)
+        .map(v -> APContext.asTypeElement(v.get(0)))
+        // figure out generics later
+        .filter(v ->
+          v.getTypeParameters().isEmpty()
+            && (v.getKind().isInterface() || hasNoArgConstructor(v)))
+        .orElse(null);
     }
 
     return type;
@@ -430,7 +428,7 @@ final class Util {
 
   static boolean hasNoArgConstructor(TypeElement beanType) {
     return ElementFilter.constructorsIn(beanType.getEnclosedElements()).stream()
-        .anyMatch(e -> e.getParameters().isEmpty() && !e.getModifiers().contains(Modifier.PRIVATE));
+      .anyMatch(e -> e.getParameters().isEmpty() && !e.getModifiers().contains(Modifier.PRIVATE));
   }
 
   public static String shortNameLazyProxy(TypeElement lazyProxyType) {

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lazy/LazyBeanAOP.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lazy/LazyBeanAOP.java
@@ -1,0 +1,23 @@
+package io.avaje.inject.generator.models.valid.lazy;
+
+import io.avaje.inject.Lazy;
+import io.avaje.inject.generator.models.valid.Timed;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+@Lazy
+@Timed
+@Singleton
+public class LazyBeanAOP {
+
+  Integer intProvider;
+
+  @Inject
+  public LazyBeanAOP(Integer intProvider) {
+    this.intProvider = intProvider;
+  }
+
+  public LazyBeanAOP() {}
+
+  void something() {}
+}

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lazy/LazyBeanTypes.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lazy/LazyBeanTypes.java
@@ -1,5 +1,6 @@
 package io.avaje.inject.generator.models.valid.lazy;
 
+import io.avaje.inject.BeanTypes;
 import io.avaje.inject.Lazy;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
@@ -7,16 +8,16 @@ import jakarta.inject.Singleton;
 
 @Lazy
 @Singleton
-public class LazyBean {
+@BeanTypes(LazyInterface.class)
+public class LazyBeanTypes implements LazyInterface {
 
   Provider<Integer> intProvider;
 
   @Inject
-  public LazyBean(Provider<Integer> intProvider) {
+  public LazyBeanTypes(Provider<Integer> intProvider) {
     this.intProvider = intProvider;
   }
 
-  public LazyBean() {}
-
-  void something() {}
+  @Override
+  public void something() {}
 }

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lazy/LazyBeanTypes.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lazy/LazyBeanTypes.java
@@ -20,4 +20,9 @@ public class LazyBeanTypes implements LazyInterface {
 
   @Override
   public void something() {}
+
+  @Override
+  public String somethingElse() { // TODO Auto-generated method stub
+    return null;
+  }
 }

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lazy/LazyFactory.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lazy/LazyFactory.java
@@ -12,4 +12,9 @@ public class LazyFactory {
   Integer lazyInt() {
     return 0;
   }
+
+  @Bean
+  LazyInterface lazyInterface() {
+    return null;
+  }
 }

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lazy/LazyInterface.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lazy/LazyInterface.java
@@ -3,4 +3,6 @@ package io.avaje.inject.generator.models.valid.lazy;
 public interface LazyInterface {
 
   void something();
+
+  String somethingElse();
 }

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lazy/LazyInterface.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lazy/LazyInterface.java
@@ -1,0 +1,6 @@
+package io.avaje.inject.generator.models.valid.lazy;
+
+public interface LazyInterface {
+
+  void something();
+}

--- a/inject/src/main/java/io/avaje/inject/Lazy.java
+++ b/inject/src/main/java/io/avaje/inject/Lazy.java
@@ -11,8 +11,8 @@ import java.lang.annotation.Target;
  * <p>When annotating a {@link Factory} as {@code @Lazy} it means that the factory itself is not
  * lazy but all beans that it provides will have lazy initialization.
  *
- * @apiNote If the annotated class is an interface or has an additional no-args constructor, a
- *     generated proxy bean will be wired for ultimate laziness.
+ * <p>If the annotated class is an interface or has an additional no-args constructor, a
+ * generated proxy bean will be wired for ultimate laziness.
  */
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.METHOD, ElementType.TYPE})

--- a/inject/src/main/java/io/avaje/inject/Lazy.java
+++ b/inject/src/main/java/io/avaje/inject/Lazy.java
@@ -6,12 +6,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a Singleton, Component or Factory method beans to be initialised lazily.
- * <p>
- * When annotating a {@link Factory} as {@code @Lazy} it means that the factory
- * itself is not lazy but all beans that it provides will have lazy initialisation.
+ * Marks a Singleton, Component or Factory method beans to be initialized lazily.
+ *
+ * <p>When annotating a {@link Factory} as {@code @Lazy} it means that the factory itself is not
+ * lazy but all beans that it provides will have lazy initialization.
+ *
+ * @apiNote If the annotated class is an interface or has an additional no-args constructor, a
+ *     generated proxy bean will be wired for ultimate laziness.
  */
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.METHOD, ElementType.TYPE})
-public @interface Lazy {
-}
+public @interface Lazy {}

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -79,9 +79,10 @@ public interface Builder {
    */
   <T> void registerProvider(Provider<T> provider);
 
-  /** Register the lazy provider into the context. */
-  default <T> void registerLazy(
-      Provider<T> provider, Function<Provider<T>, T> proxyClassConstructor) {
+  /**
+   * Register the lazy provider into the context.
+   */
+  default <T> void registerLazy(Provider<T> provider, Function<Provider<T>, T> proxyClassConstructor) {
     register(proxyClassConstructor.apply(new OnceProvider<>(provider)));
   }
 

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -1,14 +1,15 @@
 package io.avaje.inject.spi;
 
-import io.avaje.inject.BeanScope;
-import jakarta.inject.Provider;
-
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
+
+import io.avaje.inject.BeanScope;
+import jakarta.inject.Provider;
 
 /**
  * Mutable builder object used when building a bean scope.
@@ -78,6 +79,11 @@ public interface Builder {
    */
   <T> void registerProvider(Provider<T> provider);
 
+  /** Register the lazy provider into the context. */
+  default <T> void registerLazy(
+      Provider<T> provider, Function<Provider<T>, T> proxyClassConstructor) {
+    register(proxyClassConstructor.apply(new OnceProvider<>(provider)));
+  }
 
   /**
    * Register the bean instance into the context.

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntryBean.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntryBean.java
@@ -141,8 +141,7 @@ class DContextEntryBean {
 
     private final Provider<?> provider;
 
-    private OnceBeanProvider(
-        Provider<?> provider, String name, int flag, Class<? extends AvajeModule> currentModule) {
+    private OnceBeanProvider(Provider<?> provider, String name, int flag, Class<? extends AvajeModule> currentModule) {
       super(provider, name, flag, currentModule);
       this.provider = new OnceProvider<>(provider);
     }

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntryBean.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntryBean.java
@@ -136,10 +136,8 @@ class DContextEntryBean {
     }
   }
 
-  /**
-   * Single instance scoped Provider based entry.
-   */
-  static final class OnceProvider extends DContextEntryBean {
+  /** Single instance scoped Provider based entry. */
+  static final class OnceBeanProvider extends DContextEntryBean {
 
     private final Provider<?> provider;
 

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntryBean.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntryBean.java
@@ -1,9 +1,7 @@
 package io.avaje.inject.spi;
 
 import io.avaje.inject.BeanEntry;
-
 import jakarta.inject.Provider;
-import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Holds either the bean itself or a provider of the bean.
@@ -26,14 +24,14 @@ class DContextEntryBean {
    */
   static DContextEntryBean supplied(Object source, String name, int flag) {
     if (source instanceof Provider) {
-      return new OnceProvider((Provider<?>)source, name, flag, null);
+      return new OnceBeanProvider((Provider<?>)source, name, flag, null);
     } else {
       return new DContextEntryBean(source, name, flag, null);
     }
   }
 
   static DContextEntryBean provider(boolean prototype, Provider<?> provider, String name, int flag, Class<? extends AvajeModule> currentModule) {
-    return prototype ? new ProtoProvider(provider, name, flag, currentModule) : new OnceProvider(provider, name, flag, currentModule);
+    return prototype ? new ProtoProvider(provider, name, flag, currentModule) : new OnceBeanProvider(provider, name, flag, currentModule);
   }
 
   protected final Object source;
@@ -143,26 +141,17 @@ class DContextEntryBean {
    */
   static final class OnceProvider extends DContextEntryBean {
 
-    private final ReentrantLock lock = new ReentrantLock();
     private final Provider<?> provider;
-    private Object bean;
 
-    private OnceProvider(Provider<?> provider, String name, int flag, Class<? extends AvajeModule> currentModule) {
+    private OnceBeanProvider(
+        Provider<?> provider, String name, int flag, Class<? extends AvajeModule> currentModule) {
       super(provider, name, flag, currentModule);
-      this.provider = provider;
+      this.provider = new OnceProvider<>(provider);
     }
 
     @Override
     Object bean() {
-      lock.lock();
-      try {
-        if (bean == null) {
-          bean = provider.get();
-        }
-        return bean;
-      } finally {
-        lock.unlock();
-      }
+      return provider.get();
     }
   }
 }

--- a/inject/src/main/java/io/avaje/inject/spi/OnceProvider.java
+++ b/inject/src/main/java/io/avaje/inject/spi/OnceProvider.java
@@ -12,7 +12,7 @@ final class OnceProvider<T> implements Provider<T> {
   private final Provider<T> provider;
   private T bean;
 
-  public OnceProvider(Provider<T> provider) {
+  OnceProvider(Provider<T> provider) {
     this.provider = Objects.requireNonNull(provider);
   }
 

--- a/inject/src/main/java/io/avaje/inject/spi/OnceProvider.java
+++ b/inject/src/main/java/io/avaje/inject/spi/OnceProvider.java
@@ -1,0 +1,34 @@
+package io.avaje.inject.spi;
+
+import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
+
+import jakarta.inject.Provider;
+
+/** Single instance Lazy Provider. {@link #get()} will return the same instance every time */
+final class OnceProvider<T> implements Provider<T> {
+
+  private final ReentrantLock lock = new ReentrantLock();
+  private final Provider<T> provider;
+  private T bean;
+
+  public OnceProvider(Provider<T> provider) {
+    this.provider = Objects.requireNonNull(provider);
+  }
+
+  @Override
+  public T get() {
+    if (bean != null) {
+      return bean;
+    }
+    lock.lock();
+    try {
+      if (bean == null) {
+        bean = provider.get();
+      }
+      return bean;
+    } finally {
+      lock.unlock();
+    }
+  }
+}


### PR DESCRIPTION
Now will generate proxy classes for true laziness in the following situations with `@Lazy` beans:

- class with a no-arg constructor
- factory bean method returning a class with a no-arg constructor
- class without a no-arg constructor, but a `@BeanTypes` class that is an interface or has a no arg constructor
- same as above but with factory bean methods
- factory method, but an interface is the return type


given the following class:

```java
@Lazy
@Singleton
public class LazyBean {

  Provider<Integer> intProvider;

  public LazyBean() {}

  @Inject
  public LazyBean(Provider<Integer> intProvider) {
    this.intProvider = intProvider;
  }

  public LazyBean() {}

  void something() {}
}
```

the following proxy class is generated:

```java
@Proxy
@Generated("avaje-inject-generator")
public final class LazyBean$Lazy extends LazyBean {

  private final Provider<LazyBean> onceProvider;

  public LazyBean$Lazy(Provider<LazyBean> onceProvider) {
    this.onceProvider = onceProvider;
  }

   void something() {
    onceProvider.get().something();
  }

}
```


and the DI code is modified like

```java
@Generated("io.avaje.inject.generator")
public final class LazyBean$DI  {

  public static void build(Builder builder) {
    if (builder.isBeanAbsent(LazyBean.class)) {
      builder.registerLazy(() -> {
        var bean = new LazyBean(builder.getProvider(Integer.class));
        return bean;
     }, LazyBean$Lazy::new);
    }
  }

}
```



resolves #830 