### PR TITLE
Enhanced Circular Detection

### DIFF
--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
@@ -10,6 +10,7 @@ import javax.lang.model.element.TypeElement;
 import static java.util.stream.Collectors.toList;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 final class MetaDataOrdering {
 
@@ -22,7 +23,7 @@ final class MetaDataOrdering {
   private final List<MetaData> orderedList = new ArrayList<>();
   private final List<MetaData> queue = new ArrayList<>();
   private final Map<String, ProviderList> providers = new HashMap<>();
-  private final List<DependencyLink> circularDependencies = new ArrayList<>();
+  private final List<List<MetaData>> cyclePaths = new ArrayList<>();
   private final Set<String> missingDependencyTypes = new LinkedHashSet<>();
   private final Set<String> autoRequires = new TreeSet<>();
 
@@ -86,61 +87,17 @@ final class MetaDataOrdering {
   }
 
   /**
-   * Try to detect circular dependency given the remaining beans
-   * in the queue with unsatisfied dependencies.
-   */
-  private void detectCircularDependency(List<MetaData> remainder) {
-    final List<DependencyLink> dependencyLinks = new ArrayList<>();
-    for (MetaData metaData : remainder) {
-      final List<Dependency> dependsOn = metaData.dependsOn();
-      if (dependsOn != null) {
-        for (Dependency dependency : dependsOn) {
-          final MetaData provider = findCircularDependency(remainder, dependency);
-          if (provider != null) {
-            dependencyLinks.add(new DependencyLink(metaData, provider, dependency.name()));
-          }
-        }
-      }
-    }
-    if (dependencyLinks.size() > 1) {
-      // need minimum of 2 to form circular dependency
-      circularDependencies.addAll(dependencyLinks);
-    }
-  }
-
-  private MetaData findCircularDependency(List<MetaData> remainder, Dependency dependency) {
-    for (MetaData metaData : remainder) {
-      if (metaData.toString().contains(dependency.name())) {
-        return metaData;
-      }
-      final List<String> provides = metaData.provides();
-      if (provides != null && provides.contains(dependency.name())) {
-        return metaData;
-      }
-    }
-    return null;
-  }
-
-  /**
-   * Log a reasonable compile error for detected circular dependencies.
-   */
-  private void errorOnCircularDependencies() {
-    logError("Circular dependencies detected with beans %s  %s", circularDependencies, CIRC_ERR_MSG);
-    for (DependencyLink link : circularDependencies) {
-      logError("Circular dependency - %s dependsOn %s for %s", link.metaData, link.provider, link.dependency);
-    }
-  }
-
-  /**
-   * Build list of specific dependencies that are missing.
+   * Build list of specific dependencies that are missing. Runs cycle detection first so that a
+   * clear circular-dependency error is shown instead of misleading "No dependency provided" errors
+   * for each bean in the cycle.
    */
   void missingDependencies() {
+    detectCircularDependency(queue);
+    if (!cyclePaths.isEmpty()) {
+      return;
+    }
     for (MetaData metaData : queue) {
       checkMissingDependencies(metaData);
-    }
-    if (missingDependencyTypes.isEmpty()) {
-      // only look for circular dependencies if there are no missing dependencies
-      detectCircularDependency(queue);
     }
   }
 
@@ -211,15 +168,13 @@ final class MetaDataOrdering {
   private boolean dependencySatisfied(Dependency dependency, boolean includeExternal, MetaData queuedMeta, boolean anyWired) {
     String dependencyName = dependency.name();
     var providerList = providers.get(dependencyName);
-    if (providerList == null) {
-      if (scopeInfo.providedByOther(dependency)) {
-        return true;
-      } else {
-        return isExternal(dependencyName, includeExternal, queuedMeta);
-      }
-    } else {
+    if (providerList != null) {
       return providerList.isWired(anyWired);
     }
+    if (scopeInfo.providedByOther(dependency)) {
+      return true;
+    }
+    return isExternal(dependencyName, includeExternal, queuedMeta);
   }
 
   private boolean isExternal(String dependencyName, boolean includeExternal, MetaData queuedMeta) {
@@ -248,11 +203,101 @@ final class MetaDataOrdering {
   }
 
   /**
-   * Return true if the beans with unsatisfied dependencies seem
-   * to form a circular dependency.
+   * Return true if a circular dependency was detected among the remaining beans.
    */
   private boolean hasCircularDependencies() {
-    return !circularDependencies.isEmpty();
+    return !cyclePaths.isEmpty();
+  }
+
+
+  /**
+   * Try to detect circular dependency given the remaining beans in the queue. Uses DFS to find
+   * cycles, including those routed through interface implementations or factory-produced beans.
+   */
+  private void detectCircularDependency(List<MetaData> remainder) {
+    if (remainder.isEmpty()) return;
+    final Set<MetaData> remainderSet = new HashSet<>(remainder);
+    // Build adjacency: each bean -> the beans it depends on that are also in the remainder
+    final Map<MetaData, List<MetaData>> graph = new LinkedHashMap<>();
+    for (MetaData bean : remainder) {
+      graph.put(bean, resolveQueuedDeps(bean, remainderSet));
+    }
+    final Set<MetaData> visited = new HashSet<>();
+    final LinkedHashSet<MetaData> inStack = new LinkedHashSet<>();
+    for (MetaData bean : remainder) {
+      if (!visited.contains(bean)) {
+        dfsCycle(bean, graph, visited, inStack);
+      }
+    }
+  }
+
+  /** Resolve which beans (from the remainder) a given bean depends on. */
+  private List<MetaData> resolveQueuedDeps(MetaData bean, Set<MetaData> remainderSet) {
+    if (bean.dependsOn() == null) return Collections.emptyList();
+    final List<MetaData> result = new ArrayList<>();
+    for (Dependency dep : bean.dependsOn()) {
+      String depName = dep.name();
+      if (Util.isProvider(depName)) {
+        // Unwrap Provider<T> -> T so we can detect cycles through Provider injection
+        depName = Util.unwrapProvider(depName);
+      }
+      if (Constants.BEANSCOPE.equals(depName)) continue;
+      final ProviderList pl = providers.get(depName.replace(", ", ","));
+      if (pl != null) {
+        for (MetaData provider : pl.all()) {
+          if (remainderSet.contains(provider)) {
+            result.add(provider);
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  private void dfsCycle(
+      MetaData current,
+      Map<MetaData, List<MetaData>> graph,
+      Set<MetaData> visited,
+      LinkedHashSet<MetaData> stack) {
+    visited.add(current);
+    stack.add(current);
+    for (var neighbor : graph.getOrDefault(current, List.of())) {
+      if (!visited.contains(neighbor)) {
+        dfsCycle(neighbor, graph, visited, stack);
+      } else if (stack.contains(neighbor)) {
+        final var cycle = new ArrayList<MetaData>();
+        boolean collecting = false;
+        for (MetaData m : stack) {
+          if (m == neighbor) collecting = true;
+          if (collecting) cycle.add(m);
+        }
+        if (!isDuplicateCycle(cycle)) {
+          cyclePaths.add(cycle);
+        }
+      }
+    }
+    stack.remove(current);
+  }
+
+  private boolean isDuplicateCycle(List<MetaData> candidate) {
+    for (var existing : cyclePaths) {
+      if (existing.size() == candidate.size() && existing.containsAll(candidate)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Log a clear compile error for each detected circular dependency, showing the full cycle path.
+   */
+  private void errorOnCircularDependencies() {
+    for (var cycle : cyclePaths) {
+      final var path = cycle.stream().map(MetaData::type).collect(Collectors.joining(" -> "));
+      logError(
+          "Circular dependency detected: %s -> %s (cycle)  %s",
+          path, cycle.get(0).type(), CIRC_ERR_MSG);
+    }
   }
 
   private static class ProviderList {
@@ -261,6 +306,10 @@ final class MetaDataOrdering {
 
     private void add(MetaData beanMeta) {
       list.add(beanMeta);
+    }
+
+    private List<MetaData> all() {
+      return list;
     }
 
     private boolean isWired(boolean anyWired) {
@@ -283,24 +332,6 @@ final class MetaDataOrdering {
         }
       }
       return list.isEmpty();
-    }
-  }
-
-  private static class DependencyLink {
-
-    final MetaData metaData;
-    final MetaData provider;
-    final String dependency;
-
-    DependencyLink(MetaData metaData, MetaData provider, String dependency) {
-      this.metaData = metaData;
-      this.provider = provider;
-      this.dependency = dependency;
-    }
-
-    @Override
-    public String toString() {
-      return metaData.toString();
     }
   }
 }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
@@ -214,26 +214,35 @@ final class MetaDataOrdering {
    * cycles, including those routed through interface implementations or factory-produced beans.
    */
   private void detectCircularDependency(List<MetaData> remainder) {
+    cyclePaths.addAll(detectCycles(remainder, providers));
+  }
+
+  /**
+   * Detect cycles in the given remainder using the providers map. Package-private for testing.
+   */
+  static List<List<MetaData>> detectCycles(List<MetaData> remainder, Map<String, ProviderList> providers) {
     if (remainder.isEmpty()) {
-      return;
+      return Collections.emptyList();
     }
+    final List<List<MetaData>> cycles = new ArrayList<>();
     final Set<MetaData> remainderSet = new HashSet<>(remainder);
     // Build adjacency: each bean -> the beans it depends on that are also in the remainder
     final Map<MetaData, List<MetaData>> graph = new LinkedHashMap<>();
     for (MetaData bean : remainder) {
-      graph.put(bean, resolveQueuedDeps(bean, remainderSet));
+      graph.put(bean, resolveQueuedDeps(bean, remainderSet, providers));
     }
     final Set<MetaData> visited = new HashSet<>();
     final LinkedHashSet<MetaData> inStack = new LinkedHashSet<>();
     for (MetaData bean : remainder) {
       if (!visited.contains(bean)) {
-        dfsCycle(bean, graph, visited, inStack);
+        dfsCycle(bean, graph, visited, inStack, cycles);
       }
     }
+    return cycles;
   }
 
   /** Resolve which beans (from the remainder) a given bean depends on. */
-  private List<MetaData> resolveQueuedDeps(MetaData bean, Set<MetaData> remainderSet) {
+  private static List<MetaData> resolveQueuedDeps(MetaData bean, Set<MetaData> remainderSet, Map<String, ProviderList> providers) {
     if (bean.dependsOn() == null) {
       return Collections.emptyList();
     }
@@ -259,12 +268,12 @@ final class MetaDataOrdering {
     return result;
   }
 
-  private void dfsCycle(MetaData current, Map<MetaData, List<MetaData>> graph, Set<MetaData> visited, LinkedHashSet<MetaData> stack) {
+  private static void dfsCycle(MetaData current, Map<MetaData, List<MetaData>> graph, Set<MetaData> visited, LinkedHashSet<MetaData> stack, List<List<MetaData>> cycles) {
     visited.add(current);
     stack.add(current);
     for (var neighbor : graph.getOrDefault(current, List.of())) {
       if (!visited.contains(neighbor)) {
-        dfsCycle(neighbor, graph, visited, stack);
+        dfsCycle(neighbor, graph, visited, stack, cycles);
       } else if (stack.contains(neighbor)) {
         final var cycle = new ArrayList<MetaData>();
         boolean collecting = false;
@@ -276,16 +285,16 @@ final class MetaDataOrdering {
             cycle.add(m);
           }
         }
-        if (!isDuplicateCycle(cycle)) {
-          cyclePaths.add(cycle);
+        if (!isDuplicateCycle(cycle, cycles)) {
+          cycles.add(cycle);
         }
       }
     }
     stack.remove(current);
   }
 
-  private boolean isDuplicateCycle(List<MetaData> candidate) {
-    for (var existing : cyclePaths) {
+  private static boolean isDuplicateCycle(List<MetaData> candidate, List<List<MetaData>> cycles) {
+    for (var existing : cycles) {
       if (existing.size() == candidate.size() && existing.containsAll(candidate)) {
         return true;
       }
@@ -303,15 +312,15 @@ final class MetaDataOrdering {
     }
   }
 
-  private static class ProviderList {
+  static class ProviderList {
 
     private final List<MetaData> list = new ArrayList<>();
 
-    private void add(MetaData beanMeta) {
+    void add(MetaData beanMeta) {
       list.add(beanMeta);
     }
 
-    private List<MetaData> all() {
+    List<MetaData> all() {
       return list;
     }
 

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
@@ -209,13 +209,14 @@ final class MetaDataOrdering {
     return !cyclePaths.isEmpty();
   }
 
-
   /**
    * Try to detect circular dependency given the remaining beans in the queue. Uses DFS to find
    * cycles, including those routed through interface implementations or factory-produced beans.
    */
   private void detectCircularDependency(List<MetaData> remainder) {
-    if (remainder.isEmpty()) return;
+    if (remainder.isEmpty()) {
+      return;
+    }
     final Set<MetaData> remainderSet = new HashSet<>(remainder);
     // Build adjacency: each bean -> the beans it depends on that are also in the remainder
     final Map<MetaData, List<MetaData>> graph = new LinkedHashMap<>();
@@ -233,7 +234,9 @@ final class MetaDataOrdering {
 
   /** Resolve which beans (from the remainder) a given bean depends on. */
   private List<MetaData> resolveQueuedDeps(MetaData bean, Set<MetaData> remainderSet) {
-    if (bean.dependsOn() == null) return Collections.emptyList();
+    if (bean.dependsOn() == null) {
+      return Collections.emptyList();
+    }
     final List<MetaData> result = new ArrayList<>();
     for (Dependency dep : bean.dependsOn()) {
       String depName = dep.name();
@@ -241,7 +244,9 @@ final class MetaDataOrdering {
         // Unwrap Provider<T> -> T so we can detect cycles through Provider injection
         depName = Util.unwrapProvider(depName);
       }
-      if (Constants.BEANSCOPE.equals(depName)) continue;
+      if (Constants.BEANSCOPE.equals(depName)) {
+        continue;
+      }
       final ProviderList pl = providers.get(depName.replace(", ", ","));
       if (pl != null) {
         for (MetaData provider : pl.all()) {
@@ -254,11 +259,7 @@ final class MetaDataOrdering {
     return result;
   }
 
-  private void dfsCycle(
-      MetaData current,
-      Map<MetaData, List<MetaData>> graph,
-      Set<MetaData> visited,
-      LinkedHashSet<MetaData> stack) {
+  private void dfsCycle(MetaData current, Map<MetaData, List<MetaData>> graph, Set<MetaData> visited, LinkedHashSet<MetaData> stack) {
     visited.add(current);
     stack.add(current);
     for (var neighbor : graph.getOrDefault(current, List.of())) {
@@ -268,8 +269,12 @@ final class MetaDataOrdering {
         final var cycle = new ArrayList<MetaData>();
         boolean collecting = false;
         for (MetaData m : stack) {
-          if (m == neighbor) collecting = true;
-          if (collecting) cycle.add(m);
+          if (m == neighbor) {
+            collecting = true;
+          }
+          if (collecting) {
+            cycle.add(m);
+          }
         }
         if (!isDuplicateCycle(cycle)) {
           cyclePaths.add(cycle);
@@ -294,9 +299,7 @@ final class MetaDataOrdering {
   private void errorOnCircularDependencies() {
     for (var cycle : cyclePaths) {
       final var path = cycle.stream().map(MetaData::type).collect(Collectors.joining(" -> "));
-      logError(
-          "Circular dependency detected: %s -> %s (cycle)  %s",
-          path, cycle.get(0).type(), CIRC_ERR_MSG);
+      logError("Circular dependency detected: %s -> %s (cycle)  %s", path, cycle.get(0).type(), CIRC_ERR_MSG);
     }
   }
 

--- a/inject-generator/src/test/java/io/avaje/inject/generator/MetaDataOrderingTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/MetaDataOrderingTest.java
@@ -1,0 +1,174 @@
+package io.avaje.inject.generator;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MetaDataOrderingTest {
+
+  /**
+   * Build a providers map from the given beans, mirroring the constructor logic in MetaDataOrdering.
+   */
+  private static Map<String, MetaDataOrdering.ProviderList> buildProviders(MetaData... beans) {
+    var providers = new HashMap<String, MetaDataOrdering.ProviderList>();
+    for (MetaData bean : beans) {
+      providerAdd(providers, bean.toString()).add(bean);
+      providerAdd(providers, bean.type()).add(bean);
+      for (String provide : bean.provides()) {
+        providerAdd(providers, provide).add(bean);
+      }
+    }
+    return providers;
+  }
+
+  private static MetaDataOrdering.ProviderList providerAdd(Map<String, MetaDataOrdering.ProviderList> providers, String key) {
+    return providers.computeIfAbsent(key.replace(", ", ","), s -> new MetaDataOrdering.ProviderList());
+  }
+
+  @Test
+  void detectCycles_simple2NodeCycle() {
+    // A depends on B, B depends on A
+    var a = new MetaData("my.A", null);
+    a.setDependsOn(List.of("my.B"));
+    var b = new MetaData("my.B", null);
+    b.setDependsOn(List.of("my.A"));
+
+    var providers = buildProviders(a, b);
+    var cycles = MetaDataOrdering.detectCycles(List.of(a, b), providers);
+
+    assertThat(cycles).hasSize(1);
+    assertThat(cycles.get(0)).containsExactly(a, b);
+  }
+
+  @Test
+  void detectCycles_3NodeCycle() {
+    // A -> B -> C -> A
+    var a = new MetaData("my.A", null);
+    a.setDependsOn(List.of("my.B"));
+    var b = new MetaData("my.B", null);
+    b.setDependsOn(List.of("my.C"));
+    var c = new MetaData("my.C", null);
+    c.setDependsOn(List.of("my.A"));
+
+    var providers = buildProviders(a, b, c);
+    var cycles = MetaDataOrdering.detectCycles(List.of(a, b, c), providers);
+
+    assertThat(cycles).hasSize(1);
+    assertThat(cycles.get(0)).containsExactly(a, b, c);
+  }
+
+  @Test
+  void detectCycles_noCycle_linear() {
+    // A -> B -> C (no cycle, linear chain)
+    var a = new MetaData("my.A", null);
+    a.setDependsOn(List.of("my.B"));
+    var b = new MetaData("my.B", null);
+    b.setDependsOn(List.of("my.C"));
+    var c = new MetaData("my.C", null);
+    // C has no dependencies
+
+    var providers = buildProviders(a, b, c);
+    var cycles = MetaDataOrdering.detectCycles(List.of(a, b, c), providers);
+
+    assertThat(cycles).isEmpty();
+  }
+
+  @Test
+  void detectCycles_noCycle_empty() {
+    var cycles = MetaDataOrdering.detectCycles(List.of(), Map.of());
+    assertThat(cycles).isEmpty();
+  }
+
+  @Test
+  void detectCycles_multipleIndependentCycles() {
+    // Cycle 1: A <-> B
+    var a = new MetaData("my.A", null);
+    a.setDependsOn(List.of("my.B"));
+    var b = new MetaData("my.B", null);
+    b.setDependsOn(List.of("my.A"));
+
+    // Cycle 2: C <-> D
+    var c = new MetaData("my.C", null);
+    c.setDependsOn(List.of("my.D"));
+    var d = new MetaData("my.D", null);
+    d.setDependsOn(List.of("my.C"));
+
+    var providers = buildProviders(a, b, c, d);
+    var cycles = MetaDataOrdering.detectCycles(List.of(a, b, c, d), providers);
+
+    assertThat(cycles).hasSize(2);
+  }
+
+  @Test
+  void detectCycles_throughInterfaceProvides() {
+    // A depends on "my.Iface", B provides "my.Iface" and depends on A
+    var a = new MetaData("my.A", null);
+    a.setDependsOn(List.of("my.Iface"));
+
+    var b = new MetaData("my.B", null);
+    b.setProvides(List.of("my.Iface"));
+    b.setDependsOn(List.of("my.A"));
+
+    var providers = buildProviders(a, b);
+    var cycles = MetaDataOrdering.detectCycles(List.of(a, b), providers);
+
+    assertThat(cycles).hasSize(1);
+    assertThat(cycles.get(0)).containsExactly(a, b);
+  }
+
+  @Test
+  void detectCycles_noFalsePositive_depNotInRemainder() {
+    // A depends on B, but B is not in the remainder (already wired)
+    var a = new MetaData("my.A", null);
+    a.setDependsOn(List.of("my.B"));
+    var b = new MetaData("my.B", null);
+    b.setWired();
+
+    // B is in providers but NOT in the remainder list
+    var providers = buildProviders(a, b);
+    var cycles = MetaDataOrdering.detectCycles(List.of(a), providers);
+
+    assertThat(cycles).isEmpty();
+  }
+
+  @Test
+  void detectCycles_multiHopCycle() {
+    // A -> B -> C -> D -> A (4-node cycle)
+    var a = new MetaData("my.A", null);
+    a.setDependsOn(List.of("my.B"));
+    var b = new MetaData("my.B", null);
+    b.setDependsOn(List.of("my.C"));
+    var c = new MetaData("my.C", null);
+    c.setDependsOn(List.of("my.D"));
+    var d = new MetaData("my.D", null);
+    d.setDependsOn(List.of("my.A"));
+
+    var providers = buildProviders(a, b, c, d);
+    var cycles = MetaDataOrdering.detectCycles(List.of(a, b, c, d), providers);
+
+    assertThat(cycles).hasSize(1);
+    assertThat(cycles.get(0)).containsExactly(a, b, c, d);
+  }
+
+  @Test
+  void detectCycles_cycleWithInterfaceMultiHop() {
+    // A -> Iface (provided by B) -> C -> A
+    var a = new MetaData("my.A", null);
+    a.setDependsOn(List.of("my.Iface"));
+
+    var b = new MetaData("my.B", null);
+    b.setProvides(List.of("my.Iface"));
+    b.setDependsOn(List.of("my.C"));
+
+    var c = new MetaData("my.C", null);
+    c.setDependsOn(List.of("my.A"));
+
+    var providers = buildProviders(a, b, c);
+    var cycles = MetaDataOrdering.detectCycles(List.of(a, b, c), providers);
+
+    assertThat(cycles).hasSize(1);
+    assertThat(cycles.get(0)).containsExactly(a, b, c);
+  }
+}


### PR DESCRIPTION
It turns out that for more complicated dependency graphs the current circular detection was insufficient. The old method used `String.contains()` matching and only detected direct 1-hop links, so it missed multi-hop cycles through interface implementations (e.g. `JdaMessages implements Messages`).

- Replaced detectCircularDependency + findCircularDependency with a DFS-based approach that builds a proper adjacency graph.                                                                                                                                       
- adds `resolveQueuedDeps` to look up each dependency in the providers map and follows interface -> implementation resolution, including unwrapping Provider<T> -> T.
- dfsCycle uses LinkedHashSet<MetaData> stack as both the O(1) cycle-membership check and the ordered path record. When a back edge is found, iterating the stack in insertion order gives the cycle path directly.      
- Clearer error message


Resolves #1022 

for that case described in the above issue, avaje inject will now give the following error

`
 Circular dependency detected: com.github.sfxd.trust.discord.BotCommandFactory -> com.github.sfxd.trust.instances.InstanceRepository -> io.ebean.Database -> com.github.sfxd.trust.events.EventfulBeanPersistListener -> com.github.sfxd.trust.events.Pipeline -> com.github.sfxd.trust.instances.InstanceUpdatedEvent$Handler -> com.github.sfxd.trust.discord.JdaMessages -> net.dv8tion.jda.api.JDA -> com.github.sfxd.trust.discord.MessageListener -> com.github.sfxd.trust.discord.BotCommandFactory (cycle)  To handle circular dependencies consider using field injection rather than constructor injection on one of the dependencies. 
`

instead of 

```
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /C:/Users/george/code/trust-bot/src/main/java/com/github/sfxd/trust/discord/BotCommandFactory.java:[19,8] No dependency provided for com.github.sfxd.trust.instances.InstanceRepository on com.github.sfxd.trust.discord.BotCommandFactory
[ERROR] /C:/Users/george/code/trust-bot/src/main/java/com/github/sfxd/trust/discord/JdaMessages.java:[12,8] No dependency provided for net.dv8tion.jda.api.JDA on com.github.sfxd.trust.discord.JdaMessages
[ERROR] /C:/Users/george/code/trust-bot/src/main/java/com/github/sfxd/trust/discord/MessageListener.java:[17,8] No dependency provided for com.github.sfxd.trust.discord.BotCommandFactory on com.github.sfxd.trust.discord.MessageListener
[ERROR] /C:/Users/george/code/trust-bot/src/main/java/com/github/sfxd/trust/events/EventfulBeanPersistListener.java:[10,8] No dependency provided for com.github.sfxd.trust.events.Pipeline on com.github.sfxd.trust.events.EventfulBeanPersistListener
[ERROR] /C:/Users/george/code/trust-bot/src/main/java/com/github/sfxd/trust/events/Pipeline.java:[8,8] No dependency provided for soft:com.github.sfxd.trust.events.EventHandler on com.github.sfxd.trust.events.Pipeline
[ERROR] /C:/Users/george/code/trust-bot/src/main/java/com/github/sfxd/trust/instances/InstanceRepository.java:[15,8] No dependency provided for io.ebean.Database on com.github.sfxd.trust.instances.InstanceRepository
[ERROR] No dependency provided for com.github.sfxd.trust.Messages on com.github.sfxd.trust.instances.InstanceUpdatedEvent$Handler
[ERROR] /C:/Users/george/code/trust-bot/src/main/java/com/github/sfxd/trust/integrations/InstanceRefreshConsumer.java:[20,8] No dependency provided for com.github.sfxd.trust.instances.InstanceRepository on com.github.sfxd.trust.integrations.InstanceRefreshConsumer
[ERROR] /C:/Users/george/code/trust-bot/src/main/java/com/github/sfxd/trust/integrations/InstanceRefreshRoute.java:[23,8] No dependency provided for com.github.sfxd.trust.integrations.InstanceRefreshConsumer on com.github.sfxd.trust.integrations.InstanceRefreshRoute
[ERROR] No dependency provided for soft:io.ebean.event.BeanPersistListener on io.ebean.Database
[ERROR] No dependency provided for com.github.sfxd.trust.discord.MessageListener on net.dv8tion.jda.api.JDA
[ERROR] No dependency provided for soft:org.apache.camel.builder.RouteBuilder on org.apache.camel.CamelContext
[ERROR] Dependencies [com.github.sfxd.trust.instances.InstanceRepository, net.dv8tion.jda.api.JDA, com.github.sfxd.trust.discord.BotCommandFactory, com.github.sfxd.trust.events.Pipeline, com.github.sfxd.trust.events.EventHandler, io.ebean.Database, com.github.sfxd.trust.Messages, com.github.sfxd.trust.integrations.InstanceRefreshConsumer, io.ebean.event.BeanPersistListener, com.github.sfxd.trust.discord.MessageListener, org.apache.camel.builder.RouteBuilder] are not provided - there are no @Singleton, @Component, @Factory/@Bean that currently provide this type. If this is an external dependency consider specifying via @Ext
```