### PR TITLE
Register Generic Supertype as an Injectable Type

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/generic/MyUseGenericDependencies.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/generic/MyUseGenericDependencies.java
@@ -1,9 +1,10 @@
 package org.example.myapp.generic;
 
-import jakarta.inject.Singleton;
-
+import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
+
+import jakarta.inject.Singleton;
 
 @Singleton
 class MyUseGenericDependencies {
@@ -11,13 +12,17 @@ class MyUseGenericDependencies {
   private final Aldrich<String, String> aldrich;
   private final Map<String, MyConsumer> genericMap;
   private final BiConsumer<MyA, MyB> biConsumer;
+  private final List<Generic<?>> genList;
 
-  MyUseGenericDependencies(Aldrich<String, String> aldrich,
-                           Map<String, MyConsumer> genericMap,
-                           BiConsumer<MyA, MyB> biConsumer) {
+  MyUseGenericDependencies(
+      Aldrich<String, String> aldrich,
+      Map<String, MyConsumer> genericMap,
+      BiConsumer<MyA, MyB> biConsumer,
+      List<Generic<?>> genList) {
     this.aldrich = aldrich;
     this.genericMap = genericMap;
     this.biConsumer = biConsumer;
+    this.genList = genList;
   }
 
   Aldrich<String, String> getAldrich() {
@@ -30,5 +35,9 @@ class MyUseGenericDependencies {
 
   BiConsumer<MyA, MyB> getBiConsumer() {
     return biConsumer;
+  }
+
+  public List<Generic<?>> getGenList() {
+    return genList;
   }
 }

--- a/blackbox-test-inject/src/test/java/org/example/myapp/generic/GenericFactoryTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/generic/GenericFactoryTest.java
@@ -21,5 +21,6 @@ class GenericFactoryTest {
     assertThat(others.getAldrich()).isNotNull();
     assertThat(others.getGenericMap()).isNotNull();
     assertThat(others.getBiConsumer()).isNotNull();
+    assertThat(others.getGenList()).hasSize(2);
   }
 }

--- a/blackbox-test-inject/src/test/java/org/example/myapp/generic/GenericFactoryTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/generic/GenericFactoryTest.java
@@ -22,5 +22,6 @@ class GenericFactoryTest {
     assertThat(others.getGenericMap()).isNotNull();
     assertThat(others.getBiConsumer()).isNotNull();
     assertThat(others.getGenList()).hasSize(2);
+    assertThat(others.getGenList()).contains(stringy, intymcintface);
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeAppender.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeAppender.java
@@ -24,9 +24,8 @@ final class TypeAppender {
     var type = Util.unwrapProvider(utype);
     if (isAddGenericType(type)) {
       addUType(type);
-    } else {
-      addSimpleType(type.mainType());
     }
+    addSimpleType(type.mainType());
   }
 
   private static boolean isAddGenericType(UType type) {


### PR DESCRIPTION
Had a problem in the Discord where a multi-module project failed to work because it couldn't retrieve all the implementations of a generic type.

- now generic super types will be added to the bean entry