### PR TITLE
 Order Providers Ahead of Consumers in the Last Ditch Wiring Round

### DIFF
--- a/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/lastditch/Beatrice.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/lastditch/Beatrice.java
@@ -1,0 +1,14 @@
+package org.example.myapp.profileorder.lastditch;
+
+import io.avaje.inject.Profile;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Profile("paradiso")
+public class Beatrice implements Guide {
+
+  @Override
+  public String name() {
+    return "beatrice";
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/lastditch/Circle.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/lastditch/Circle.java
@@ -1,0 +1,3 @@
+package org.example.myapp.profileorder.lastditch;
+
+public interface Circle {}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/lastditch/Dante.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/lastditch/Dante.java
@@ -1,0 +1,18 @@
+package org.example.myapp.profileorder.lastditch;
+
+import jakarta.inject.Singleton;
+
+/** Needs a guide, and is declared before the only guide he can be given. */
+@Singleton
+public class Dante {
+
+  private final Guide guide;
+
+  public Dante(Guide guide) {
+    this.guide = guide;
+  }
+
+  public String guideName() {
+    return guide.name();
+  }
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/lastditch/Gluttony.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/lastditch/Gluttony.java
@@ -1,0 +1,13 @@
+package org.example.myapp.profileorder.lastditch;
+
+import jakarta.inject.Singleton;
+
+/**
+ * The third circle, also descending from the one above it. Two beans that both implement Circle and
+ * depend on Circle is what stalls the strict ordering rounds.
+ */
+@Singleton
+public class Gluttony implements Circle {
+
+  public Gluttony(Circle above) {}
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/lastditch/Guide.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/lastditch/Guide.java
@@ -1,0 +1,7 @@
+package org.example.myapp.profileorder.lastditch;
+
+/** Whoever leads Dante on this leg of the journey. */
+public interface Guide {
+
+  String name();
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/lastditch/Limbo.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/lastditch/Limbo.java
@@ -1,0 +1,9 @@
+package org.example.myapp.profileorder.lastditch;
+
+import io.avaje.inject.Primary;
+import jakarta.inject.Singleton;
+
+/** The first circle, so it descends from nothing. */
+@Primary
+@Singleton
+public class Limbo implements Circle {}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/lastditch/Lust.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/lastditch/Lust.java
@@ -1,0 +1,10 @@
+package org.example.myapp.profileorder.lastditch;
+
+import jakarta.inject.Singleton;
+
+/** The second circle, descending from the one above it. */
+@Singleton
+public class Lust implements Circle {
+
+  public Lust(Circle above) {}
+}

--- a/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/lastditch/Virgil.java
+++ b/blackbox-test-inject/src/main/java/org/example/myapp/profileorder/lastditch/Virgil.java
@@ -1,0 +1,16 @@
+package org.example.myapp.profileorder.lastditch;
+
+import io.avaje.inject.Profile;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Profile(none = "paradiso")
+public class Virgil implements Guide {
+
+  public Virgil(Circle circle) {}
+
+  @Override
+  public String name() {
+    return "virgil";
+  }
+}

--- a/blackbox-test-inject/src/test/java/org/example/myapp/lastditch/LastDitchOrderTest.java
+++ b/blackbox-test-inject/src/test/java/org/example/myapp/lastditch/LastDitchOrderTest.java
@@ -1,0 +1,27 @@
+package org.example.myapp.lastditch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.example.myapp.profileorder.lastditch.Dante;
+import org.junit.jupiter.api.Test;
+
+import io.avaje.inject.BeanScope;
+
+/**
+ * Lust and Gluttony both implement Circle and both depend on Circle, and two such beans over the
+ * same interface can not be wired by the strict rounds. The ordering therefore falls back to the
+ * last ditch round, which treats a dependency as satisfied once any one of the beans providing it
+ * is wired. That relaxation must not let Dante be ordered before Virgil, the only Guide active
+ * outside the paradiso profile.
+ *
+ * <p>See https://github.com/avaje/avaje-inject/issues/1049
+ */
+class LastDitchOrderTest {
+
+  @Test
+  void consumerWiredAfterAllImplementationsOfItsDependency() {
+    try (BeanScope beanScope = BeanScope.builder().build()) {
+      assertThat(beanScope.get(Dante.class).guideName()).isEqualTo("virgil");
+    }
+  }
+}

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
@@ -138,7 +138,7 @@ final class MetaDataOrdering {
 
   private int processQueueRound(boolean includeExternal, boolean anyWired) {
     if (anyWired) {
-      return processLastDitchRound(includeExternal);
+      return processLastDitchRound();
     }
     // loop queue looking for entry that has all provides marked as included
     int count = 0;
@@ -160,12 +160,12 @@ final class MetaDataOrdering {
    * wired. Collect everything the round makes ready and order the providers ahead of their
    * consumers.
    */
-  private int processLastDitchRound(boolean includeExternal) {
+  private int processLastDitchRound() {
     final var ready = new ArrayList<MetaData>();
     final var iterator = queue.iterator();
     while (iterator.hasNext()) {
       final var queuedMeta = iterator.next();
-      if (allDependenciesWired(queuedMeta, includeExternal, true)) {
+      if (allDependenciesWired(queuedMeta, true, true)) {
         ready.add(queuedMeta);
         iterator.remove();
       }

--- a/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
+++ b/inject-generator/src/main/java/io/avaje/inject/generator/MetaDataOrdering.java
@@ -137,12 +137,15 @@ final class MetaDataOrdering {
   }
 
   private int processQueueRound(boolean includeExternal, boolean anyWired) {
+    if (anyWired) {
+      return processLastDitchRound(includeExternal);
+    }
     // loop queue looking for entry that has all provides marked as included
     int count = 0;
-    Iterator<MetaData> iterator = queue.iterator();
+    final var iterator = queue.iterator();
     while (iterator.hasNext()) {
-      MetaData queuedMeta = iterator.next();
-      if (allDependenciesWired(queuedMeta, includeExternal, anyWired)) {
+      final var queuedMeta = iterator.next();
+      if (allDependenciesWired(queuedMeta, includeExternal, false)) {
         orderedList.add(queuedMeta);
         queuedMeta.setWired();
         iterator.remove();
@@ -150,6 +153,57 @@ final class MetaDataOrdering {
       }
     }
     return count;
+  }
+
+  /**
+   * The last ditch round treats a dependency as satisfied once any one of the beans providing it is
+   * wired. Collect everything the round makes ready and order the providers ahead of their
+   * consumers.
+   */
+  private int processLastDitchRound(boolean includeExternal) {
+    final var ready = new ArrayList<MetaData>();
+    final var iterator = queue.iterator();
+    while (iterator.hasNext()) {
+      final var queuedMeta = iterator.next();
+      if (allDependenciesWired(queuedMeta, includeExternal, true)) {
+        ready.add(queuedMeta);
+        iterator.remove();
+      }
+    }
+    for (var metaData : providersFirst(ready)) {
+      orderedList.add(metaData);
+      metaData.setWired();
+    }
+    return ready.size();
+  }
+
+  /**
+   * Return the given beans ordered such that any bean providing a dependency of another one in the
+   * list comes first. Beans that are part of a cycle keep their original relative order.
+   */
+  private List<MetaData> providersFirst(List<MetaData> ready) {
+    if (ready.size() < 2) {
+      return ready;
+    }
+    final var readySet = new HashSet<>(ready);
+    final var visiting = new HashSet<MetaData>();
+    final var result = new LinkedHashSet<MetaData>();
+    for (var bean : ready) {
+      addProvidersFirst(bean, readySet, visiting, result);
+    }
+    return new ArrayList<>(result);
+  }
+
+  private void addProvidersFirst(MetaData bean, Set<MetaData> readySet, Set<MetaData> visiting, Set<MetaData> result) {
+    if (result.contains(bean) || !visiting.add(bean)) {
+      // already ordered, or part of a cycle
+      return;
+    }
+    for (var provider : resolveQueuedDeps(bean, readySet, providers)) {
+      addProvidersFirst(provider, readySet, visiting, result);
+    }
+    visiting.remove(bean);
+    result.add(bean);
   }
 
   private boolean allDependenciesWired(MetaData queuedMeta, boolean includeExternal, boolean anyWired) {

--- a/inject-generator/src/test/java/io/avaje/inject/generator/Issue1049Test.java
+++ b/inject-generator/src/test/java/io/avaje/inject/generator/Issue1049Test.java
@@ -1,6 +1,5 @@
 package io.avaje.inject.generator;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -35,22 +34,16 @@ import static org.assertj.core.api.Assertions.assertThat;
  * (LocalService) had not been wired yet - producing the reported wrong order: CloudService,
  * Consumer, LocalService.
  *
- * <p>Fix: {@link MetaDataOrdering.ProviderList#isAllWired} / {@code isAnyWired} now exclude the
- * bean being checked from its own "provides" requirement, so a decorator/wrapper bean resolves
- * correctly in the normal strict rounds without ever needing the blanket last-ditch relaxation.
+ * <p>Fix, in two parts: {@link MetaDataOrdering.ProviderList#isAllWired} / {@code isAnyWired} now
+ * exclude the bean being checked from its own "provides" requirement, so a decorator/wrapper bean
+ * resolves correctly in the normal strict rounds without ever needing the blanket last-ditch
+ * relaxation. Additionally the last-ditch round now orders the beans it makes eligible such that
+ * providers come before their consumers, so any other bean that forces that round can no longer
+ * leak leniency into the ordering of an unrelated multi-implementation interface.
  */
 class Issue1049Test {
 
   @Test
-  @Disabled(
-      "Known separate/broader edge case NOT fixed by the self-exclusion change: a genuinely "
-          + "unresolvable OTHER bean (unrelated to any decorator/self-reference) still forces the "
-          + "blanket last-ditch (anyWired) round for the entire remaining queue, which can still "
-          + "leak leniency into unrelated multi-implementation interfaces. This differs from the "
-          + "actual #1049 trigger (a decorator bean depending on the interface it implements),"
-          + " which IS fixed - see realWorldDecoratorBeanTrigger below. Left here to document the"
-          + " remaining, more invasive fix needed (targeted per-provider-list relaxation instead"
-          + " of a blanket per-round flag) as potential follow-up work.")
   void consumerOrderedBeforeAllInterfaceImplementations_whenUnrelatedBeanForcesLastDitchRound() {
     // CloudService: no deps, provides MyService -- wired immediately (round 0 / noDepends)
     var cloud = new MetaData("my.CloudService", null);


### PR DESCRIPTION
 Follow-up to #1050, closing the gap Rob flagged there. 

The last ditch round now collects everything it makes ready, then orders that set so any bean providing a dependency of another comes first (`providersFirst`, a DFS over the existing `resolveQueuedDeps` provider graph). Beans in a cycle keep their original relative order.