### PR TITLE
Fix invalid `Provider` generation with AOP

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/config/MyAopProviderConsumer.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/config/MyAopProviderConsumer.java
@@ -1,0 +1,20 @@
+package org.example.myapp.config;
+
+import io.avaje.inject.Component;
+import jakarta.inject.Provider;
+import org.example.myapp.aspect.MyTimed;
+
+@Component
+@MyTimed
+public class MyAopProviderConsumer {
+
+  final Provider<AppConfig.Builder> builderProvider;
+
+  public MyAopProviderConsumer(Provider<AppConfig.Builder> builderProvider) {
+    this.builderProvider = builderProvider;
+  }
+
+  public AppConfig.Builder doStuff() {
+    return builderProvider.get();
+  }
+}

--- a/blackbox-test-inject/src/test/java/org/example/myapp/config/MyAopProviderConsumerTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/config/MyAopProviderConsumerTest.java
@@ -1,0 +1,23 @@
+package org.example.myapp.config;
+
+import io.avaje.inject.test.InjectTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@InjectTest
+class MyAopProviderConsumerTest {
+
+  @Inject MyAopProviderConsumer consumer;
+
+  @Test
+  void doStuff() {
+    AppConfig.Builder builder1 = consumer.doStuff();
+    AppConfig.Builder builder2 = consumer.doStuff();
+
+    assertThat(builder1).isNotNull();
+    assertThat(builder2).isNotNull();
+    assertThat(builder2).isNotSameAs(builder1);
+  }
+}

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -669,10 +669,10 @@ final class MethodReader {
       if (nullable) {
         writer.append("@Nullable ");
       }
-      if (genericType.isGeneric()) {
-        writer.append(genericType.shortWithoutAnnotations());
+      if (fullUType.isGeneric()) {
+        writer.append(fullUType.shortWithoutAnnotations());
       } else {
-        writer.append(Util.shortName(genericType.mainType()));
+        writer.append(Util.shortName(fullUType.mainType()));
       }
       writer.append(" ").append(simpleName);
     }

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/MethodTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/MethodTest.java
@@ -11,12 +11,6 @@ import jakarta.inject.Provider;
 @Component
 public class MethodTest {
 
-  Provider<TestClass> provider;
-
-  public MethodTest(Provider<TestClass> provider) {
-    this.provider = provider;
-  }
-
   @Timed
   void test(@Param Map<@TypeUse String, String> str, @Param int inty, String regular) {}
 

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/MethodTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/MethodTest.java
@@ -4,9 +4,7 @@ import java.util.Map;
 
 import io.avaje.inject.Component;
 import io.avaje.inject.aop.AOPFallback;
-import io.avaje.inject.generator.models.valid.TestClass;
 import io.avaje.inject.generator.models.valid.Timed;
-import jakarta.inject.Provider;
 
 @Component
 public class MethodTest {

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/MethodTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/aspect/MethodTest.java
@@ -4,10 +4,18 @@ import java.util.Map;
 
 import io.avaje.inject.Component;
 import io.avaje.inject.aop.AOPFallback;
+import io.avaje.inject.generator.models.valid.TestClass;
 import io.avaje.inject.generator.models.valid.Timed;
+import jakarta.inject.Provider;
 
 @Component
 public class MethodTest {
+
+  Provider<TestClass> provider;
+
+  public MethodTest(Provider<TestClass> provider) {
+    this.provider = provider;
+  }
 
   @Timed
   void test(@Param Map<@TypeUse String, String> str, @Param int inty, String regular) {}


### PR DESCRIPTION
In a case like 

```java
@Timed
@Component
public class MethodTest {

  Provider<TestClass> provider;

  public MethodTest(Provider<TestClass> provider) {
    this.provider = provider;
  }
//...
}
```

It was generating incorrectly and causing a compilation error 

```java
@Proxy
@Generated("io.avaje.inject.generator")
public final class MethodTest$Proxy extends MethodTest {

//...

  public MethodTest$Proxy(AspectProvider<Timed> timed, TestClass provider) { //invalid
    super(provider);
   //....
  }
}
