### PR TITLE
Determine Priority Annotations at Compile Time

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -70,7 +70,7 @@ final class BeanReader {
         || importedComponent && ProcessingContext.isImportedPrototype(actualType);
     this.primary = PrimaryPrism.isPresent(actualType);
     this.secondary = !primary && SecondaryPrism.isPresent(actualType);
-    this.priority = Util.getPriority(actualType);
+    this.priority = Util.priority(actualType);
     var beanTypes =
       BeanTypesPrism.getOptionalOn(actualType)
         .map(BeanTypesPrism::value)

--- a/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/BeanReader.java
@@ -54,6 +54,7 @@ final class BeanReader {
   private boolean suppressGeneratedImport;
   private Set<UType> allUTypes;
   private final boolean delayed;
+  private final Integer priority;
 
   BeanReader(TypeElement beanType, boolean factory, boolean importedComponent) {
     this.beanType = beanType;
@@ -69,6 +70,7 @@ final class BeanReader {
         || importedComponent && ProcessingContext.isImportedPrototype(actualType);
     this.primary = PrimaryPrism.isPresent(actualType);
     this.secondary = !primary && SecondaryPrism.isPresent(actualType);
+    this.priority = Util.getPriority(actualType);
     var beanTypes =
       BeanTypesPrism.getOptionalOn(actualType)
         .map(BeanTypesPrism::value)
@@ -368,6 +370,8 @@ final class BeanReader {
       writer.append("asPrimary().");
     } else if (secondary) {
       writer.append("asSecondary().");
+    } else if (priority != null) {
+      writer.append("asPriority(%s).", priority);
     }
     writer.append("register(bean);").eol();
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -37,6 +37,7 @@ final class MethodReader {
   private final boolean prototype;
   private final boolean primary;
   private final boolean secondary;
+  private final Integer priority;
   private final boolean lazy;
   private final boolean proxyLazy;
   private final TypeElement lazyProxyType;
@@ -68,6 +69,7 @@ final class MethodReader {
       prototype = PrototypePrism.isPresent(element);
       primary = PrimaryPrism.isPresent(element);
       secondary = SecondaryPrism.isPresent(element);
+      priority = Util.getPriority(element);
       lazy = LazyPrism.isPresent(element) || LazyPrism.isPresent(element.getEnclosingElement());
       conditions.readAll(element);
       this.lazyProxyType = lazy ? Util.lazyProxy(element) : null;
@@ -76,6 +78,7 @@ final class MethodReader {
       prototype = false;
       primary = false;
       secondary = false;
+      priority = null;
       lazy = false;
       this.proxyLazy = false;
       this.lazyProxyType = null;
@@ -273,6 +276,8 @@ final class MethodReader {
       writer.append(".asPrototype()");
     } else if (secondary) {
       writer.append(".asSecondary()");
+    } else if (priority != null) {
+      writer.append(".asPriority(%s)", priority);
     }
 
     if (proxyLazy) {
@@ -331,6 +336,8 @@ final class MethodReader {
         writer.append(".asPrimary()");
       } else if (secondary) {
         writer.append(".asSecondary()");
+      } else if (priority != null) {
+        writer.append(".asPriority(%s)", priority);
       } else if (prototype) {
         writer.append(".asPrototype()");
       }
@@ -526,7 +533,7 @@ final class MethodReader {
   }
 
   boolean isUseProviderForSecondary() {
-    return secondary && !optionalType && !Util.isProvider(returnTypeRaw);
+    return (secondary || priority != null) && !optionalType && !Util.isProvider(returnTypeRaw);
   }
 
   boolean isPublic() {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -4,6 +4,7 @@ import static io.avaje.inject.generator.APContext.logWarn;
 import static io.avaje.inject.generator.Constants.CONDITIONAL_DEPENDENCY;
 import static io.avaje.inject.generator.ProcessingContext.asElement;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -69,7 +70,7 @@ final class MethodReader {
       prototype = PrototypePrism.isPresent(element);
       primary = PrimaryPrism.isPresent(element);
       secondary = SecondaryPrism.isPresent(element);
-      priority = Util.getPriority(element);
+      priority = Util.priority(element);
       lazy = LazyPrism.isPresent(element) || LazyPrism.isPresent(element.getEnclosingElement());
       conditions.readAll(element);
       this.lazyProxyType = lazy ? Util.lazyProxy(element) : null;
@@ -532,6 +533,13 @@ final class MethodReader {
     return lazy;
   }
 
+  /**
+   * Use a Provider with Secondary or Priority annotation.
+   *
+   * <p> As a Provider, the bean won't be instantiated unless it is needed
+   * by being wired as the highest priority, or wired in a List/Set/Map, or
+   * by being accessed via {@link io.avaje.inject.BeanScope#list(Type)} etc.
+   */
   boolean isUseProviderForSecondary() {
     return (secondary || priority != null) && !optionalType && !Util.isProvider(returnTypeRaw);
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -430,6 +430,20 @@ final class Util {
   }
 
   public static String shortNameLazyProxy(TypeElement lazyProxyType) {
-    return shortName(lazyProxyType.getQualifiedName().toString())
-      .replace(".", "_");  }
+    return shortName(lazyProxyType.getQualifiedName().toString()).replace(".", "_");
+  }
+
+  static Integer getPriority(Element element) {
+
+    for (final var mirror : element.getAnnotationMirrors()) {
+      if (mirror.getAnnotationType().asElement().getSimpleName().toString().contains("Priority")
+          && mirror.getElementValues().size() == 1) {
+        var value = mirror.getElementValues().values().iterator().next().getValue();
+        if (value instanceof Integer) {
+          return (Integer) value;
+        }
+      }
+    }
+    return null;
+  }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -440,7 +440,8 @@ final class Util {
           && mirror.getElementValues().size() == 1) {
         var value = mirror.getElementValues().values().iterator().next().getValue();
         if (value instanceof Integer) {
-          return (Integer) value;
+          var val = (Integer) value;
+          return val <= Integer.MIN_VALUE + 1 ? Integer.MIN_VALUE + 2 : val;
         }
       }
     }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -433,11 +433,9 @@ final class Util {
     return shortName(lazyProxyType.getQualifiedName().toString()).replace(".", "_");
   }
 
-  static Integer getPriority(Element element) {
-
+  static Integer priority(Element element) {
     for (final var mirror : element.getAnnotationMirrors()) {
-      if (mirror.getAnnotationType().asElement().getSimpleName().toString().contains("Priority")
-          && mirror.getElementValues().size() == 1) {
+      if (isPriorityAnnotation(mirror) && mirror.getElementValues().size() == 1) {
         var value = mirror.getElementValues().values().iterator().next().getValue();
         if (value instanceof Integer) {
           var val = (Integer) value;
@@ -446,5 +444,9 @@ final class Util {
       }
     }
     return null;
+  }
+
+  private static boolean isPriorityAnnotation(AnnotationMirror mirror) {
+    return mirror.getAnnotationType().asElement().getSimpleName().toString().contains("Priority");
   }
 }

--- a/inject-test/src/test/java/io/avaje/inject/xtra/SystemContextTest.java
+++ b/inject-test/src/test/java/io/avaje/inject/xtra/SystemContextTest.java
@@ -10,6 +10,7 @@ import org.example.coffee.priority.base.ABasei;
 import org.example.coffee.priority.base.BBasei;
 import org.example.coffee.priority.base.BaseIface;
 import org.example.coffee.priority.base.CBasei;
+import org.example.coffee.priority.base.PriorityFactory.DBasei;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Priority;
@@ -23,11 +24,12 @@ public class SystemContextTest {
   public void getBeansByPriority() {
     try (BeanScope context = BeanScope.builder().build()) {
       final List<BaseIface> beans = context.listByPriority(BaseIface.class);
-      assertThat(beans).hasSize(3);
+      assertThat(beans).hasSize(4);
 
       assertThat(beans.get(0)).isInstanceOf(CBasei.class);
       assertThat(beans.get(1)).isInstanceOf(BBasei.class);
       assertThat(beans.get(2)).isInstanceOf(ABasei.class);
+      assertThat(beans.get(3)).isInstanceOf(DBasei.class);
     }
   }
 

--- a/inject-test/src/test/java/org/example/coffee/CoffeeMakerTest.java
+++ b/inject-test/src/test/java/org/example/coffee/CoffeeMakerTest.java
@@ -68,7 +68,7 @@ class CoffeeMakerTest {
       assertThat(entry.qualifierName()).isEqualTo("B");
       assertThat(entry.keys()).containsExactlyInAnyOrder(name(BSomei.class), name(Somei.class));
       assertThat(entry.type()).isEqualTo(BSomei.class);
-      assertThat(entry.priority()).isEqualTo(-1);
+      assertThat(entry.priority()).isEqualTo(1);
       assertThat(entry.bean()).isEqualTo(context.get(Somei.class, "B"));
       assertThat(entry.bean()).isEqualTo(context.get(BSomei.class));
     }

--- a/inject-test/src/test/java/org/example/coffee/CoffeeMakerTest.java
+++ b/inject-test/src/test/java/org/example/coffee/CoffeeMakerTest.java
@@ -68,7 +68,7 @@ class CoffeeMakerTest {
       assertThat(entry.qualifierName()).isEqualTo("B");
       assertThat(entry.keys()).containsExactlyInAnyOrder(name(BSomei.class), name(Somei.class));
       assertThat(entry.type()).isEqualTo(BSomei.class);
-      assertThat(entry.priority()).isEqualTo(0);
+      assertThat(entry.priority()).isEqualTo(-1);
       assertThat(entry.bean()).isEqualTo(context.get(Somei.class, "B"));
       assertThat(entry.bean()).isEqualTo(context.get(BSomei.class));
     }

--- a/inject-test/src/test/java/org/example/coffee/priority/base/PriorityFactory.java
+++ b/inject-test/src/test/java/org/example/coffee/priority/base/PriorityFactory.java
@@ -1,0 +1,23 @@
+package org.example.coffee.priority.base;
+
+import io.avaje.inject.Bean;
+import io.avaje.inject.Factory;
+import io.avaje.inject.Priority;
+
+@Factory
+public class PriorityFactory {
+
+  @Bean
+  @Priority(69)
+  BaseIface iface() {
+    return new DBasei();
+  }
+
+  public static class DBasei implements BaseIface {
+
+    @Override
+    public String other() {
+      return "b";
+    }
+  }
+}

--- a/inject-test/src/test/java/org/example/coffee/priority/base/PriorityTest.java
+++ b/inject-test/src/test/java/org/example/coffee/priority/base/PriorityTest.java
@@ -1,13 +1,15 @@
 package org.example.coffee.priority.base;
 
-import io.avaje.inject.xtra.ApplicationScope;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.example.coffee.priority.base.PriorityFactory.DBasei;
+import org.junit.jupiter.api.Test;
 
-public class PriorityTest {
+import io.avaje.inject.xtra.ApplicationScope;
+
+class PriorityTest {
 
   @Test
   void listByPriority() {
@@ -15,9 +17,15 @@ public class PriorityTest {
     assertExpectedOrder(sorted);
   }
 
+  @Test
+  void testGet() {
+    assertThat(ApplicationScope.get(BaseIface.class)).isInstanceOf(CBasei.class);
+  }
+
   private void assertExpectedOrder(List<BaseIface> sorted) {
     assertThat(sorted.get(0)).isInstanceOf(CBasei.class);
     assertThat(sorted.get(1)).isInstanceOf(BBasei.class);
     assertThat(sorted.get(2)).isInstanceOf(ABasei.class);
+    assertThat(sorted.get(3)).isInstanceOf(DBasei.class);
   }
 }

--- a/inject/src/main/java/io/avaje/inject/BeanEntry.java
+++ b/inject/src/main/java/io/avaje/inject/BeanEntry.java
@@ -45,7 +45,7 @@ public interface BeanEntry {
   Class<?> type();
 
   /**
-   * Return the priority indicating if the bean is Supplied Primary, Normal or Secondary.
+   * Return the wiring priority of the bean.
    */
   int priority();
 

--- a/inject/src/main/java/io/avaje/inject/BeanEntry.java
+++ b/inject/src/main/java/io/avaje/inject/BeanEntry.java
@@ -12,12 +12,12 @@ public interface BeanEntry {
   /**
    * Priority of externally supplied bean.
    */
-  int SUPPLIED = 2;
+  int SUPPLIED = Integer.MAX_VALUE;
 
   /**
    * Priority of <code>@Primary</code> bean.
    */
-  int PRIMARY = 1;
+  int PRIMARY = Integer.MAX_VALUE - 1;
 
   /**
    * Priority of normal bean.
@@ -27,7 +27,7 @@ public interface BeanEntry {
   /**
    * Priority of <code>@Secondary</code> bean.
    */
-  int SECONDARY = -1;
+  int SECONDARY = Integer.MIN_VALUE;
 
   /**
    * Return the bean name.

--- a/inject/src/main/java/io/avaje/inject/BeanEntry.java
+++ b/inject/src/main/java/io/avaje/inject/BeanEntry.java
@@ -12,12 +12,12 @@ public interface BeanEntry {
   /**
    * Priority of externally supplied bean.
    */
-  int SUPPLIED = Integer.MAX_VALUE;
+  int SUPPLIED = Integer.MIN_VALUE;
 
   /**
    * Priority of <code>@Primary</code> bean.
    */
-  int PRIMARY = Integer.MAX_VALUE - 1;
+  int PRIMARY = Integer.MIN_VALUE + 1;
 
   /**
    * Priority of normal bean.
@@ -27,7 +27,7 @@ public interface BeanEntry {
   /**
    * Priority of <code>@Secondary</code> bean.
    */
-  int SECONDARY = Integer.MIN_VALUE;
+  int SECONDARY = Integer.MAX_VALUE;
 
   /**
    * Return the bean name.

--- a/inject/src/main/java/io/avaje/inject/BeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/BeanScope.java
@@ -198,21 +198,21 @@ public interface BeanScope extends AutoCloseable {
    */
   <T> List<T> list(Type type);
 
-  /**
-   * Return the list of beans that implement the interface sorting by priority.
-   */
-  <T> List<T> listByPriority(Class<T> type);
+  /** Return the list of beans that implement the class sorting by priority. */
+  default <T> List<T> listByPriority(Class<T> type) {
+    return listByPriority((Type) type);
+  }
+
+  /** Return the list of beans that implement the type sorting by priority. */
+  <T> List<T> listByPriority(Type type);
 
   /**
-   * Return the beans that implement the interface sorting by the priority annotation used.
-   * <p>
-   * The priority annotation will typically be either <code>javax.annotation.Priority</code>
-   * or <code>jakarta.annotation.Priority</code>.
-   *
-   * @param type     The interface type of the beans to return
-   * @param priority The priority annotation used to sort the beans
+   * @deprecated use {@link #listByPriority(Class)}
    */
-  <T> List<T> listByPriority(Class<T> type, Class<? extends Annotation> priority);
+  @Deprecated(forRemoval = true)
+  default <T> List<T> listByPriority(Class<T> type, Class<? extends Annotation> priority) {
+    return listByPriority(type);
+  }
 
   /**
    * Return the beans for this type mapped by their qualifier name.

--- a/inject/src/main/java/io/avaje/inject/Priority.java
+++ b/inject/src/main/java/io/avaje/inject/Priority.java
@@ -1,26 +1,26 @@
 package io.avaje.inject;
 
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
 /**
- * The <code>Priority</code> annotation can be applied to classes to indicate
- * in what order they should be returned via @{@link BeanScope#listByPriority(Class)}.
- * <p>
- * Beans can be returned using other Priority annotation such as <code>javax.annotation.Priority</code>
- * or any custom priority annotation that has an <code>int value()</code> attribute.
- * </p>
+ * The <code>Priority</code> annotation can be applied to classes to indicate the wiring priority of
+ * a bean to resolve cases where multiple beans of the same type exist.
  *
- * @see BeanScope#listByPriority(Class)
- * @see BeanScope#listByPriority(Class, Class)
+ * <p>Beans can be returned using other Priority annotation such as <code>
+ * jakartak.annotation.Priority
+ * </code> or any custom priority annotation that has an <code>int value()</code> attribute.
+ *
+ * @see BeanScope#listByPriority(Type)
  */
 @Documented
 @Retention(RUNTIME)
-@Target(TYPE)
+@Target({TYPE, METHOD})
 public @interface Priority {
   int value();
 }

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -70,6 +70,12 @@ public interface Builder {
   Builder asSecondary();
 
   /**
+   * Register the next bean as having Secondary priority. Lowest priority, only used if no other
+   * matching beans are available.
+   */
+  Builder asPriority(int priority);
+
+  /**
    * Register the next bean as having Prototype scope.
    */
   Builder asPrototype();

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -59,18 +59,18 @@ public interface Builder {
 
   /**
    * Register the next bean as having Primary priority.
-   * Highest priority, will be used over any other matching beans.
+   * Highest priority, wired over any other matching beans.
    */
   Builder asPrimary();
 
   /**
    * Register the next bean as having Secondary priority.
-   * Lowest priority, only used if no other matching beans are available.
+   * Lowest priority, wired when no other matching beans are available.
    */
   Builder asSecondary();
 
   /**
-   * Register the next bean as having Secondary priority. Lowest priority, only used if no other
+   * Register the next bean as having the given priority. Wired only if no other higher priority
    * matching beans are available.
    */
   Builder asPriority(int priority);

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
@@ -1,17 +1,20 @@
 package io.avaje.inject.spi;
 
-import io.avaje.inject.BeanEntry;
-import io.avaje.inject.BeanScope;
-import jakarta.inject.Provider;
+import static java.util.stream.Collectors.toList;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
+import io.avaje.inject.BeanEntry;
+import io.avaje.inject.BeanScope;
+import jakarta.inject.Provider;
 
 /**
  * Map of types (class types, interfaces and annotations) to a DContextEntry where the
@@ -119,6 +122,19 @@ final class DBeanMap {
       return null;
     }
     return (T) entry.get(name, currentModule);
+  }
+
+  public <T> List<T> listByPriority(Type type) {
+
+    DContextEntry entry = beans.get(type.getTypeName());
+    if (entry == null) {
+      return List.of();
+    }
+
+    return entry.entries().stream()
+        .sorted(Comparator.comparingInt(DContextEntryBean::priority).reversed())
+        .map(e -> (T) e.bean())
+        .collect(toList());
   }
 
   @SuppressWarnings("unchecked")

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
@@ -132,7 +132,7 @@ final class DBeanMap {
     }
 
     return entry.entries().stream()
-        .sorted(Comparator.comparingInt(DContextEntryBean::priority).reversed())
+        .sorted(Comparator.comparingInt(DContextEntryBean::priority))
         .map(e -> (T) e.bean())
         .collect(toList());
   }

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScopeProxy.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScopeProxy.java
@@ -106,18 +106,9 @@ final class DBeanScopeProxy implements BeanScope {
   }
 
   @Override
-  public <T> List<T> listByPriority(Class<T> type) {
+  public <T> List<T> listByPriority(Type type) {
     if (delegate != null) {
       return delegate.listByPriority(type);
-    } else {
-      throw illegal("listByPriority");
-    }
-  }
-
-  @Override
-  public <T> List<T> listByPriority(Class<T> type, Class<? extends Annotation> priority) {
-    if (delegate != null) {
-      return delegate.listByPriority(type, priority);
     } else {
       throw illegal("listByPriority");
     }

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -172,7 +172,7 @@ class DBuilder implements Builder {
 
   @Override
   public Builder asPriority(int priority) {
-    beanMap.nextPriority(priority * -1);
+    beanMap.nextPriority(priority);
     return this;
   }
 

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -171,6 +171,12 @@ class DBuilder implements Builder {
   }
 
   @Override
+  public Builder asPriority(int priority) {
+    beanMap.nextPriority(priority * -1);
+    return this;
+  }
+
+  @Override
   public Builder asPrototype() {
     beanMap.nextPrototype();
     return this;

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
@@ -150,10 +150,10 @@ final class DContextEntry {
         match = entry;
         return;
       }
-      if (match.priority() > entry.priority()) {
+      if (match.priority() < entry.priority()) {
         // existing supplied match always wins
         return;
-      } else if (match.priority() < entry.priority()) {
+      } else if (match.priority() > entry.priority()) {
         // new supplied wins
         match = entry;
         return;

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
@@ -1,11 +1,12 @@
 package io.avaje.inject.spi;
 
-import jakarta.inject.Provider;
-
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import io.avaje.inject.BeanEntry;
+import jakarta.inject.Provider;
 
 /**
  * Entry for a given key (bean class, interface class or annotation class).
@@ -149,37 +150,29 @@ final class DContextEntry {
         match = entry;
         return;
       }
-      if (match.isSupplied()) {
+      if (match.priority() > entry.priority()) {
         // existing supplied match always wins
         return;
-      } else if (entry.isSupplied()) {
+      } else if (match.priority() < entry.priority()) {
         // new supplied wins
-        match = entry;
-        return;
-      }
-      if (match.isSecondary() && !entry.isSecondary()) {
-        // secondary loses
         match = entry;
         return;
       }
       if (match.isPrimary()) {
         if (entry.isPrimary()) {
-          throw new IllegalStateException("Expecting only 1 bean match but have multiple primary beans " + match.bean() + " and " + entry.bean());
+          throw new IllegalStateException(
+              "Expecting only 1 bean match but have multiple primary beans "
+                  + match.bean()
+                  + " and "
+                  + entry.bean());
         }
         // leave as is, current primary wins
         return;
-      }
-      if (entry.isSecondary()) {
-        if (match.isSecondary()) {
-          ignoredSecondaryMatch = entry;
-        }
+      } else if (impliedName) {
+        ignoredSecondaryMatch = entry;
         return;
       }
-      if (entry.isPrimary()) {
-        // new primary wins
-        match = entry;
-        return;
-      }
+
       // try to resolve match using qualifier name (including null)
       if (match.isNameEqual(name) && !entry.isNameEqual(name)) {
         ignoredSecondaryMatch = entry;
@@ -197,8 +190,12 @@ final class DContextEntry {
         match = entry;
         return;
       }
-      throw new IllegalStateException("Expecting only 1 bean match but have multiple matching beans " + match.bean()
-        + " and " + entry.bean() + ". Maybe need a rebuild is required after adding a @Named qualifier?");
+      throw new IllegalStateException(
+          "Expecting only 1 bean match but have multiple matching beans "
+              + match.bean()
+              + " and "
+              + entry.bean()
+              + ". Maybe need a rebuild is required after adding a @Named qualifier or @Priority annotation?");
     }
 
     private DContextEntryBean candidate() {
@@ -210,10 +207,17 @@ final class DContextEntry {
     }
 
     private void checkSecondary() {
-      if (match.isSecondary() && ignoredSecondaryMatch != null) {
-        throw new IllegalStateException("Expecting only 1 bean match but have multiple secondary beans " + match.bean() + " and " + ignoredSecondaryMatch.bean());
+      if (match.priority() != BeanEntry.SUPPLIED
+          && match.priority() != BeanEntry.NORMAL
+          && ignoredSecondaryMatch != null
+          && ignoredSecondaryMatch.priority() == match.priority()) {
+        throw new IllegalStateException(
+            "Expecting only 1 bean match but have multiple beans with the same priority"
+                + match.bean()
+                + " and "
+                + ignoredSecondaryMatch.bean()
+                + ". Maybe need a rebuild is required after adding a @Named qualifier or @Priority annotation?");
       }
     }
-
   }
 }

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntryBean.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntryBean.java
@@ -11,22 +11,22 @@ class DContextEntryBean {
   /**
    * Create taking into account if it is a Provider or the bean itself.
    */
-  static DContextEntryBean of(Object source, String name, int flag, Class<? extends AvajeModule> currentModule) {
+  static DContextEntryBean of(Object source, String name, int priority, Class<? extends AvajeModule> currentModule) {
     if (source instanceof Provider) {
-      return new ProtoProvider((Provider<?>)source, name, flag, currentModule);
+      return new ProtoProvider((Provider<?>)source, name, priority, currentModule);
     } else {
-      return new DContextEntryBean(source, name, flag, currentModule);
+      return new DContextEntryBean(source, name, priority, currentModule);
     }
   }
 
   /**
    * Create an entry with supplied Providers using a 'Once' / 'one instance' provider.
    */
-  static DContextEntryBean supplied(Object source, String name, int flag) {
+  static DContextEntryBean supplied(Object source, String name, int priority) {
     if (source instanceof Provider) {
-      return new OnceBeanProvider((Provider<?>)source, name, flag, null);
+      return new OnceBeanProvider((Provider<?>)source, name, priority, null);
     } else {
-      return new DContextEntryBean(source, name, flag, null);
+      return new DContextEntryBean(source, name, priority, null);
     }
   }
 
@@ -37,12 +37,12 @@ class DContextEntryBean {
   protected final Object source;
   protected final String name;
   protected final Class<? extends AvajeModule> sourceModule;
-  private final int flag;
+  private final int priority;
 
-  private DContextEntryBean(Object source, String name, int flag, Class<? extends AvajeModule> currentModule) {
+  private DContextEntryBean(Object source, String name, int priority, Class<? extends AvajeModule> currentModule) {
     this.source = source;
     this.name = name;
-    this.flag = flag;
+    this.priority = priority;
     this.sourceModule = currentModule;
   }
 
@@ -51,13 +51,13 @@ class DContextEntryBean {
     return "Bean{" +
       "source=" + source +
       ", name='" + name + '\'' +
-      ", flag=" + flag +
+      ", priority=" + priority +
       ", sourceModule=" + sourceModule +
       '}';
   }
 
   final DEntry entry() {
-    return new DEntry(name, flag, bean());
+    return new DEntry(name, priority, bean());
   }
 
   /**
@@ -98,19 +98,15 @@ class DContextEntryBean {
   }
 
   final boolean isPrimary() {
-    return flag == BeanEntry.PRIMARY;
+    return priority == BeanEntry.PRIMARY;
   }
 
-  final boolean isSecondary() {
-    return flag == BeanEntry.SECONDARY;
-  }
-
-  final boolean isSupplied() {
-    return flag == BeanEntry.SUPPLIED;
+  final int priority() {
+    return priority;
   }
 
   final boolean isSupplied(String qualifierName) {
-    return flag == BeanEntry.SUPPLIED && (qualifierName == null || qualifierName.equals(name));
+    return priority == BeanEntry.SUPPLIED && (qualifierName == null || qualifierName.equals(name));
   }
 
   /**

--- a/inject/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
+++ b/inject/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
@@ -305,12 +305,7 @@ class BeanScopeBuilderTest {
     }
 
     @Override
-    public <T> List<T> listByPriority(Class<T> type) {
-      return null;
-    }
-
-    @Override
-    public <T> List<T> listByPriority(Class<T> type, Class<? extends Annotation> priority) {
+    public <T> List<T> listByPriority(Type type) {
       return null;
     }
 


### PR DESCRIPTION
- read the `@Priority` annotations at compile time
- listByPriority will now sort `@Primary`/`@Secondary` beans
- simplify duplicate type matching logic
- Add support for using `@Priority` on factory `@Bean` methods

Resolves #854 