### PR TITLE
Fix Self-Providing Beans

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/Conn.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/Conn.java
@@ -1,0 +1,3 @@
+package org.example.myapp.profileorder;
+
+public interface Conn {}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/DbService.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/DbService.java
@@ -1,0 +1,16 @@
+package org.example.myapp.profileorder;
+
+import io.avaje.inject.Profile;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Profile("cloud")
+public class DbService implements MyService {
+
+  public DbService(Pool pool) {}
+
+  @Override
+  public String name() {
+    return "db";
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/FileService.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/FileService.java
@@ -1,0 +1,14 @@
+package org.example.myapp.profileorder;
+
+import io.avaje.inject.Profile;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Profile(none = "cloud")
+public class FileService implements MyService {
+
+  @Override
+  public String name() {
+    return "file";
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/MyService.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/MyService.java
@@ -1,0 +1,6 @@
+package org.example.myapp.profileorder;
+
+public interface MyService {
+
+  String name();
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/Pool.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/Pool.java
@@ -1,0 +1,4 @@
+package org.example.myapp.profileorder;
+
+/** Mimics r2dbc ConnectionPool which itself implements ConnectionFactory. */
+public class Pool implements Conn {}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/PoolFactory.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/PoolFactory.java
@@ -1,0 +1,20 @@
+package org.example.myapp.profileorder;
+
+import io.avaje.inject.Bean;
+import io.avaje.inject.Factory;
+import io.avaje.inject.Profile;
+
+@Factory
+@Profile("cloud")
+public class PoolFactory {
+
+  @Bean
+  Conn conn() {
+    return new Conn() {};
+  }
+
+  @Bean
+  Pool pool(Conn conn) {
+    return new Pool();
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/ServiceConsumer.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/ServiceConsumer.java
@@ -1,0 +1,17 @@
+package org.example.myapp.profileorder;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class ServiceConsumer {
+
+  private final MyService service;
+
+  public ServiceConsumer(MyService service) {
+    this.service = service;
+  }
+
+  public String serviceName() {
+    return service.name();
+  }
+}

--- a/blackbox-test-inject/src/test/java/org/example/myapp/profileorder/ProfileOrderTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/profileorder/ProfileOrderTest.java
@@ -1,0 +1,39 @@
+package org.example.myapp.profileorder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.avaje.config.Config;
+import io.avaje.inject.BeanScope;
+
+/**
+ * When multiple beans implement the same interface and are selected by profile, every one of them
+ * must be wired before any consumer of that interface.
+ *
+ * <p>See https://github.com/avaje/avaje-inject/issues/1049
+ */
+class ProfileOrderTest {
+
+  @AfterEach
+  void clearConfig() {
+    Config.clearProperty("avaje.profiles");
+  }
+
+  @Test
+  void cloudProfile_dbServiceWiredBeforeConsumer() {
+    Config.setProperty("avaje.profiles", "cloud");
+
+    try (BeanScope beanScope = BeanScope.builder().build()) {
+      assertThat(beanScope.get(ServiceConsumer.class).serviceName()).isEqualTo("db");
+    }
+  }
+
+  @Test
+  void defaultProfile_fileServiceWiredBeforeConsumer() {
+    try (BeanScope beanScope = BeanScope.builder().build()) {
+      assertThat(beanScope.get(ServiceConsumer.class).serviceName()).isEqualTo("file");
+    }
+  }
+}

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
@@ -169,7 +169,7 @@ final class MetaDataOrdering {
     String dependencyName = dependency.name();
     var providerList = providers.get(dependencyName);
     if (providerList != null) {
-      return providerList.isWired(anyWired);
+      return providerList.isWired(anyWired, queuedMeta);
     }
     if (scopeInfo.providedByOther(dependency)) {
       return true;
@@ -326,22 +326,39 @@ final class MetaDataOrdering {
       return list;
     }
 
-    private boolean isWired(boolean anyWired) {
-      return anyWired ? isAnyWired() : isAllWired();
+    /**
+     * Return true when this dependency is considered satisfied for the given bean.
+     *
+     * <p>The bean itself is excluded from the check as a bean can provide the same type it depends
+     * on - for example a connection pool that takes a connection factory and is itself a connection
+     * factory. Without excluding it that bean can never be wired, which pushes it (and everything
+     * that depends on it) into the last ditch "any wired" round where consumers can be ordered
+     * before other beans providing the type.
+     */
+    private boolean isWired(boolean anyWired, MetaData self) {
+      if (containsOnly(self)) {
+        // the only provider is the bean itself - a genuine self reference
+        return false;
+      }
+      return anyWired ? isAnyWired(self) : isAllWired(self);
     }
 
-    private boolean isAllWired() {
+    private boolean containsOnly(MetaData self) {
+      return list.size() == 1 && list.get(0) == self;
+    }
+
+    private boolean isAllWired(MetaData self) {
       for (MetaData metaData : list) {
-        if (!metaData.isWired()) {
+        if (metaData != self && !metaData.isWired()) {
           return false;
         }
       }
       return true;
     }
 
-    private boolean isAnyWired() {
+    private boolean isAnyWired(MetaData self) {
       for (MetaData metaData : list) {
-        if (metaData.isWired()) {
+        if (metaData != self && metaData.isWired()) {
           return true;
         }
       }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
@@ -326,43 +326,36 @@ final class MetaDataOrdering {
       return list;
     }
 
-    /**
-     * Return true when this dependency is considered satisfied for the given bean.
-     *
-     * <p>The bean itself is excluded from the check as a bean can provide the same type it depends
-     * on - for example a connection pool that takes a connection factory and is itself a connection
-     * factory. Without excluding it that bean can never be wired, which pushes it (and everything
-     * that depends on it) into the last ditch "any wired" round where consumers can be ordered
-     * before other beans providing the type.
-     */
     private boolean isWired(boolean anyWired, MetaData self) {
-      if (containsOnly(self)) {
-        // the only provider is the bean itself - a genuine self reference
-        return false;
-      }
       return anyWired ? isAnyWired(self) : isAllWired(self);
     }
 
-    private boolean containsOnly(MetaData self) {
-      return list.size() == 1 && list.get(0) == self;
-    }
-
     private boolean isAllWired(MetaData self) {
+      boolean hasOther = false;
       for (MetaData metaData : list) {
-        if (metaData != self && !metaData.isWired()) {
+        if (metaData == self) {
+          continue;
+        }
+        hasOther = true;
+        if (!metaData.isWired()) {
           return false;
         }
       }
-      return true;
+      return hasOther || list.isEmpty() || self.isWired();
     }
 
     private boolean isAnyWired(MetaData self) {
+      boolean hasOther = false;
       for (MetaData metaData : list) {
-        if (metaData != self && metaData.isWired()) {
+        if (metaData == self) {
+          continue;
+        }
+        hasOther = true;
+        if (metaData.isWired()) {
           return true;
         }
       }
-      return list.isEmpty();
+      return !hasOther && (list.isEmpty() || self.isWired());
     }
   }
 }

--- a/inject-generator/src/test/java/io/avaje/inject/generator/Issue1049Test.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/Issue1049Test.java
@@ -1,0 +1,156 @@
+package io.avaje.inject.generator;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for the ordering bug reported in
+ * https://github.com/avaje/avaje-inject/issues/1049
+ *
+ * <p>Confirmed against the real-world reproducer at
+ * https://github.com/daviian/avaja-inject-reproducer - the actual (non-synthetic) trigger there
+ * is a "decorator" style bean: {@code io.r2dbc.pool.ConnectionPool implements
+ * io.r2dbc.spi.ConnectionFactory} while ALSO having a constructor dependency on a
+ * {@code ConnectionFactory} (the one it wraps). This means {@code ConnectionPool} is itself a
+ * member of the "ConnectionFactory" provider list AND depends on that same provider list, so it
+ * could never satisfy "all providers wired" under strict semantics (it would require itself to
+ * already be wired). Note this is a perfectly valid, always-resolvable-at-runtime pattern - not a
+ * real error.
+ *
+ * <p>Root cause: {@link MetaDataOrdering#processQueue()} resolves the wiring order in 3 phases,
+ * the last being a "last ditch" phase that relaxes a multi-implementation dependency so that it
+ * is considered satisfied once ANY ONE implementation is wired, rather than ALL implementations.
+ * That relaxed ("anyWired") check used to be applied as a blanket flag to every still-queued bean
+ * in that phase - not scoped to only the specific provider list that actually had a permanently-
+ * unresolvable-under-strict-semantics member (the self-referencing ConnectionPool/ConnectionFactory
+ * pair). So once the decorator bean forced the algorithm to reach the last-ditch phase at all, a
+ * Consumer of a completely unrelated, otherwise-fully-resolvable multi-implementation interface
+ * (MyService, satisfied by profile-conditional CloudService/LocalService) could get wired as soon
+ * as ONE implementation (CloudService) was wired, even though the other implementation
+ * (LocalService) had not been wired yet - producing the reported wrong order: CloudService,
+ * Consumer, LocalService.
+ *
+ * <p>Fix: {@link MetaDataOrdering.ProviderList#isAllWired} / {@code isAnyWired} now exclude the
+ * bean being checked from its own "provides" requirement, so a decorator/wrapper bean resolves
+ * correctly in the normal strict rounds without ever needing the blanket last-ditch relaxation.
+ */
+class Issue1049Test {
+
+  @Test
+  @Disabled(
+      "Known separate/broader edge case NOT fixed by the self-exclusion change: a genuinely "
+          + "unresolvable OTHER bean (unrelated to any decorator/self-reference) still forces the "
+          + "blanket last-ditch (anyWired) round for the entire remaining queue, which can still "
+          + "leak leniency into unrelated multi-implementation interfaces. This differs from the "
+          + "actual #1049 trigger (a decorator bean depending on the interface it implements),"
+          + " which IS fixed - see realWorldDecoratorBeanTrigger below. Left here to document the"
+          + " remaining, more invasive fix needed (targeted per-provider-list relaxation instead"
+          + " of a blanket per-round flag) as potential follow-up work.")
+  void consumerOrderedBeforeAllInterfaceImplementations_whenUnrelatedBeanForcesLastDitchRound() {
+    // CloudService: no deps, provides MyService -- wired immediately (round 0 / noDepends)
+    var cloud = new MetaData("my.CloudService", null);
+    cloud.setProvides(List.of("my.MyService"));
+
+    // GateA: no deps, provides Gate -- wired immediately
+    var gateA = new MetaData("my.GateA", null);
+    gateA.setProvides(List.of("my.Gate"));
+
+    // GateB: depends on itself, so it can never be wired (permanently unresolved)
+    var gateB = new MetaData("my.GateB", null);
+    gateB.setProvides(List.of("my.Gate"));
+    gateB.setDependsOn(List.of("my.GateB"));
+
+    // LocalService: depends on "my.Gate" (satisfied only via ALL of [gateA, gateB] wired,
+    // which never happens under strict semantics because gateB can never wire)
+    var local = new MetaData("my.LocalService", null);
+    local.setProvides(List.of("my.MyService"));
+    local.setDependsOn(List.of("my.Gate"));
+
+    // Consumer: depends on "my.MyService" (provided by both cloud and local)
+    var consumer = new MetaData("my.Consumer", null);
+    consumer.setDependsOn(List.of("my.MyService"));
+
+    // Order beans so Consumer is queued/iterated BEFORE LocalService (matches real generator
+    // encounter order in the reported issue - see build_Consumer before build_LocalService)
+    var ordering = new MetaDataOrdering(List.of(cloud, gateA, gateB, consumer, local), new ScopeInfo());
+    ordering.processQueue();
+
+    var orderedTypes = ordering.ordered().stream().map(MetaData::type).collect(Collectors.toList());
+
+    int consumerIdx = orderedTypes.indexOf("my.Consumer");
+    int localIdx = orderedTypes.indexOf("my.LocalService");
+
+    // Expected: LocalService (an implementation Consumer depends on) must be wired
+    // BEFORE Consumer, regardless of unrelated beans elsewhere forcing a lenient last-ditch round.
+    assertThat(localIdx).isLessThan(consumerIdx);
+  }
+
+  @Test
+  void consumerOrderedBeforeAllInterfaceImplementations_realWorldDecoratorBeanTrigger() {
+    // Config: no deps -- wired immediately (analogous to the @Factory class itself)
+    var config = new MetaData("my.Config", null);
+
+    // FooA: the plain ConnectionFactory bean (Config.a()) - depends only on Config, provides Foo
+    var fooA = new MetaData("my.FooA", null);
+    fooA.setProvides(List.of("my.Foo"));
+    fooA.setDependsOn(List.of("my.Config"));
+
+    // FooWrapper: analogous to ConnectionPool, which implements ConnectionFactory (Foo) AND
+    // has a constructor dependency on a Foo (the one it wraps). It is therefore a member of
+    // its own required provider list for "Foo", which could never be "all wired" under strict
+    // semantics (it would require itself to already be wired).
+    var fooWrapper = new MetaData("my.FooWrapper", null);
+    fooWrapper.setProvides(List.of("my.Foo", "my.FooWrapper"));
+    fooWrapper.setDependsOn(List.of("my.Config", "my.Foo"));
+
+    // CloudService: no deps, provides MyService -- wired immediately
+    var cloud = new MetaData("my.CloudService", null);
+    cloud.setProvides(List.of("my.MyService"));
+
+    // LocalService: depends on FooWrapper (analogous to DbService depending on ConnectionPool),
+    // provides MyService
+    var local = new MetaData("my.LocalService", null);
+    local.setProvides(List.of("my.MyService"));
+    local.setDependsOn(List.of("my.FooWrapper"));
+
+    // Consumer: depends on MyService (provided by both cloud and local)
+    var consumer = new MetaData("my.Consumer", null);
+    consumer.setDependsOn(List.of("my.MyService"));
+
+    // Matches the real generator's encounter order: Config, Consumer, LocalService, CloudService,
+    // FooWrapper, FooA (roughly alphabetical local-class order, factory beans grouped near Config)
+    var ordering = new MetaDataOrdering(
+      List.of(config, consumer, local, cloud, fooWrapper, fooA), new ScopeInfo());
+    ordering.processQueue();
+
+    var orderedTypes = ordering.ordered().stream().map(MetaData::type).collect(Collectors.toList());
+
+    int consumerIdx = orderedTypes.indexOf("my.Consumer");
+    int localIdx = orderedTypes.indexOf("my.LocalService");
+
+    // Expected: LocalService must be wired before Consumer, matching the real bug report order
+    // build_reproducer_Consumer(builder) before build_reproducer_DbService(builder).
+    assertThat(localIdx).isLessThan(consumerIdx);
+  }
+
+  @Test
+  void directSelfDependency_stillDetectedAsCircular_notSilentlySatisfied() {
+    // A bean depending on its own exact type with no other implementation/provider must NOT be
+    // silently treated as "satisfied" by the self-exclusion fix - it should remain unwired so
+    // the normal circular dependency detection/reporting still applies. (Unresolved beans are
+    // still appended to ordered() at the end so generated code compiles, but never marked wired.)
+    var selfDependent = new MetaData("my.SelfDependent", null);
+    selfDependent.setDependsOn(List.of("my.SelfDependent"));
+
+    var ordering = new MetaDataOrdering(List.of(selfDependent), new ScopeInfo());
+    int remaining = ordering.processQueue();
+
+    assertThat(remaining).isEqualTo(1);
+    assertThat(selfDependent.isWired()).isFalse();
+  }
+}

--- a/inject-generator/src/test/java/io/avaje/inject/generator/MetaDataOrderingTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/MetaDataOrderingTest.java
@@ -27,6 +27,45 @@ class MetaDataOrderingTest {
     return providers.computeIfAbsent(key.replace(", ", ","), s -> new MetaDataOrdering.ProviderList());
   }
 
+  /**
+   * A bean that depends on a type it also provides (e.g. a connection pool that takes a connection
+   * factory and is itself a connection factory) must not block ordering. Prior to excluding the
+   * bean itself from the provider check it could only be wired via the last ditch "any wired"
+   * round, which allowed consumers of an interface to be ordered before other beans providing that
+   * interface. See https://github.com/avaje/avaje-inject/issues/1049
+   */
+  @Test
+  void ordering_beanProvidingTypeItDependsOn() {
+    var conn = new MetaData("my.Conn", null);
+
+    var pool = new MetaData("my.Pool", null);
+    pool.setProvides(List.of("my.Conn"));
+    pool.setDependsOn(List.of("my.Conn"));
+
+    var dbService = new MetaData("my.DbService", null);
+    dbService.setProvides(List.of("my.MyService"));
+    dbService.setDependsOn(List.of("my.Pool"));
+
+    var fileService = new MetaData("my.FileService", null);
+    fileService.setProvides(List.of("my.MyService"));
+
+    var consumer = new MetaData("my.Consumer", null);
+    consumer.setDependsOn(List.of("my.MyService"));
+
+    // consumer declared before dbService - the ordering must still delay it
+    var beans = List.of(conn, pool, fileService, consumer, dbService);
+    var ordering = new MetaDataOrdering(beans, new ScopeInfo());
+
+    assertThat(ordering.processQueue()).isZero();
+
+    var ordered = ordering.ordered();
+    assertThat(ordered.indexOf(conn)).isLessThan(ordered.indexOf(pool));
+    assertThat(ordered.indexOf(pool)).isLessThan(ordered.indexOf(dbService));
+    // every bean providing my.MyService is ordered before the consumer of my.MyService
+    assertThat(ordered.indexOf(dbService)).isLessThan(ordered.indexOf(consumer));
+    assertThat(ordered.indexOf(fileService)).isLessThan(ordered.indexOf(consumer));
+  }
+
   @Test
   void detectCycles_simple2NodeCycle() {
     // A depends on B, B depends on A

--- a/inject-generator/src/test/java/io/avaje/inject/generator/MetaDataOrderingTest.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/MetaDataOrderingTest.java
@@ -67,6 +67,20 @@ class MetaDataOrderingTest {
   }
 
   @Test
+  void detectCycles_directSelfDependency() {
+    // a bean depending on its own type is reported as a circular dependency rather than
+    // the misleading "No dependency provided"
+    var a = new MetaData("my.A", null);
+    a.setDependsOn(List.of("my.A"));
+
+    var providers = buildProviders(a);
+    var cycles = MetaDataOrdering.detectCycles(List.of(a), providers);
+
+    assertThat(cycles).hasSize(1);
+    assertThat(cycles.get(0)).containsExactly(a);
+  }
+
+  @Test
   void detectCycles_simple2NodeCycle() {
     // A depends on B, B depends on A
     var a = new MetaData("my.A", null);


### PR DESCRIPTION
 Resolves #1049 

  Profile was a red herring,  In the issue reproducer, `ConnectionPool` implemented `ConnectionFactory`, so
  factory method `b(ConnectionFactory a) ` was registered as a provider of `ConnectionFactory` (its own dependency) which messed up the ordering. 

- exclude the bean itself from its own provider-list check.