### PR TITLE
Fix GHA Cache Action Conflicts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: Build
 
 on: [push, pull_request, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 
@@ -27,9 +31,12 @@ jobs:
       env:
         cache-name: maven-cache
       with:
-        path:
-          ~/.m2
-        key: build-${{ env.cache-name }}
+        path: |
+          ~/.m2/repository
+          !~/.m2/repository/io/avaje
+        key: build-${{ env.cache-name }}-${{ matrix.os }}-${{ matrix.java_version }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          build-${{ env.cache-name }}-${{ matrix.os }}-${{ matrix.java_version }}-
     - name: Maven version
       run: mvn --version
     - name: Build with Maven

--- a/.github/workflows/jdk-ea-stable.yml
+++ b/.github/workflows/jdk-ea-stable.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '39 1 * * 1,3,5'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 
@@ -34,9 +38,12 @@ jobs:
       env:
         cache-name: maven-cache
       with:
-        path:
-          ~/.m2
-        key: build-${{ env.cache-name }}
+        path: |
+          ~/.m2/repository
+          !~/.m2/repository/io/avaje
+        key: ea-stable-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ea-stable-${{ env.cache-name }}-
     - name: Maven version
       run: mvn --version
     - name: Build with Maven

--- a/.github/workflows/jdk-ea.yml
+++ b/.github/workflows/jdk-ea.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '39 1 * * 1,3,5'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 
@@ -33,9 +37,12 @@ jobs:
       env:
         cache-name: maven-cache
       with:
-        path:
-          ~/.m2
-        key: build-${{ env.cache-name }}
+        path: |
+          ~/.m2/repository
+          !~/.m2/repository/io/avaje
+        key: ea-${{ env.cache-name }}-${{ matrix.os }}-${{ matrix.java_version }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ea-${{ env.cache-name }}-${{ matrix.os }}-${{ matrix.java_version }}-
     - name: Maven version
       run: mvn --version
     - name: Build with Maven

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,12 @@ jobs:
       env:
         cache-name: maven-cache
       with:
-        path: ~/.m2
-        key: build-${{ env.cache-name }}
+        path: |
+          ~/.m2/repository
+          !~/.m2/repository/io/avaje
+        key: release-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          release-${{ env.cache-name }}-
     - name: Set up Java and Maven
       uses: actions/setup-java@v5
       with:

--- a/.github/workflows/valhalla-ea.yml
+++ b/.github/workflows/valhalla-ea.yml
@@ -33,9 +33,12 @@ jobs:
       env:
         cache-name: maven-cache
       with:
-        path:
-          ~/.m2
-        key: build-${{ env.cache-name }}
+        path: |
+          ~/.m2/repository
+          !~/.m2/repository/io/avaje
+        key: valhalla-${{ env.cache-name }}-${{ matrix.os }}-${{ matrix.java_version }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          valhalla-${{ env.cache-name }}-${{ matrix.os }}-${{ matrix.java_version }}-
     - name: Maven version
       run: mvn --version
     - name: Prepare


### PR DESCRIPTION
It seems that all 5 workflows use same static key. On one push they all run at once, all miss, then all try reserve same key. Maven central was throwing 429s because of lack of caching.

- more unique keys 
- cancel stale workflows