### PR TITLE
DBuilder contains checking parent if present

### DIFF
--- a/blackbox-multi-scope/src/main/java/org/multi/parents/BeanIn4.java
+++ b/blackbox-multi-scope/src/main/java/org/multi/parents/BeanIn4.java
@@ -1,10 +1,13 @@
 package org.multi.parents;
 
+import io.avaje.inject.RequiresBean;
 import jakarta.inject.Singleton;
 import org.multi.scope.Mod4Scope;
 
 @Singleton
 @Mod4Scope
+// Generate `contains` method calls in `BeanIn4$DI` to test DBuilder checks parent scope
+@RequiresBean({BeanIn1.class, BeanIn3.class})
 public final class BeanIn4 {
   private final BeanIn1 beanIn1;
   private final BeanIn3 beanIn3;

--- a/blackbox-multi-scope/src/test/java/org/multi/parents/ParentageTest.java
+++ b/blackbox-multi-scope/src/test/java/org/multi/parents/ParentageTest.java
@@ -4,6 +4,7 @@ import io.avaje.inject.BeanScope;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ParentageTest {
   @Test
@@ -14,6 +15,10 @@ class ParentageTest {
       BeanScope parent = BeanScope.builder().parent(grandparent).modules(new Mod3Module()).build();
       BeanScope scope = BeanScope.builder().parent(parent).modules(new Mod4Module()).build();
     ) {
+      assertTrue(scope.contains(BeanIn4.class));
+      assertTrue(scope.contains(BeanIn3.class));
+      assertTrue(scope.contains(BeanIn2.class));
+      assertTrue(scope.contains(BeanIn1.class));
       BeanIn4 beanIn4 = scope.get(BeanIn4.class);
       BeanIn3 beanIn3 = scope.get(BeanIn3.class);
       BeanIn2 beanIn2 = scope.get(BeanIn2.class);

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -378,7 +378,7 @@ class DBuilder implements Builder {
 
   @Override
   public final boolean contains(String type) {
-    return beanMap.contains(type) || (parent != null && parent.contains(type));
+    return beanMap.contains(type)  || (parent != null && parent.contains(type));
   }
 
   @Override

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -26,7 +26,7 @@ class DBuilder implements Builder {
   /** The beans created and added to the scope during building. */
   protected final DBeanMap beanMap = new DBeanMap();
 
-  protected final BeanScope parent;
+  protected final @Nullable BeanScope parent;
   protected final boolean parentOverride;
   /** Bean provided by the parent scope that we are not overriding. */
   protected Object parentMatch;
@@ -378,12 +378,12 @@ class DBuilder implements Builder {
 
   @Override
   public final boolean contains(String type) {
-    return beanMap.contains(type);
+    return beanMap.contains(type) || (parent != null && parent.contains(type));
   }
 
   @Override
   public final boolean contains(Type type) {
-    return beanMap.contains(type);
+    return beanMap.contains(type) || (parent != null && parent.contains(type));
   }
 
   @Override


### PR DESCRIPTION
Apparently when I did #873 I missed that `DBuilder` didn't check the parent scope when calling `contains`... sorry!