### PR TITLE
Support Non-Void `PostConstruct`

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/lifecycle/PostConstructReturnsThis.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/lifecycle/PostConstructReturnsThis.java
@@ -1,4 +1,4 @@
-package io.avaje.inject.generator.models.valid.lifecycle;
+package org.example.myapp.lifecycle;
 
 import io.avaje.inject.PostConstruct;
 import jakarta.inject.Singleton;

--- a/blackbox-test-inject/src/test/java/org/example/myapp/lifecycle/PostConstructReturnsThisTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/lifecycle/PostConstructReturnsThisTest.java
@@ -1,0 +1,20 @@
+package org.example.myapp.lifecycle;
+
+import io.avaje.inject.BeanScope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostConstructReturnsThisTest {
+
+  @Test
+  void beanWithPostConstructReturningSelf() {
+    try (BeanScope beanScope = BeanScope.builder().build()) {
+      var bean = beanScope.get(PostConstructReturnsThis.class);
+      assertThat(bean).isNotNull();
+
+      var self = bean.init();
+      assertThat(bean).isSameAs(self);
+    }
+  }
+}

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MethodReader.java
@@ -149,13 +149,14 @@ final class MethodReader {
       this.typeReader = new TypeReader(beanTypes.orElse(List.of()), genericType, returnElement, importTypes, element);
       typeReader.process();
       if (bean != null) {
+        // factory @Bean method, read lifecycle methods from the return type
         var lifecycleReader = new MethodLifecycleReader(returnElement, initMethod, destroyMethod, importTypes);
         this.initMethod = lifecycleReader.initMethod();
         this.initMethodReader = lifecycleReader.initMethodReader();
         this.destroyMethod = lifecycleReader.destroyMethod();
       } else {
-        this.initMethod = initMethod;
-        this.destroyMethod = destroyMethod;
+        this.initMethod = null;
+        this.destroyMethod = null;
       }
     }
     if (lazy && prototype) {


### PR DESCRIPTION
Now the processor will not roll over and die if a post construct returns something.

 Previously, `@PostConstruct `methods were required to return void or else fail catastrophically because of a recursive infinite loop of MethodLifecycleReader -> MethodReader -> MethodLifecycleReader and so on.
                                                                                                                                                              
The fix gates the MethodLifecycleReader call on bean != null (i.e., only when it's a @Bean factory method).


## Other Options considered

Raising an error on non-void

## Why this option was chosen

- throwing errors for something easily accommodated is lame
- Spring behaves like this


Resolves #991 