### PR TITLE
FactoryOrder: preserve module order when supplied beans satisfy a requires

### DIFF
--- a/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
+++ b/inject/src/main/java/io/avaje/inject/DBeanScopeBuilder.java
@@ -388,12 +388,21 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
     private void processQueue() {
       int count;
       do {
-        count = processQueuedFactories();
+        count = processQueuedFactories(false);
       } while (count > 0);
 
-      if (suppliedBeans) {
-        // just push everything left assuming supplied beans
-        // will satisfy the required dependencies
+      if (suppliedBeans && !queue.isEmpty()) {
+        // Relaxed pass: when supplied beans may satisfy unknown dependencies,
+        // treat a required type with no module-level provider as externally
+        // supplied, and treat a required type with at least one provider already
+        // pushed as satisfied. This preserves topological order between modules
+        // whose only unsatisfied dependency is supplied via BeanScopeBuilder.bean()
+        // or comes from a partial multi-provider chain.
+        do {
+          count = processQueuedFactories(true);
+        } while (count > 0);
+        // Anything still queued has an in-module provider that was never pushed
+        // (a cycle or otherwise unresolvable case); emit in insertion order.
         for (final FactoryState factoryState : queue) {
           push(factoryState);
         }
@@ -422,24 +431,38 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
     }
 
     private boolean notProvided(String dependency) {
+      return notProvided(dependency, false);
+    }
+
+    private boolean notProvided(String dependency, boolean relaxed) {
       if (parent != null && (parent.contains(dependency) || parent.customScopeAnnotations().contains(dependency))) {
         return false;
       }
       final var factoryList = providesMap.get(dependency);
-      return factoryList == null || !factoryList.allPushed();
+      if (factoryList == null) {
+        // No module on the list provides this type. In strict mode that's a
+        // missing dependency; in relaxed mode (supplied beans in play) we assume
+        // the bean was supplied externally via BeanScopeBuilder.bean().
+        return !relaxed;
+      }
+      return relaxed ? !factoryList.anyPushed() : !factoryList.allPushed();
     }
 
     /**
      * Process the queued factories pushing them when all their (module) dependencies are satisfied.
      *
      * <p>This returns the number of factories added so once this returns 0 it is done.
+     *
+     * @param relaxed when true, a requirement is satisfied if at least one of its
+     *     providers has been pushed, and a requirement with no module-level provider
+     *     is assumed to be supplied externally.
      */
-    private int processQueuedFactories() {
+    private int processQueuedFactories(boolean relaxed) {
       int count = 0;
       final var it = queue.iterator();
       while (it.hasNext()) {
         final FactoryState factory = it.next();
-        if (factory.factory.interweaved() || satisfiedDependencies(factory)) {
+        if (factory.factory.interweaved() || satisfiedDependencies(factory, relaxed)) {
           // push the factory onto the build order
           it.remove();
           push(factory);
@@ -450,14 +473,14 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
     }
 
     /** Return true if the (module) requires dependencies are satisfied for this factory. */
-    private boolean satisfiedDependencies(FactoryState factory) {
-      return satisfiedDependencies(factory.requires())
-          && satisfiedDependencies(factory.requiresPackages());
+    private boolean satisfiedDependencies(FactoryState factory, boolean relaxed) {
+      return satisfiedDependencies(factory.requires(), relaxed)
+          && satisfiedDependencies(factory.requiresPackages(), relaxed);
     }
 
-    private boolean satisfiedDependencies(String[] requires) {
+    private boolean satisfiedDependencies(String[] requires, boolean relaxed) {
       for (final var dependency : requires) {
-        if (notProvided(dependency)) {
+        if (notProvided(dependency, relaxed)) {
           return false;
         }
       }
@@ -536,6 +559,16 @@ final class DBeanScopeBuilder implements BeanScopeBuilder.ForTesting {
         }
       }
       return true;
+    }
+
+    /** Return true if at least one factory here has been pushed onto the build order. */
+    boolean anyPushed() {
+      for (final FactoryState factory : factories) {
+        if (factory.isPushed()) {
+          return true;
+        }
+      }
+      return false;
     }
   }
 }

--- a/inject/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
+++ b/inject/src/test/java/io/avaje/inject/BeanScopeBuilderTest.java
@@ -160,6 +160,24 @@ class BeanScopeBuilderTest {
   }
 
   @Test
+  void supplied_externalRequires_orderPreservedForChain() {
+    // When BeanScopeBuilder.bean() is in play (suppliedBeans=true) and a module chain
+    // B<-A has A's requires satisfied externally, modules added in order [B, A] must
+    // still be wired in dependency order. The strict pass stalls because B's TypeX is
+    // only provided by A (not yet pushed) and A's external requires are not in the
+    // providesMap. Without a relaxed fallback that treats absent providesMap entries
+    // as externally supplied, the queue is dumped in insertion order and B is wired
+    // before A, leaving TypeX null at injection time.
+    DBeanScopeBuilder.FactoryOrder factoryOrder =
+      new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), true);
+    factoryOrder.add(bc("B", EMPTY_CLASSES, of(MyFeature.class)));
+    factoryOrder.add(bc("A", of(MyFeature.class), of(FeatureA.class)));
+    factoryOrder.orderModules();
+
+    assertThat(names(factoryOrder.factories())).containsExactly("A", "B");
+  }
+
+  @Test
   void missingRequiresPackage_expect_unsatisfiedRequiresPackages() {
     DBeanScopeBuilder.FactoryOrder factoryOrder = new DBeanScopeBuilder.FactoryOrder(null, Collections.emptySet(), false);
     factoryOrder.add(bc("1", EMPTY_CLASSES, new Class[0], of(Mod3.class)));


### PR DESCRIPTION
This is an AI-assisted attempt to fix a purported bug in module ordering. Human-me had already run into confusing cases regarding module ordering with @External beans, without really understanding what was wrong. Claude's analysis, claiming this is a bug or shortcoming in Avaje, follows. I've attempted to verify it myself but some extra scrutiny might be warranted before accepting this change. Same as before - feel free to totally junk the code if you don't find it acceptable; happy to write this up as simply a bug report with test if that's preferred:


When BeanScopeBuilder.build() is called with one or more supplied beans, FactoryOrder runs with suppliedBeans=true. If the strict topological pass stalls, the existing fallback dumps the remaining queue in insertion order, discarding the partial order it had already computed.

This breaks any module whose @InjectModule(requires=...) names a type that is supplied via BeanScopeBuilder.bean() (or only partially provided through a multi-provider chain). With modules added in [B, A] where A provides TypeX (consumed by B) and A's other requires are externally supplied, B gets wired before A and Avaje throws "Injecting null for TypeX ... potential beans to inject: []" at runtime.

Add a relaxed second pass that runs only when suppliedBeans=true and only after the strict pass has stalled:
  - a required type with no module-level provider is treated as externally supplied (assume it came from .bean());
  - a required type counts as satisfied once at least one of its providers has been pushed.

Anything still queued after the relaxed pass has an in-module provider that was never pushed (a cycle or otherwise unresolvable case); those still emit in insertion order, as before. Existing behavior for the strict path is unchanged.