### PR TITLE
Add Compile Warnings to Use Lazy Correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ public final class ExampleModule implements AvajeModule {
 
 - Specifically aimed for server-side development (rather than Android)
 - Supports "component testing" via `avaje-inject-test` and `@InjectTest`
-- Provides API to obtain all bean instances that implement an interface
+- Provides an API to obtain all bean instances that implement an interface
 - Lifecycle methods with `@PostConstruct` and `@PreDestroy`
 - Spring-like factory classes with `@Factory` and `@Bean`
 - Conditional Wiring based on active profiles or existing beans/properties
@@ -165,6 +165,7 @@ public final class ExampleModule implements AvajeModule {
 | [@Factory and @Bean](https://avaje.io/inject/#factory) | - | @Configuration and @Bean
 | [@RequiresBean and @RequiresProperty](https://avaje.io/inject/#conditional) | - | @Conditional
 | [@Lazy](https://avaje.io/inject/#lazy) | - | @Lazy
+| [@Prototype](https://avaje.io/inject/#prototype) | - | @Scope("prototype")
 | [@Primary](https://avaje.io/inject/#primary) | - | @Primary
 | [@Secondary](https://avaje.io/inject/#secondary) | - | @Fallback
 | [@InjectTest](https://avaje.io/inject/#component-testing) | - | @SpringBootTest

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -1,6 +1,7 @@
 package io.avaje.inject.generator;
 
 import static io.avaje.inject.generator.APContext.logError;
+import static io.avaje.inject.generator.APContext.logWarn;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -194,6 +195,8 @@ final class BeanReader {
     conditions.addImports(importTypes);
     if (proxyLazy) {
       SimpleBeanLazyWriter.write(APContext.elements().getPackageOf(beanType), lazyProxyType);
+    } else if (lazy) {
+      logWarn(beanType, "Lazy beans should have a no-arg constructor");
     }
     return this;
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -1,5 +1,6 @@
 package io.avaje.inject.generator;
 
+import static io.avaje.inject.generator.APContext.logWarn;
 import static io.avaje.inject.generator.Constants.CONDITIONAL_DEPENDENCY;
 import static io.avaje.inject.generator.ProcessingContext.asElement;
 
@@ -169,13 +170,15 @@ final class MethodReader {
   }
 
   MethodReader read() {
-    List<? extends VariableElement> ps = element.getParameters();
-    for (VariableElement p : ps) {
+    var ps = element.getParameters();
+    for (var p : ps) {
       params.add(new MethodParam(p));
     }
     observeParameter = params.stream().filter(MethodParam::observeEvent).findFirst().orElse(null);
     if (proxyLazy) {
       SimpleBeanLazyWriter.write(APContext.elements().getPackageOf(element), lazyProxyType);
+    } else if (lazy) {
+      logWarn(element, "Lazy return types should be abstract or have a no-arg constructor");
     }
     return this;
   }

--- a/inject/src/main/java/io/avaje/inject/Lazy.java
+++ b/inject/src/main/java/io/avaje/inject/Lazy.java
@@ -6,13 +6,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a Singleton, Component or Factory method beans to be initialized lazily.
+ * Marks a class or factory method bean to be initialized lazily.
  *
- * <p>When annotating a {@link Factory} as {@code @Lazy} it means that the factory itself is not
- * lazy but all beans that it provides will have lazy initialization.
+ * <p>When annotating a {@link Factory} class as {@code @Lazy}, the factory itself is not lazy but
+ * all beans that it provides will have lazy initialization.
  *
- * <p>If the annotated class is an interface or has an additional no-args constructor, a
- * generated proxy bean will be wired for ultimate laziness.
+ * <p>If the annotated class or factory method is an interface or has an additional no-args
+ * constructor, a generated proxy bean will be wired for ultimate laziness.
  */
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.METHOD, ElementType.TYPE})


### PR DESCRIPTION
Now warns on compilation if missing a no-args constructor