### PR TITLE
Support a main package called `avaje`

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeUtil.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeUtil.java
@@ -4,7 +4,19 @@ final class ScopeUtil {
 
   static String initName(String name) {
     name = name(name);
-    return "Inject".equals(name) ? "DInject" : name;
+
+    if (name == null) {
+      return null;
+    }
+
+    switch (name) {
+      case "Inject":
+        return "DInject";
+      case "Avaje":
+        return "AvajeInject";
+      default:
+        return name;
+    }
   }
 
   static String name(String name) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeUtil.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeUtil.java
@@ -4,11 +4,9 @@ final class ScopeUtil {
 
   static String initName(String name) {
     name = name(name);
-
     if (name == null) {
       return null;
     }
-
     switch (name) {
       case "Inject":
         return "DInject";

--- a/inject-generator/src/test/java/io/avaje/inject/generator/ScopeUtilTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/ScopeUtilTest.java
@@ -1,8 +1,8 @@
 package io.avaje.inject.generator;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 class ScopeUtilTest {
 
@@ -18,6 +18,13 @@ class ScopeUtilTest {
   void initName_inject() {
     // resulting module can't be InjectModule as that clashes with @InjectModule
     assertEquals("DInject", ScopeUtil.initName("org.example.inject"));
+    assertEquals("Foo", ScopeUtil.initName("org.example.foo"));
+  }
+
+  @Test
+  void initName_avaje() {
+    // resulting module can't be InjectModule as that clashes with @InjectModule
+    assertEquals("AvajeInject", ScopeUtil.initName("org.example.avaje"));
     assertEquals("Foo", ScopeUtil.initName("org.example.foo"));
   }
 

--- a/inject-generator/src/test/java/io/avaje/inject/generator/ScopeUtilTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/ScopeUtilTest.java
@@ -1,6 +1,7 @@
 package io.avaje.inject.generator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
@@ -12,6 +13,9 @@ class ScopeUtilTest {
     assertEquals("Example", ScopeUtil.name("org.Example"));
     assertEquals("Example", ScopeUtil.name("example"));
     assertEquals("Example", ScopeUtil.name("Example"));
+    assertEquals("Example", ScopeUtil.name("ExampleScope"));
+    assertEquals("Example", ScopeUtil.name("ExampleModule"));
+    assertNull(ScopeUtil.name(null));
   }
 
   @Test
@@ -19,6 +23,7 @@ class ScopeUtilTest {
     // resulting module can't be InjectModule as that clashes with @InjectModule
     assertEquals("DInject", ScopeUtil.initName("org.example.inject"));
     assertEquals("Foo", ScopeUtil.initName("org.example.foo"));
+    assertNull(ScopeUtil.initName(null));
   }
 
   @Test


### PR DESCRIPTION
now generated module classes will not have the name `AvajeModule` when the package is `avaje`, which clashes with the class of the same name