### PR TITLE
Adds Compiler Warning to useless `@Inject`

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanProxyWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanProxyWriter.java
@@ -55,7 +55,6 @@ final class SimpleBeanProxyWriter {
   }
 
   private void writeConstructor() {
-    writer.append("  @Inject\n");
     writer.append("  public %s%s(", shortName, suffix);
     int count = 0;
     for (final String aspectName : aspects.aspectNames()) {
@@ -96,7 +95,6 @@ final class SimpleBeanProxyWriter {
     writer.append("import %s;", Constants.INVOCATION_EXCEPTION).eol();
     writer.append("import %s;", Constants.METHOD_INTERCEPTOR).eol();
     writer.append("import %s;", Constants.COMPONENT).eol();
-    writer.append("import %s;", Constants.INJECT).eol();
     writer.append("import %s;", Constants.PROXY).eol();
     beanReader.writeImports(writer, packageName);
   }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsInjection.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeExtendsInjection.java
@@ -1,6 +1,7 @@
 package io.avaje.inject.generator;
 
 import static io.avaje.inject.generator.APContext.logError;
+import static io.avaje.inject.generator.APContext.logWarn;
 import static io.avaje.inject.generator.ProcessingContext.getImportedAspect;
 
 import javax.lang.model.element.AnnotationMirror;
@@ -58,6 +59,11 @@ final class TypeExtendsInjection {
         default:
           break;
       }
+    }
+    if (injectConstructor != null
+        && otherConstructors.isEmpty()
+        && InjectPrism.isPresent(injectConstructor.element())) {
+      logWarn(injectConstructor.element(), "Remove Unused @Inject Annotation");
     }
   }
 


### PR DESCRIPTION
Now will warn when the `@inject` annotation is not needed