### PR TITLE
error when `io.avaje.inject.spi.AvajeModule` class not found

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/ExternalProvider.java
@@ -232,7 +232,7 @@ final class ExternalProvider {
 
     if (typeElement == null) {
       throw new IllegalStateException(String.format(
-        "Unable to find the type [%s]; ensure that `avaje-inject` dependency is included in your project",
+        "Unable to find the type [%s]; ensure that the `avaje-inject` dependency is included in your project",
         CLASS_NAME_AVAJE_MODULE));
     }
 


### PR DESCRIPTION
If the project does not have the `avaje-inject` dependency configured on the project but the code-generator is configured then it will yield an NPE. This fix will at least raise an exception with an explanation.