### PR TITLE
Add BeanTypes registerTypes, for separate set of types that are excluded from isBeanAbsent()

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/beantypes/LimitedFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/beantypes/LimitedFactory.java
@@ -7,6 +7,7 @@ import jakarta.inject.Named;
 import org.jspecify.annotations.Nullable;
 
 import java.io.Serializable;
+import java.util.GregorianCalendar;
 import java.util.Optional;
 
 @Factory
@@ -14,7 +15,7 @@ public class LimitedFactory {
 
   @Bean
   @Named("factory")
-  @BeanTypes(LimitedInterface.class)
+  @BeanTypes(value = LimitedInterface.class, registerTypes = GregorianCalendar.class)
   BeanTypeComponent bean() {
     return new BeanTypeComponent();
   }

--- a/blackbox-test-inject/src/main/java/org/example/myapp/lazy/generic/LazyGenericImpl.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/lazy/generic/LazyGenericImpl.java
@@ -1,5 +1,6 @@
 package org.example.myapp.lazy.generic;
 
+import java.util.Calendar;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.avaje.inject.BeanScope;
@@ -13,7 +14,7 @@ import jakarta.inject.Singleton;
 @Lazy
 @Singleton
 @Named("single")
-@BeanTypes(LazyGenericInterface.class)
+@BeanTypes(value = LazyGenericInterface.class, registerTypes = Calendar.class)
 public class LazyGenericImpl implements LazyGenericInterface<String> {
 
   AtomicBoolean initialized;

--- a/blackbox-test-inject/src/test/java/org/example/myapp/beantypes/BeanTypeComponentTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/beantypes/BeanTypeComponentTest.java
@@ -3,9 +3,13 @@ package org.example.myapp.beantypes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import org.example.myapp.lazy.generic.LazyGenericImpl;
 import org.junit.jupiter.api.Test;
 
 import io.avaje.inject.BeanScope;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 
 class BeanTypesTest {
 
@@ -17,6 +21,14 @@ class BeanTypesTest {
       assertThat(scope.get(AbstractSuperClass.class)).isNotNull();
       assertThat(scope.get(LimitedInterface.class)).isNotNull();
       assertThat(scope.get(CharSequence.class)).isEqualTo("IAmNullable");
+
+      Object extraTypeGregorianCalendar = scope.get(Calendar.class);
+      assertThat(extraTypeGregorianCalendar).isNotNull();
+      assertThat(extraTypeGregorianCalendar).isInstanceOf(LazyGenericImpl.class);
+
+      Object extraTypeCalendar = scope.get(GregorianCalendar.class);
+      assertThat(extraTypeCalendar).isNotNull();
+      assertThat(extraTypeCalendar).isInstanceOf(BeanTypeComponent.class);
     }
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/AssistBeanReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/AssistBeanReader.java
@@ -39,7 +39,7 @@ final class AssistBeanReader {
     this.beanType = beanType;
     this.type = beanType.getQualifiedName().toString();
     this.typeReader =
-      new TypeReader(List.of(), UType.parse(beanType.asType()), beanType, importTypes, false);
+      new TypeReader(List.of(), List.of(), UType.parse(beanType.asType()), beanType, importTypes, false);
 
     typeReader.process();
     qualifierName = typeReader.name();

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeAppender.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeAppender.java
@@ -46,8 +46,9 @@ final class TypeAppender {
         Stream.of(u), componentTypes.stream().flatMap(TypeAppender::allComponentTypes));
   }
 
-  void add(List<UType> sourceTypes) {
+  TypeAppender add(List<UType> sourceTypes) {
     sourceTypes.forEach(this::add);
+    return this;
   }
 
   void addSimpleType(String classType) {

--- a/inject-generator/src/main/java/io/avaje/inject/generator/TypeReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/TypeReader.java
@@ -21,28 +21,33 @@ final class TypeReader {
   private final TypeAnnotationReader annotationReader;
   private Set<UType> genericTypes;
   private String typesRegister;
+  private String extraTypesRegister;
   private final List<UType> injectsTypes;
+  private final List<UType> extraTypes;
 
   TypeReader(
       List<TypeMirror> injectsTypes,
+      List<TypeMirror> extraTypes,
       UType genericType,
       TypeElement beanType,
       ImportTypeMap importTypes,
       boolean factory) {
-    this(injectsTypes, genericType, true, beanType, importTypes, factory, beanType);
+    this(injectsTypes, extraTypes, genericType, true, beanType, importTypes, factory, beanType);
   }
 
   TypeReader(
       List<TypeMirror> injectsTypes,
+      List<TypeMirror> extraTypes,
       UType genericType,
       TypeElement returnElement,
       ImportTypeMap importTypes,
       ExecutableElement source) {
-    this(injectsTypes, genericType, false, returnElement, importTypes, false, source);
+    this(injectsTypes, extraTypes, genericType, false, returnElement, importTypes, false, source);
   }
 
   private TypeReader(
       List<TypeMirror> injectsTypes,
+      List<TypeMirror> extraTypes,
       UType genericType,
       boolean forBean,
       TypeElement beanType,
@@ -50,6 +55,7 @@ final class TypeReader {
       boolean factory,
       Element source) {
     this.injectsTypes = injectsTypes.stream().map(UType::parse).collect(toList());
+    this.extraTypes = extraTypes.stream().map(UType::parse).collect(toList());
     this.forBean = forBean;
     this.beanType = beanType;
     this.importTypes = importTypes;
@@ -61,6 +67,10 @@ final class TypeReader {
 
   String typesRegister() {
     return typesRegister;
+  }
+
+  String extraTypesRegister() {
+    return extraTypesRegister;
   }
 
   List<String> provides() {
@@ -156,6 +166,12 @@ final class TypeReader {
       appender.add(extendsReader.provides());
     } else {
       appender.add(injectsTypes);
+      if (!extraTypes.isEmpty()) {
+        this.extraTypesRegister =
+          new TypeAppender(importTypes)
+            .add(extraTypes)
+            .asString();
+      }
     }
     this.genericTypes = appender.genericTypes();
     this.typesRegister = appender.asString();

--- a/inject/src/main/java/io/avaje/inject/BeanTypes.java
+++ b/inject/src/main/java/io/avaje/inject/BeanTypes.java
@@ -7,5 +7,14 @@ import java.lang.annotation.*;
 @Target({ElementType.METHOD, ElementType.TYPE})
 public @interface BeanTypes {
 
+  /** The types the component will register to. */
   Class<?>[] value();
+
+  /**
+   * Extra types to register the component to that are not included in the
+   * <code>isBeanAbsent()</code> check. For testing purposes, when providing
+   * test doubles, these types are not checked.
+   */
+  Class<?>[] registerTypes() default {};
+
 }

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -58,6 +58,11 @@ public interface Builder {
   }
 
   /**
+   * Register extra types that the next registered bean implements and provides.
+   */
+  void registerTypes(Type... types);
+
+  /**
    * Register the next bean as having Primary priority.
    * Highest priority, wired over any other matching beans.
    */

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -85,6 +85,11 @@ class DBuilder implements Builder {
     return true;
   }
 
+  @Override
+  public void registerTypes(Type... types) {
+    beanMap.nextBeanRegisterTypes(types);
+  }
+
   /**
    * Return the types without any annotation types or raw generics.
    *


### PR DESCRIPTION
These register types are not included in the isBeanAbsent() check

-----------

Currently the thinking is to NOT merge this PR, in that it isn't strictly required and possibly will not be.