### PR TITLE
Fix raw generic messing up tests

### DIFF
--- a/inject-test/src/test/java/org/example/generic/GenericBean.java
+++ b/inject-test/src/test/java/org/example/generic/GenericBean.java
@@ -1,0 +1,14 @@
+package org.example.generic;
+
+import java.util.function.Supplier;
+
+import io.avaje.inject.test.TestScope;
+
+@TestScope
+public class GenericBean implements Supplier<Short> {
+
+  @Override
+  public Short get() {
+    return null;
+  }
+}

--- a/inject-test/src/test/java/org/example/generic/GenericBean2.java
+++ b/inject-test/src/test/java/org/example/generic/GenericBean2.java
@@ -1,0 +1,14 @@
+package org.example.generic;
+
+import java.util.function.Supplier;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class GenericBean2 implements Supplier<Long> {
+
+  @Override
+  public Long get() {
+    return null;
+  }
+}

--- a/inject-test/src/test/java/org/example/generic/TestScopeGenericTest.java
+++ b/inject-test/src/test/java/org/example/generic/TestScopeGenericTest.java
@@ -1,0 +1,21 @@
+package org.example.generic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.inject.test.InjectTest;
+import jakarta.inject.Inject;
+
+@InjectTest
+public class TestScopeGenericTest {
+
+  @Inject public GenericBean bean1;
+  @Inject public GenericBean2 bean2;
+
+  @Test
+  void getTypeName() {
+    assertThat(bean1).isNotNull();
+    assertThat(bean2).isNotNull();
+  }
+}

--- a/inject-test/src/test/resources/META-INF/services/io.avaje.inject.spi.InjectExtension
+++ b/inject-test/src/test/resources/META-INF/services/io.avaje.inject.spi.InjectExtension
@@ -1,1 +1,5 @@
 io.avaje.inject.events.spi.ObserverManagerPlugin
+io.avaje.http.inject.DefaultResolverProvider
+io.avaje.inject.events.spi.ObserverManagerPlugin
+io.avaje.jsonb.inject.DefaultJsonbProvider
+org.example.ExampleModule

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -65,7 +65,7 @@ class DBuilder implements Builder {
   }
 
   /**
-   * Return the types without any annotation types.
+   * Return the types without any annotation types or raw generics.
    *
    * <p>For the purposes of supplied beans (typically test doubles) we are not interested in
    * annotation types.
@@ -81,7 +81,11 @@ class DBuilder implements Builder {
   }
 
   private boolean isAnnotationType(Type type) {
-    return type instanceof Class && ((Class<?>) type).isAnnotation();
+    if (type instanceof Class<?>) {
+      var clazz = (Class<?>) type;
+      return clazz.isAnnotation() || clazz.getTypeParameters().length != 0;
+    }
+    return false;
   }
 
   protected final void next(String name, Type... types) {


### PR DESCRIPTION
Fixes issue introduced by #836 where the raw generic type would match in test scopes and cause beans not to be wired.