### PR TITLE
Merge requires/provides with their auto variants

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
@@ -25,7 +25,6 @@ final class MetaDataOrdering {
   private final List<DependencyLink> circularDependencies = new ArrayList<>();
   private final Set<String> missingDependencyTypes = new LinkedHashSet<>();
   private final Set<String> autoRequires = new TreeSet<>();
-  private final Set<String> autoRequiresAspects = new TreeSet<>();
 
   MetaDataOrdering(Collection<MetaData> values, ScopeInfo scopeInfo) {
     this.scopeInfo = scopeInfo;
@@ -224,11 +223,7 @@ final class MetaDataOrdering {
 
   private boolean isExternal(String dependencyName, boolean includeExternal, MetaData queuedMeta) {
     if (includeExternal && externallyProvided(dependencyName)) {
-      if (Util.isAspectProvider(dependencyName)) {
-        autoRequiresAspects.add(Util.extractAspectType(dependencyName));
-      } else {
-        autoRequires.add(dependencyName);
-      }
+      autoRequires.add(dependencyName);
       queuedMeta.markWithExternalDependency(dependencyName);
       return true;
     }
@@ -237,10 +232,6 @@ final class MetaDataOrdering {
 
   Set<String> autoRequires() {
     return autoRequires;
-  }
-
-  Set<String> autoRequiresAspects() {
-    return autoRequiresAspects;
   }
 
   List<MetaData> ordered() {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ScopeInfo.java
@@ -427,7 +427,7 @@ final class ScopeInfo {
     writer.append("}");
   }
 
-  void buildProvides(Append writer) {
+  void buildProvides(Append writer, Set<String> provides, Set<String> requires) {
     if (!provides.isEmpty()) {
       buildProvidesMethod(writer, "provides", provides);
     }
@@ -458,34 +458,6 @@ final class ScopeInfo {
     }
     writer.append("    };").eol();
     writer.append("  }").eol().eol();
-  }
-
-  void buildAutoProvides(Append writer, Set<String> autoProvides) {
-    autoProvides.removeAll(provides);
-    if (!autoProvides.isEmpty()) {
-      buildProvidesMethod(writer, "autoProvides", autoProvides);
-    }
-  }
-
-  void buildAutoProvidesAspects(Append writer, Set<String> autoProvidesAspects) {
-    autoProvidesAspects.removeAll(provides);
-    if (!autoProvidesAspects.isEmpty()) {
-      buildProvidesMethod(writer, "autoProvidesAspects", autoProvidesAspects);
-    }
-  }
-
-  void buildAutoRequires(Append writer, Set<String> autoRequires) {
-    autoRequires.removeAll(requires);
-    if (!autoRequires.isEmpty()) {
-      buildProvidesMethod(writer, "autoRequires", autoRequires);
-    }
-  }
-
-  void buildAutoRequiresAspects(Append writer, Set<String> autoRequires) {
-    autoRequires.removeAll(requires);
-    if (!autoRequires.isEmpty()) {
-      buildProvidesMethod(writer, "autoRequiresAspects", autoRequires);
-    }
   }
 
   void readModuleMetaData(TypeElement moduleType) {

--- a/inject/src/main/java/io/avaje/inject/spi/AvajeModule.java
+++ b/inject/src/main/java/io/avaje/inject/spi/AvajeModule.java
@@ -24,7 +24,7 @@ public interface AvajeModule extends InjectExtension {
 
   /** Build all the beans. */
   void build(Builder builder);
-  
+
   /**
    * Return the set of types this module explicitly provides to other modules.
    *

--- a/inject/src/main/java/io/avaje/inject/spi/AvajeModule.java
+++ b/inject/src/main/java/io/avaje/inject/spi/AvajeModule.java
@@ -39,6 +39,7 @@ public interface AvajeModule extends InjectExtension {
    * <p>This is a convenience when using multiple modules that is otherwise controlled manually by
    * explicitly using {@link AvajeModule#provides()}.
    */
+  @Deprecated(forRemoval = true)
   default Type[] autoProvides() {
     return EMPTY_CLASSES;
   }
@@ -49,6 +50,7 @@ public interface AvajeModule extends InjectExtension {
    * <p>This is a convenience when using multiple modules that we otherwise manually specify via
    * {@link AvajeModule#provides()}.
    */
+  @Deprecated(forRemoval = true)
   default Class<?>[] autoProvidesAspects() {
     return EMPTY_CLASSES;
   }
@@ -60,6 +62,7 @@ public interface AvajeModule extends InjectExtension {
    * <p>This is a convenience when using multiple modules that is otherwise controlled manually by
    * explicitly using {@link AvajeModule#requires()} or {@link AvajeModule#requiresPackages()}.
    */
+  @Deprecated(forRemoval = true)
   default Type[] autoRequires() {
     return EMPTY_CLASSES;
   }
@@ -68,6 +71,7 @@ public interface AvajeModule extends InjectExtension {
    * These are the aspects that this module requires whose implementations are provided by other
    * external modules (that are in the classpath at compile time).
    */
+  @Deprecated(forRemoval = true)
   default Class<?>[] autoRequiresAspects() {
     return EMPTY_CLASSES;
   }

--- a/inject/src/main/java/io/avaje/inject/spi/AvajeModule.java
+++ b/inject/src/main/java/io/avaje/inject/spi/AvajeModule.java
@@ -13,6 +13,19 @@ public interface AvajeModule extends InjectExtension {
   Class<?>[] EMPTY_CLASSES = {};
 
   /**
+   * Return public classes of the beans that would be registered by this module.
+   *
+   * <p>This method allows code to use reflection to inspect the modules classes before the module
+   * is wired. This method is not required for DI wiring.
+   */
+  Class<?>[] classes();
+
+  /**
+   * Build all the beans.
+   */
+  void build(Builder builder);
+  
+  /**
    * Return the set of types this module explicitly provides to other modules.
    */
   default Type[] provides() {
@@ -75,19 +88,6 @@ public interface AvajeModule extends InjectExtension {
   default Class<?>[] autoRequiresAspects() {
     return EMPTY_CLASSES;
   }
-
-  /**
-   * Return public classes of the beans that would be registered by this module.
-   *
-   * <p>This method allows code to use reflection to inspect the modules classes before the module
-   * is wired. This method is not required for DI wiring.
-   */
-  Class<?>[] classes();
-
-  /**
-   * Build all the beans.
-   */
-  void build(Builder builder);
 
   /**
    * Marker for custom scoped modules.


### PR DESCRIPTION
Honestly, there is no reason to split into three separate methods, given that we support generic wiring.

- deprecates auto requires/provides
- generate only provides/requires
- move the generation order such that the build method is seen first. (got tired of scrolling past the massive classes/provides to see the wiring logic)