### PR TITLE
Fix external dependency error messages

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
@@ -146,7 +146,7 @@ final class MetaDataOrdering {
 
   private void checkMissingDependencies(MetaData metaData) {
     for (Dependency dependency : metaData.dependsOn()) {
-      if (providers.get(dependency.name()) == null && !scopeInfo.providedByOtherScope(dependency.name())) {
+      if (!dependencySatisfied(dependency, true, metaData)) {
         TypeElement element = elementMaybe(metaData.type());
         logError(element, "No dependency provided for %s on %s", dependency, metaData.type());
         missingDependencyTypes.add(dependency.name());


### PR DESCRIPTION
Now will pinpoint the exact missing dependency in the error message when external beans are involved.

before given class
```java
@Singleton
public class ExternalDeps {
  @Inject @Nullable AtomicLong longy;

  public ExternalDeps(AtomicBoolean bool, @External AtomicInteger inty) {}
}
```

it would error with 

```
Dependencies [java.util.concurrent.atomic.AtomicBoolean, java.util.concurrent.atomic.AtomicInteger] are not provided
```


Now it will correctly error with 
```
Dependencies [java.util.concurrent.atomic.AtomicBoolean] are not provided
```
