### PR TITLE
[events] support prototype scope

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
@@ -418,6 +419,11 @@ final class MethodReader {
     // TYPE_ generic types are fully qualified
     if (optionalType) {
       importTypes.add(Constants.OPTIONAL);
+    }
+
+    if (observeParameter != null) {
+      importTypes.add(Supplier.class.getCanonicalName());
+      importTypes.add(Constants.BEANSCOPE);
     }
     conditions.addImports(importTypes);
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanWriter.java
@@ -256,6 +256,7 @@ final class SimpleBeanWriter {
   private void writeObserveMethods() {
     final var bean = "bean";
     final var builder = "builder";
+    final var scope = "events$$beanScope";
 
     final var indent = "      ";
     for (MethodReader methodReader : beanReader.observerMethods()) {
@@ -264,9 +265,17 @@ final class SimpleBeanWriter {
       final var shortWithoutAnnotations = observeUtype.shortWithoutAnnotations();
       var injectParams = methodReader.params().stream().skip(1).collect(toList());
 
+      if (!injectParams.isEmpty()) {
+        writer.indent(indent).append("var %s = %s.get(BeanScope.class);", scope, builder).eol();
+      }
+
       for (MethodParam param : injectParams) {
-        writer.indent(indent).append("var %s = ", methodReader.name() + "$" + param.simpleName());
-        param.builderGetDependency(writer, builder);
+        writer
+            .indent(indent)
+            .append(
+                "Supplier<%s> %s = () -> ",
+                param.getFullUType().shortType(), methodReader.name() + "$" + param.simpleName());
+        param.builderGetDependency(writer, scope);
         writer.append(";").eol();
       }
 
@@ -280,9 +289,10 @@ final class SimpleBeanWriter {
       if (methodReader.params().size() == 1) {
         writer.append("%s::%s;", bean, methodReader.name());
       } else {
-        var injectParamNames = injectParams.stream()
-          .map(p -> methodReader.name() + "$" + p.simpleName())
-          .collect(joining(", "));
+        var injectParamNames =
+            injectParams.stream()
+                .map(p -> methodReader.name() + "$" + p.simpleName() + ".get()")
+                .collect(joining(", "));
         writer.append("e -> bean.%s(e, %s);", methodReader.name(), injectParamNames);
       }
       final var observesPrism = ObservesPrism.getInstanceOn(observeEvent.element());

--- a/inject-test/src/test/java/org/example/observes/MyObserverInjectPrototype.java
+++ b/inject-test/src/test/java/org/example/observes/MyObserverInjectPrototype.java
@@ -1,0 +1,22 @@
+package org.example.observes;
+
+import java.util.ArrayDeque;
+
+import org.example.coffee.prototype.MyProto;
+
+import io.avaje.inject.events.Observes;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class MyObserverInjectPrototype {
+
+  boolean invoked = false;
+  CustomEvent event;
+  ArrayDeque<MyProto> beansList = new ArrayDeque<>();
+
+  void observe(@Observes CustomEvent e, MyProto proto) {
+    invoked = true;
+    event = e;
+    beansList.add(proto);
+  }
+}

--- a/inject-test/src/test/java/org/example/observes/TestEventMessaging.java
+++ b/inject-test/src/test/java/org/example/observes/TestEventMessaging.java
@@ -16,6 +16,7 @@ class TestEventMessaging {
   @Inject MyObserver observer;
   @Inject MyQualifiedObserver qualifiedObserver;
   @Inject MyObserverInjected observerInjected;
+  @Inject MyObserverInjectPrototype observerPrototype;
   @Inject MyStrQualifiedObserver strQualifiedObserver;
   @Inject Event<CustomEvent> event;
   @Inject EventSender2 sender2;
@@ -30,6 +31,9 @@ class TestEventMessaging {
     qualifiedObserver.event = null;
     observerInjected.invoked= false;
     observerInjected.event = null;
+    observerPrototype.invoked = false;
+    observerPrototype.event = null;
+    observerPrototype.beansList.clear();
   }
 
   @Test
@@ -43,6 +47,21 @@ class TestEventMessaging {
     assertThat(qualifiedObserver.invoked).isFalse();
     assertThat(observerInjected.invoked).isTrue();
     assertThat(observerInjected.event).isSameAs(message);
+  }
+
+  @Test
+  void testProtoType() {
+    var message = new CustomEvent("hi");
+
+    event.fire(message);
+
+    assertThat(observerPrototype.invoked).isTrue();
+    assertThat(observerPrototype.event).isSameAs(message);
+    event.fire(message);
+
+    assertThat(observerPrototype.invoked).isTrue();
+    assertThat(observerPrototype.event).isSameAs(message);
+    assertThat(observerPrototype.beansList.poll()).isNotSameAs(observerPrototype.beansList.poll());
   }
 
   @Test


### PR DESCRIPTION
now will use a supplier using `BeanScope` to inject observer beans.


Given a class:

```java
@Singleton
public class TestObserverInjection {

  void observe(@ObservesAsync String e, TestObserver observer) {}
}
```
This will generate
```java
@Generated("io.avaje.inject.generator")
public final class TestObserverInjection$DI  {

  public static void build(Builder builder) {
    if (builder.isBeanAbsent(TestObserverInjection.class)) {
      var bean = new TestObserverInjection();
      builder.register(bean);
      var events$$beanScope = builder.get(BeanScope.class);
      Supplier<TestObserver> observe$observer = () -> events$$beanScope.get(TestObserver.class,"!observer");
      Consumer<String> observe = e -> bean.observe(e, observe$observer.get());
      builder
          .get(ObserverManager.class)
          .<String>registerObserver(
              String.class, new Observer<>(1000, true, observe, ""));
    }
  }
}
```