### PR TITLE
Fix Lazy Imports on Thrown Exceptions

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanLazyWriter.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/SimpleBeanLazyWriter.java
@@ -129,6 +129,9 @@ final class SimpleBeanLazyWriter {
       }
       var returnType = UType.parse(methodElement.getReturnType());
       importTypes.addAll(returnType.importTypes());
+      methodElement.getThrownTypes().stream()
+          .map(UType::parse)
+          .forEach(t -> importTypes.addAll(t.importTypes()));
       sb.append(returnType.shortType()).append(" ");
 
       // Method name

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -430,12 +430,11 @@ final class Util {
     var rte = APContext.typeElement("java.lang.RuntimeException").asType();
 
     return ElementFilter.constructorsIn(beanType.getEnclosedElements()).stream()
-        .anyMatch(
-            e ->
-                e.getParameters().isEmpty()
-                    && !e.getModifiers().contains(Modifier.PRIVATE)
-                    && e.getThrownTypes().stream()
-                        .allMatch(t -> APContext.types().isSubtype(t, rte)));
+      .anyMatch(e ->
+        e.getParameters().isEmpty()
+          && !e.getModifiers().contains(Modifier.PRIVATE)
+          && e.getThrownTypes().stream()
+          .allMatch(t -> APContext.types().isSubtype(t, rte)));
   }
 
   public static String shortNameLazyProxy(TypeElement lazyProxyType) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/Util.java
@@ -427,8 +427,15 @@ final class Util {
   }
 
   static boolean hasNoArgConstructor(TypeElement beanType) {
+    var rte = APContext.typeElement("java.lang.RuntimeException").asType();
+
     return ElementFilter.constructorsIn(beanType.getEnclosedElements()).stream()
-      .anyMatch(e -> e.getParameters().isEmpty() && !e.getModifiers().contains(Modifier.PRIVATE));
+        .anyMatch(
+            e ->
+                e.getParameters().isEmpty()
+                    && !e.getModifiers().contains(Modifier.PRIVATE)
+                    && e.getThrownTypes().stream()
+                        .allMatch(t -> APContext.types().isSubtype(t, rte)));
   }
 
   public static String shortNameLazyProxy(TypeElement lazyProxyType) {

--- a/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lazy/LazyBean.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/models/valid/lazy/LazyBean.java
@@ -1,5 +1,7 @@
 package io.avaje.inject.generator.models.valid.lazy;
 
+import java.io.IOException;
+
 import io.avaje.inject.Lazy;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
@@ -18,5 +20,5 @@ public class LazyBean {
 
   public LazyBean() {}
 
-  void something() {}
+  void something() throws IOException {}
 }


### PR DESCRIPTION
- skip compile proxy on type with single no arg constructor with a checked exception
- import thrown method exceptions on generated lazy class

resolves #900 