### PR TITLE
Ensure Closeable beans are closed when BeanScope creation fails

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/partialbuild/FailingFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/partialbuild/FailingFactory.java
@@ -1,0 +1,35 @@
+package org.example.myapp.partialbuild;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.avaje.inject.Bean;
+import io.avaje.inject.Factory;
+import io.avaje.inject.Profile;
+
+/**
+ * Test fixture for verifying that AutoCloseable beans are closed when a
+ * {@code @Factory} method throws partway through wiring.
+ */
+@Factory
+@Profile("partial-build-failure-test")
+public class FailingFactory {
+
+  public static final AtomicBoolean FIRST_CLOSED = new AtomicBoolean();
+
+  @Bean
+  First first() {
+    return new First();
+  }
+
+  @Bean
+  String second(First f) {
+    throw new IllegalStateException("boom while wiring String from " + f);
+  }
+
+  public static final class First implements AutoCloseable {
+    @Override
+    public void close() {
+      FIRST_CLOSED.set(true);
+    }
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/partialbuild/PostConstructFailingFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/partialbuild/PostConstructFailingFactory.java
@@ -1,0 +1,37 @@
+package org.example.myapp.partialbuild;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.avaje.inject.Bean;
+import io.avaje.inject.Factory;
+import io.avaje.inject.PostConstruct;
+import io.avaje.inject.Profile;
+
+/**
+ * Test fixture for verifying that AutoCloseable beans are closed when a
+ * {@code @PostConstruct} method throws after all beans have been wired.
+ */
+@Factory
+@Profile("partial-build-postconstruct-test")
+public class PostConstructFailingFactory {
+
+  public static final AtomicBoolean CRASHER_CLOSED = new AtomicBoolean();
+
+  @Bean
+  Crasher crasher() {
+    return new Crasher();
+  }
+
+  public static final class Crasher implements AutoCloseable {
+
+    @PostConstruct
+    void start() {
+      throw new IllegalStateException("boom in postconstruct");
+    }
+
+    @Override
+    public void close() {
+      CRASHER_CLOSED.set(true);
+    }
+  }
+}

--- a/blackbox-test-inject/src/test/java/org/example/myapp/partialbuild/PartialBuildFailureTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/partialbuild/PartialBuildFailureTest.java
@@ -1,0 +1,28 @@
+package org.example.myapp.partialbuild;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.inject.BeanScope;
+
+class PartialBuildFailureTest {
+
+  /**
+   * When a factory method throws partway through wiring, AutoCloseable beans
+   * that were already constructed and registered must still be closed.
+   * Otherwise they leak resources (file handles, sockets, threads, etc.).
+   */
+  @Test
+  void buildFailureClosesAlreadyConstructedAutoCloseables() {
+    FailingFactory.FIRST_CLOSED.set(false);
+
+    assertThatThrownBy(() -> BeanScope.builder().profiles("partial-build-failure-test").build())
+        .hasMessageContaining("boom");
+
+    assertThat(FailingFactory.FIRST_CLOSED)
+        .as("AutoCloseable beans constructed before the failing factory must be closed when the build aborts")
+        .isTrue();
+  }
+}

--- a/blackbox-test-inject/src/test/java/org/example/myapp/partialbuild/PostConstructFailureTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/partialbuild/PostConstructFailureTest.java
@@ -1,0 +1,28 @@
+package org.example.myapp.partialbuild;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.inject.BeanScope;
+
+class PostConstructFailureTest {
+
+  /**
+   * When a {@code @PostConstruct} method throws after all beans have been
+   * constructed, AutoCloseable beans that were already registered must still
+   * be closed. Otherwise they leak resources.
+   */
+  @Test
+  void postConstructFailureClosesAlreadyConstructedAutoCloseables() {
+    PostConstructFailingFactory.CRASHER_CLOSED.set(false);
+
+    assertThatThrownBy(() -> BeanScope.builder().profiles("partial-build-postconstruct-test").build())
+        .hasMessageContaining("boom in postconstruct");
+
+    assertThat(PostConstructFailingFactory.CRASHER_CLOSED)
+        .as("AutoCloseable beans must be closed when a @PostConstruct throws and aborts the build")
+        .isTrue();
+  }
+}

--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -277,10 +277,15 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
     log.log(level, "building with avaje modules {0} profiles {1}", moduleNames, profiles);
 
     final var builder = Builder.newBuilder(profiles, propertyPlugin, suppliedBeans, enrichBeans, parent, parentOverride);
-    for (final var factory : factoryOrder.factories()) {
-      builder.currentModule(factory.getClass());
-      builder.currentScopes(factory.definesScopes());
-      factory.build(builder);
+    try {
+      for (final var factory : factoryOrder.factories()) {
+        builder.currentModule(factory.getClass());
+        builder.currentScopes(factory.definesScopes());
+        factory.build(builder);
+      }
+    } catch (Throwable t) {
+      builder.closeOnFailure(t);
+      throw t;
     }
 
     if (moduleNames.isEmpty()) {

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -327,14 +327,12 @@ public interface Builder {
 
   /**
    * Close any AutoCloseables that were registered before the build aborted.
-   * <p>
-   * Called by the scope builder when {@link AvajeModule#build(Builder)} throws,
-   * so that beans which were already constructed do not leak their resources.
-   * Best-effort: failures from individual {@link AutoCloseable#close()} calls
-   * are attached to {@code cause} as suppressed exceptions, never thrown.
    *
-   * @param cause the build failure that triggered cleanup, used to collect
-   *              suppressed exceptions raised during close
+   * <p>Called by the scope builder when {@link AvajeModule#build(Builder)} throws, so that beans
+   * which were already constructed do not leak their resources.
+   *
+   * @param cause the build failure that triggered cleanup, used to collect suppressed exceptions
+   *     raised during close
    */
   default void closeOnFailure(Throwable cause) {
     // default no-op for custom Builder implementations

--- a/inject/src/main/java/io/avaje/inject/spi/Builder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/Builder.java
@@ -326,6 +326,21 @@ public interface Builder {
   BeanScope build(boolean withShutdownHook, long start);
 
   /**
+   * Close any AutoCloseables that were registered before the build aborted.
+   * <p>
+   * Called by the scope builder when {@link AvajeModule#build(Builder)} throws,
+   * so that beans which were already constructed do not leak their resources.
+   * Best-effort: failures from individual {@link AutoCloseable#close()} calls
+   * are attached to {@code cause} as suppressed exceptions, never thrown.
+   *
+   * @param cause the build failure that triggered cleanup, used to collect
+   *              suppressed exceptions raised during close
+   */
+  default void closeOnFailure(Throwable cause) {
+    // default no-op for custom Builder implementations
+  }
+
+  /**
    * Set the current module being wired.
    */
   void currentModule(Class<? extends AvajeModule> currentModule);

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -468,23 +468,20 @@ class DBuilder implements Builder {
 
   @Override
   public final void closeOnFailure(Throwable cause) {
-    if (preDestroy.isEmpty()) {
-      return;
-    }
     // close in priority order, mirroring the normal shutdown path, then drain
     // the deque so a subsequent BeanScope.close() is a no-op for these hooks.
-    final var pending = new ArrayList<>(preDestroy);
-    preDestroy.clear();
-    pending.stream()
+    preDestroy.stream()
         .sorted()
         .map(ClosePair::closeable)
-        .forEach(closeable -> {
-          try {
-            closeable.close();
-          } catch (Exception closeError) {
-            cause.addSuppressed(closeError);
-          }
-        });
+        .forEach(
+            closeable -> {
+              try {
+                closeable.close();
+              } catch (Exception closeError) {
+                cause.addSuppressed(closeError);
+              }
+            });
+    preDestroy.clear();
   }
 
   /** Return the PreDestroy methods in priority order. */

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -454,7 +454,16 @@ class DBuilder implements Builder {
     if (beanScopeProxy != null) {
       beanScopeProxy.inject(scope);
     }
-    return scope.start(start);
+    try {
+      return scope.start(start);
+    } catch (Throwable t) {
+      try {
+        scope.close();
+      } catch (Exception closeError) {
+        t.addSuppressed(closeError);
+      }
+      throw t;
+    }
   }
 
   @Override

--- a/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/spi/DBuilder.java
@@ -457,6 +457,27 @@ class DBuilder implements Builder {
     return scope.start(start);
   }
 
+  @Override
+  public final void closeOnFailure(Throwable cause) {
+    if (preDestroy.isEmpty()) {
+      return;
+    }
+    // close in priority order, mirroring the normal shutdown path, then drain
+    // the deque so a subsequent BeanScope.close() is a no-op for these hooks.
+    final var pending = new ArrayList<>(preDestroy);
+    preDestroy.clear();
+    pending.stream()
+        .sorted()
+        .map(ClosePair::closeable)
+        .forEach(closeable -> {
+          try {
+            closeable.close();
+          } catch (Exception closeError) {
+            cause.addSuppressed(closeError);
+          }
+        });
+  }
+
   /** Return the PreDestroy methods in priority order. */
   private Deque<ClosePair> preDestroy() {
     return preDestroy;


### PR DESCRIPTION
This is an AI assisted attempt to fix issue #1026

The test cases included highlight that when a BeanScope fails to create due to a constructor injection throwing, or a PostConstruct throwing, beans' close() methods are not called.

I have no particular attachment to this code -- please feel free to rip this draft apart for parts, or ignore it, or modify it as you like -- Claude doesn't care ;)
