### PR TITLE
Support Builder using name qualifier with List and Set

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/ListFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/ListFactory.java
@@ -12,6 +12,12 @@ import jakarta.inject.Named;
 public class ListFactory {
 
   @Bean
+  @Named("args")
+  List<String> someNamedStrings() {
+    return List.of("arg0", "arg1");
+  }
+
+  @Bean
   List<String> test(List<Cloneable> emptyList) {
     return List.of("test1", "test2");
   }

--- a/blackbox-test-inject/src/main/java/org/example/myapp/ListService.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/ListService.java
@@ -1,18 +1,37 @@
 package org.example.myapp;
 
 import java.util.List;
+import java.util.Set;
 
+import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
 @Singleton
 public class ListService {
 
   private final List<String> strings;
+  private final List<String> argStrings;
+  private final Set<String> argsAsSet;
   private final List<ListFactory.Some> somes;
 
-  public ListService(List<String> strings, List<ListFactory.Some> somes) {
-    this.strings = strings;
+  public ListService(
+      List<String> allStrings,
+      @Named("args") List<String> argStrings,
+      @Named("args") Set<String> argsAsSet,
+      List<ListFactory.Some> somes) {
+
+    this.strings = allStrings;
+    this.argStrings = argStrings;
+    this.argsAsSet = argsAsSet;
     this.somes = somes;
+  }
+
+  public List<String> args() {
+    return argStrings;
+  }
+
+  public Set<String> argsAsSet() {
+    return argsAsSet;
   }
 
   public List<String> strings() {

--- a/blackbox-test-inject/src/test/java/org/example/myapp/ListFactoryTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/ListFactoryTest.java
@@ -18,7 +18,9 @@ class ListFactoryTest {
   @Test
   void test() {
 
-    assertThat(list.strings()).contains("test1", "test1", "test3");
+    assertThat(list.strings()).contains("test1", "test1", "test3", "arg0", "arg1");
+    assertThat(list.args()).containsOnly("arg0", "arg1");
+    assertThat(list.argsAsSet()).containsOnly("arg0", "arg1");
 
     List<ListFactory.Some> somes = list.somes();
     assertThat(somes).hasSize(4);

--- a/inject/src/main/java/io/avaje/inject/BeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/BeanScope.java
@@ -199,7 +199,14 @@ public interface BeanScope extends AutoCloseable {
    */
   <T> List<T> list(Type type);
 
-  /** Return the list of beans that implement the class sorting by priority. */
+  /**
+   * Return the list of beans for the given type and name.
+   */
+  <T> List<T> list(Type type, @Nullable String name);
+
+  /**
+   * Return the list of beans that implement the class sorting by priority.
+   */
   default <T> List<T> listByPriority(Class<T> type) {
     return listByPriority((Type) type);
   }

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -238,6 +238,11 @@ public interface Builder {
   <T> List<T> list(Type type);
 
   /**
+   * Get a list of dependencies for the type and name.
+   */
+  <T> List<T> list(Type type, String name);
+
+  /**
    * Get a set of dependencies for the type.
    */
   <T> Set<T> set(Class<T> type);
@@ -246,6 +251,11 @@ public interface Builder {
    * Get a set of dependencies for the generic type.
    */
   <T> Set<T> set(Type type);
+
+  /**
+   * Get a set of dependencies for the type and name.
+   */
+  <T> Set<T> set(Type type, String name);
 
   /**
    * Return a map of dependencies for the type keyed by qualifier name.

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanMap.java
@@ -157,11 +157,11 @@ final class DBeanMap {
   }
 
   /**
-   * Return all bean instances matching the given type.
+   * Return all bean instances matching the given type and name.
    */
-  List<Object> all(Type type) {
+  List<Object> all(Type type, @Nullable String name) {
     DContextEntry entry = beans.get(type.getTypeName());
-    return entry != null ? entry.all() : List.of();
+    return entry != null ? entry.all(name) : List.of();
   }
 
   /**

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScope.java
@@ -158,21 +158,26 @@ final class DBeanScope implements BeanScope {
 
   @Override
   public <T> List<T> list(Class<T> type) {
-    return listOf(type);
+    return listOf(type, null);
   }
 
   @Override
   public <T> List<T> list(Type type) {
-    return listOf(type);
+    return listOf(type, null);
+  }
+
+  @Override
+  public <T> List<T> list(Type type, @Nullable String name) {
+    return listOf(type, name);
   }
 
   @SuppressWarnings("unchecked")
-  private <T> List<T> listOf(Type type) {
-    List<T> values = (List<T>) beans.all(type);
+  private <T> List<T> listOf(Type type, @Nullable String name) {
+    List<T> values = (List<T>) beans.all(type, name);
     if (parent == null) {
       return values;
     }
-    return combine(values, parent.list(type));
+    return combine(values, parent.list(type, name));
   }
 
   static <T> List<T> combine(List<T> values, List<T> parentValues) {

--- a/inject/src/main/java/io/avaje/inject/spi/DBeanScopeProxy.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBeanScopeProxy.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 import io.avaje.inject.BeanEntry;
 import io.avaje.inject.BeanScope;
+import org.jspecify.annotations.Nullable;
 
 /** Proxy used when injecting the BeanScope. */
 final class DBeanScopeProxy implements BeanScope {
@@ -88,7 +89,6 @@ final class DBeanScopeProxy implements BeanScope {
 
   @Override
   public <T> List<T> list(Class<T> type) {
-
     if (delegate != null) {
       return delegate.list(type);
     } else {
@@ -102,6 +102,15 @@ final class DBeanScopeProxy implements BeanScope {
       return delegate.list(type);
     } else {
       return builder.list(type);
+    }
+  }
+
+  @Override
+  public <T> List<T> list(Type type, @Nullable String name) {
+    if (delegate != null) {
+      return delegate.list(type, name);
+    } else {
+      return builder.list(type, name);
     }
   }
 

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -120,31 +120,41 @@ class DBuilder implements Builder {
 
   @Override
   public final <T> Set<T> set(Class<T> type) {
-    return new LinkedHashSet<>(listOf(type));
+    return new LinkedHashSet<>(listOf(type, null));
   }
 
   @Override
   public final <T> List<T> list(Class<T> type) {
-    return listOf(type);
+    return listOf(type, null);
   }
 
   @Override
   public final <T> Set<T> set(Type type) {
-    return new LinkedHashSet<>(listOf(type));
+    return set(type, null);
+  }
+
+  @Override
+  public final <T> Set<T> set(Type type, String name) {
+    return new LinkedHashSet<>(listOf(type, name));
   }
 
   @Override
   public final <T> List<T> list(Type type) {
-    return listOf(type);
+    return listOf(type, null);
+  }
+
+  @Override
+  public <T> List<T> list(Type type, String name) {
+    return listOf(type, name);
   }
 
   @SuppressWarnings({"unchecked"})
-  private <T> List<T> listOf(Type type) {
-    final List<T> values = (List<T>) beanMap.all(type);
+  private <T> List<T> listOf(Type type, @Nullable String name) {
+    final List<T> values = (List<T>) beanMap.all(type, name);
     if (parent == null) {
       return values;
     }
-    return combine(values, parent.list(type));
+    return combine(values, parent.list(type, name));
   }
 
   @Override

--- a/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DContextEntry.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import io.avaje.inject.BeanEntry;
 import jakarta.inject.Provider;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Entry for a given key (bean class, interface class or annotation class).
@@ -55,12 +56,14 @@ final class DContextEntry {
   }
 
   /**
-   * Return all the beans.
+   * Return all the beans matching the name qualifier (if passed).
    */
-  List<Object> all() {
+  List<Object> all(@Nullable String name) {
     List<Object> list = new ArrayList<>(entries.size());
     for (DContextEntryBean entry : entries) {
-      list.add(entry.bean());
+      if (entry.isNameMatch(name)) {
+        list.add(entry.bean());
+      }
     }
     return list;
   }

--- a/inject/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
+++ b/inject/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import io.avaje.inject.spi.AvajeModule;
@@ -308,6 +309,11 @@ class BeanScopeBuilderTest {
 
     @Override
     public <T> List<T> list(Type type) {
+      return null;
+    }
+
+    @Override
+    public <T> List<T> list(Type type, @Nullable String name) {
       return null;
     }
 


### PR DESCRIPTION
This supports injecting a List or Set of beans that have a common name qualifier.

This seems like a rare use case, for example:
```
// A List of String that all have the same qualifier name of "args"
@Named("args") List<String>
```