### PR TITLE
AutoProvidesMojo: warn and skip unresolvable InjectExtension entries

### DIFF
--- a/inject-gradle-plugin/build.gradle
+++ b/inject-gradle-plugin/build.gradle
@@ -18,6 +18,7 @@ dependencies {
   implementation gradleApi()
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+  testImplementation 'org.assertj:assertj-core:3.27.6'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 }
 

--- a/inject-gradle-plugin/src/main/java/io/avaje/inject/plugin/AvajeInjectPlugin.java
+++ b/inject-gradle-plugin/src/main/java/io/avaje/inject/plugin/AvajeInjectPlugin.java
@@ -1,5 +1,6 @@
 package io.avaje.inject.plugin;
 
+import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.toList;
 
 import io.avaje.inject.spi.AvajeModule;
@@ -11,20 +12,25 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.GradleException;
 import org.gradle.api.tasks.bundling.Jar;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.*;
-import java.util.ServiceLoader.Provider;
 
 /**
  * Plugin that discovers external avaje inject modules and plugins.
  */
 public class AvajeInjectPlugin implements org.gradle.api.Plugin<Project> {
+
+  private static final String SERVICES_FILE = "META-INF/services/" + InjectExtension.class.getName();
 
   private final List<ModuleData> modules = new ArrayList<>();
 
@@ -70,24 +76,74 @@ public class AvajeInjectPlugin implements org.gradle.api.Plugin<Project> {
     try (var classLoader = classLoader(project);
         var pluginWriter = createFileWriter(outputDir.getPath(), "avaje-plugins.csv");
         var moduleCSV = createFileWriter(outputDir.getPath(), "avaje-module-dependencies.csv")) {
-      writeProvidedPlugins(classLoader, pluginWriter);
-      writeModuleCSV(classLoader, moduleCSV);
+      final var extensions = loadExtensions(classLoader);
+      writeProvidedPlugins(extensions, pluginWriter);
+      writeModuleCSV(extensions, moduleCSV);
     } catch (IOException e) {
       throw new GradleException("Failed to write avaje-module-provides", e);
     }
+  }
+
+  /**
+   * Load the {@link InjectExtension} services declared on the given classloader, skipping any entry
+   * whose class is not resolvable.
+   */
+  static List<InjectExtension> loadExtensions(ClassLoader classLoader) throws IOException {
+    return declaredExtensions(classLoader).entrySet().stream()
+        .map(declared -> loadExtension(declared.getKey(), declared.getValue(), classLoader))
+        .flatMap(Optional::stream)
+        .collect(toList());
+  }
+
+  private static Optional<InjectExtension> loadExtension(String className, String declaredIn, ClassLoader classLoader) {
+    try {
+      return Optional.of(Class.forName(className, false, classLoader)
+          .asSubclass(InjectExtension.class)
+          .getDeclaredConstructor()
+          .newInstance());
+    } catch (Throwable e) {
+      System.err.println("Skipping InjectExtension " + className + " declared in " + declaredIn
+          + " - not loadable from the compile classpath: " + e);
+      return Optional.empty();
+    }
+  }
+
+  /** Declared service entries, in classpath order, mapped to the services file(s) declaring them. */
+  private static Map<String, String> declaredExtensions(ClassLoader classLoader) throws IOException {
+    final Map<String, String> declared = new LinkedHashMap<>();
+    for (final URL resource : Collections.list(classLoader.getResources(SERVICES_FILE))) {
+      for (final String className : readServiceEntries(resource)) {
+        declared.merge(className, resource.toString(), (first, next) -> first + ", " + next);
+      }
+    }
+    return declared;
+  }
+
+  private static List<String> readServiceEntries(URL resource) throws IOException {
+    try (var reader = new BufferedReader(new InputStreamReader(resource.openStream(), StandardCharsets.UTF_8))) {
+      return reader.lines()
+          .map(AvajeInjectPlugin::stripComment)
+          .filter(not(String::isEmpty))
+          .collect(toList());
+    } catch (UncheckedIOException e) {
+      throw e.getCause();
+    }
+  }
+
+  private static String stripComment(String line) {
+    final int comment = line.indexOf('#');
+    return (comment < 0 ? line : line.substring(0, comment)).trim();
   }
 
   private FileWriter createFileWriter(String dir, String file) throws IOException {
     return new FileWriter(new File(dir, file));
   }
 
-  private void writeProvidedPlugins(ClassLoader classLoader, FileWriter pluginWriter) throws IOException {
-    final List<InjectPlugin> plugins = new ArrayList<>();
-    ServiceLoader.load(InjectExtension.class, classLoader).stream()
-        .map(Provider::get)
+  private void writeProvidedPlugins(List<InjectExtension> extensions, FileWriter pluginWriter) throws IOException {
+    final List<InjectPlugin> plugins = extensions.stream()
         .filter(InjectPlugin.class::isInstance)
         .map(InjectPlugin.class::cast)
-        .forEach(plugins::add);
+        .collect(toList());
 
     final Map<String, List<String>> pluginEntries = new HashMap<>();
     for (final var plugin : plugins) {
@@ -148,14 +204,12 @@ public class AvajeInjectPlugin implements org.gradle.api.Plugin<Project> {
     }
   }
 
-  private void writeModuleCSV(ClassLoader classLoader, FileWriter moduleWriter) throws IOException {
+  private void writeModuleCSV(List<InjectExtension> extensions, FileWriter moduleWriter) throws IOException {
 
-    final List<AvajeModule> avajeModules = new ArrayList<>();
-    ServiceLoader.load(InjectExtension.class, classLoader).stream()
-        .map(Provider::get)
+    final List<AvajeModule> avajeModules = extensions.stream()
         .filter(AvajeModule.class::isInstance)
         .map(AvajeModule.class::cast)
-        .forEach(avajeModules::add);
+        .collect(toList());
 
     for (final var module : avajeModules) {
       final var name = module.getClass().getTypeName();

--- a/inject-gradle-plugin/src/test/java/io/avaje/inject/plugin/AvajeInjectPluginTest.java
+++ b/inject-gradle-plugin/src/test/java/io/avaje/inject/plugin/AvajeInjectPluginTest.java
@@ -1,4 +1,4 @@
-package io.avaje.inject.mojo;
+package io.avaje.inject.plugin;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -6,16 +6,14 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.avaje.inject.spi.InjectExtension;
 
-class AutoProvidesMojoTest {
+class AvajeInjectPluginTest {
 
   public static class TestExtension implements InjectExtension {}
 
@@ -37,25 +35,9 @@ class AutoProvidesMojoTest {
         "does.not.Exist",
         OtherTestExtension.class.getName() + " # trailing comment")) {
 
-      final var extensions = new AutoProvidesMojo().loadExtensions(classLoader);
-
-      assertThat(extensions).hasExactlyElementsOfTypes(TestExtension.class, OtherTestExtension.class);
+      assertThat(AvajeInjectPlugin.loadExtensions(classLoader))
+        .hasExactlyElementsOfTypes(TestExtension.class, OtherTestExtension.class);
     }
-  }
-
-  @Test
-  void loadExtensions_warnsNamingTheDeclaringServicesFile(@TempDir Path dir) throws Exception {
-    final var mojo = new AutoProvidesMojo();
-    final var warnings = capturingLog(mojo);
-
-    try (var classLoader = classLoaderWithServices(dir, getClass().getClassLoader(), "does.not.Exist")) {
-      mojo.loadExtensions(classLoader);
-    }
-
-    assertThat(warnings).hasSize(1);
-    assertThat(warnings.get(0))
-      .contains("does.not.Exist")
-      .contains("META-INF/services/" + InjectExtension.class.getName());
   }
 
   @Test
@@ -64,51 +46,30 @@ class AutoProvidesMojoTest {
         "does.not.Exist",
         "also.does.not.Exist")) {
 
-      assertThat(new AutoProvidesMojo().loadExtensions(classLoader)).isEmpty();
+      assertThat(AvajeInjectPlugin.loadExtensions(classLoader)).isEmpty();
     }
   }
 
   @Test
   void loadExtensions_skipsProviderThatIsNotASubtype(@TempDir Path dir) throws Exception {
-    final var mojo = new AutoProvidesMojo();
-    final var warnings = capturingLog(mojo);
-
     try (var classLoader = classLoaderWithServices(dir, getClass().getClassLoader(),
         NotAnExtension.class.getName(),
         TestExtension.class.getName())) {
 
-      assertThat(mojo.loadExtensions(classLoader)).hasExactlyElementsOfTypes(TestExtension.class);
+      assertThat(AvajeInjectPlugin.loadExtensions(classLoader))
+        .hasExactlyElementsOfTypes(TestExtension.class);
     }
-
-    assertThat(warnings).hasSize(1);
-    assertThat(warnings.get(0)).contains(NotAnExtension.class.getName());
   }
 
   @Test
   void loadExtensions_skipsProviderWhoseConstructorThrows(@TempDir Path dir) throws Exception {
-    final var mojo = new AutoProvidesMojo();
-    final var warnings = capturingLog(mojo);
-
     try (var classLoader = classLoaderWithServices(dir, getClass().getClassLoader(),
         BrokenExtension.class.getName(),
         TestExtension.class.getName())) {
 
-      assertThat(mojo.loadExtensions(classLoader)).hasExactlyElementsOfTypes(TestExtension.class);
+      assertThat(AvajeInjectPlugin.loadExtensions(classLoader))
+        .hasExactlyElementsOfTypes(TestExtension.class);
     }
-
-    assertThat(warnings).hasSize(1);
-    assertThat(warnings.get(0)).contains(BrokenExtension.class.getName());
-  }
-
-  private List<String> capturingLog(AutoProvidesMojo mojo) {
-    final List<String> warnings = new ArrayList<>();
-    mojo.setLog(new SystemStreamLog() {
-      @Override
-      public void warn(CharSequence content) {
-        warnings.add(content.toString());
-      }
-    });
-    return warnings;
   }
 
   private URLClassLoader classLoaderWithServices(Path dir, ClassLoader parent, String... lines) throws Exception {

--- a/inject-maven-plugin/pom.xml
+++ b/inject-maven-plugin/pom.xml
@@ -30,6 +30,13 @@
       <artifactId>avaje-inject</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.8</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
+++ b/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
@@ -1,5 +1,6 @@
 package io.avaje.inject.mojo;
 
+import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.toList;
 
 import java.io.BufferedReader;
@@ -7,6 +8,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -15,14 +17,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.ServiceConfigurationError;
-import java.util.ServiceLoader;
-import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
@@ -55,7 +53,7 @@ import io.avaje.inject.spi.PluginProvides;
     threadSafe = true)
 public class AutoProvidesMojo extends AbstractMojo {
 
-  private static final int MAX_SKIPPED = 10_000;
+  private static final String SERVICES_FILE = "META-INF/services/" + InjectExtension.class.getName();
 
   @Parameter(defaultValue = "${project}", readonly = true, required = true)
   private MavenProject project;
@@ -82,90 +80,68 @@ public class AutoProvidesMojo extends AbstractMojo {
     }
   }
 
-  List<InjectExtension> loadExtensions(URLClassLoader classLoader) throws IOException {
-    final Set<String> loadedNames = new HashSet<>();
-    final List<InjectExtension> extensions = new ArrayList<>();
-    final List<ServiceConfigurationError> skipped = new ArrayList<>();
-    // a services entry can name a class from a dependency that is not resolvable at compile
-    // scope (test-scoped, optional, or excluded); such a module is not a compile-time concern
-    // for this project, so skip it rather than failing the build. The JDK iterator does not
-    // retry an entry that failed, so catching the per-element error resumes with the next
-    // entry. A provider class that is present but broken still fails the build.
-    final var providers = ServiceLoader.load(InjectExtension.class, classLoader).stream().iterator();
-    while (true) {
-      try {
-        if (!providers.hasNext()) {
-          break;
-        }
-        final var provider = providers.next();
-        extensions.add(provider.get());
-        loadedNames.add(provider.type().getTypeName());
-      } catch (final ServiceConfigurationError e) {
-        if (!missingClass(e) || skipped.size() >= MAX_SKIPPED) {
-          throw e;
-        }
-        skipped.add(e);
-      }
+  /**
+   * Load the {@link InjectExtension} services declared on the given classloader, skipping any entry
+   * whose class is not resolvable.
+   */
+  List<InjectExtension> loadExtensions(ClassLoader classLoader) throws IOException {
+    return declaredExtensions(classLoader).entrySet().stream()
+        .map(declared -> loadExtension(declared.getKey(), declared.getValue(), classLoader))
+        .flatMap(Optional::stream)
+        .collect(toList());
+  }
+
+  private Optional<InjectExtension> loadExtension(
+      String className, String declaredIn, ClassLoader classLoader) {
+    try {
+      return Optional.of(
+          Class.forName(className, false, classLoader)
+              .asSubclass(InjectExtension.class)
+              .getDeclaredConstructor()
+              .newInstance());
+    } catch (final Throwable e) {
+      getLog()
+          .warn(
+              "Skipping InjectExtension "
+                  + className
+                  + " declared in "
+                  + declaredIn
+                  + " - not loadable from the compile-scope classpath: "
+                  + e);
+      return Optional.empty();
     }
-    if (!skipped.isEmpty()) {
-      warnSkipped(classLoader, loadedNames, skipped);
-    }
-    return extensions;
   }
 
   /**
-   * True when the entry failed because its class is missing rather than present but broken.
+   * Declared service entries, in classpath order, mapped to the services file(s) declaring them.
    */
-  private static boolean missingClass(ServiceConfigurationError error) {
-    for (Throwable cause = error.getCause(); cause != null; cause = cause.getCause()) {
-      if (cause instanceof ClassNotFoundException || cause instanceof NoClassDefFoundError) {
-        return true;
-      }
-    }
-    // the JDK reports an unresolvable provider class without a cause
-    return error.getCause() == null && String.valueOf(error.getMessage()).endsWith(" not found");
-  }
-
-  private void warnSkipped(URLClassLoader classLoader, Set<String> loadedNames, List<ServiceConfigurationError> skipped) throws IOException {
-    for (final var declared : declaredExtensions(classLoader).entrySet()) {
-      final String className = declared.getKey();
-      if (loadedNames.contains(className)) {
-        continue;
-      }
-      final String message = "Skipped InjectExtension " + className + " declared in " + declared.getValue()
-        + " - not loadable from the compile-scope classpath";
-      final var error = skipped.stream()
-        .filter(e -> String.valueOf(e.getMessage()).contains(className))
-        .findFirst();
-      final Throwable cause = error.map(Throwable::getCause).orElse(null);
-      if (cause != null && !(cause instanceof ClassNotFoundException)) {
-        getLog().warn(message, error.get());
-      } else {
-        getLog().warn(error.map(e -> message + ": " + e).orElse(message));
-      }
-    }
-  }
-
-  private Map<String, List<URL>> declaredExtensions(URLClassLoader classLoader) throws IOException {
-    final Map<String, List<URL>> declared = new LinkedHashMap<>();
-    final var resources = classLoader.getResources("META-INF/services/" + InjectExtension.class.getName());
-    while (resources.hasMoreElements()) {
-      final URL resource = resources.nextElement();
-      try (var reader = new BufferedReader(new InputStreamReader(resource.openStream(), StandardCharsets.UTF_8))) {
-        String line;
-        while ((line = reader.readLine()) != null) {
-          final int comment = line.indexOf('#');
-          if (comment >= 0) {
-            line = line.substring(0, comment);
-          }
-          line = line.trim();
-          if (!line.isEmpty()) {
-            declared.computeIfAbsent(line, key -> new ArrayList<>()).add(resource);
-          }
-        }
+  private static Map<String, String> declaredExtensions(ClassLoader classLoader)
+      throws IOException {
+    final Map<String, String> declared = new LinkedHashMap<>();
+    for (final URL resource : Collections.list(classLoader.getResources(SERVICES_FILE))) {
+      for (final String className : readServiceEntries(resource)) {
+        declared.merge(className, resource.toString(), (first, next) -> first + ", " + next);
       }
     }
     return declared;
+  }
+
+  private static List<String> readServiceEntries(URL resource) throws IOException {
+    try (var reader =
+        new BufferedReader(new InputStreamReader(resource.openStream(), StandardCharsets.UTF_8))) {
+      return reader
+          .lines()
+          .map(AutoProvidesMojo::stripComment)
+          .filter(not(String::isEmpty))
+          .collect(toList());
+    } catch (final UncheckedIOException e) {
+      throw e.getCause();
+    }
+  }
+
+  private static String stripComment(String line) {
+    final int comment = line.indexOf('#');
+    return (comment < 0 ? line : line.substring(0, comment)).trim();
   }
 
   private List<URL> compileDependencies() throws MojoExecutionException {
@@ -192,11 +168,10 @@ public class AutoProvidesMojo extends AbstractMojo {
   private void writeProvidedPlugins(List<InjectExtension> extensions, FileWriter pluginWriter) throws IOException {
     final Log log = getLog();
 
-    final List<InjectPlugin> plugins = new ArrayList<>();
-    extensions.stream()
+    final List<InjectPlugin> plugins = extensions.stream()
         .filter(InjectPlugin.class::isInstance)
         .map(InjectPlugin.class::cast)
-        .forEach(plugins::add);
+        .collect(toList());
 
     final Map<String, List<String>> pluginEntries = new HashMap<>();
     for (final var plugin : plugins) {
@@ -235,11 +210,10 @@ public class AutoProvidesMojo extends AbstractMojo {
 
   private void writeModuleCSV(List<InjectExtension> extensions, FileWriter moduleWriter) throws IOException {
     final Log log = getLog();
-    final List<AvajeModule> avajeModules = new ArrayList<>();
-    extensions.stream()
+    final List<AvajeModule> avajeModules = extensions.stream()
         .filter(AvajeModule.class::isInstance)
         .map(AvajeModule.class::cast)
-        .forEach(avajeModules::add);
+        .collect(toList());
 
     List<ModuleData> modules = new ArrayList<>();
     for (final var module : avajeModules) {

--- a/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
+++ b/inject-maven-plugin/src/main/java/io/avaje/inject/mojo/AutoProvidesMojo.java
@@ -2,21 +2,27 @@ package io.avaje.inject.mojo;
 
 import static java.util.stream.Collectors.toList;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
-import java.util.ServiceLoader.Provider;
+import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
@@ -49,6 +55,8 @@ import io.avaje.inject.spi.PluginProvides;
     threadSafe = true)
 public class AutoProvidesMojo extends AbstractMojo {
 
+  private static final int MAX_SKIPPED = 10_000;
+
   @Parameter(defaultValue = "${project}", readonly = true, required = true)
   private MavenProject project;
 
@@ -65,12 +73,99 @@ public class AutoProvidesMojo extends AbstractMojo {
         var pluginWriter = createFileWriter("avaje-plugins.csv");
         var moduleCSV = createFileWriter("avaje-module-dependencies.csv")) {
 
-      writeProvidedPlugins(newClassLoader, pluginWriter);
-      writeModuleCSV(newClassLoader, moduleCSV);
+      final var extensions = loadExtensions(newClassLoader);
+      writeProvidedPlugins(extensions, pluginWriter);
+      writeModuleCSV(extensions, moduleCSV);
 
     } catch (final IOException e) {
       throw new MojoExecutionException("Failed to write spi classes", e);
     }
+  }
+
+  List<InjectExtension> loadExtensions(URLClassLoader classLoader) throws IOException {
+    final Set<String> loadedNames = new HashSet<>();
+    final List<InjectExtension> extensions = new ArrayList<>();
+    final List<ServiceConfigurationError> skipped = new ArrayList<>();
+    // a services entry can name a class from a dependency that is not resolvable at compile
+    // scope (test-scoped, optional, or excluded); such a module is not a compile-time concern
+    // for this project, so skip it rather than failing the build. The JDK iterator does not
+    // retry an entry that failed, so catching the per-element error resumes with the next
+    // entry. A provider class that is present but broken still fails the build.
+    final var providers = ServiceLoader.load(InjectExtension.class, classLoader).stream().iterator();
+    while (true) {
+      try {
+        if (!providers.hasNext()) {
+          break;
+        }
+        final var provider = providers.next();
+        extensions.add(provider.get());
+        loadedNames.add(provider.type().getTypeName());
+      } catch (final ServiceConfigurationError e) {
+        if (!missingClass(e) || skipped.size() >= MAX_SKIPPED) {
+          throw e;
+        }
+        skipped.add(e);
+      }
+    }
+    if (!skipped.isEmpty()) {
+      warnSkipped(classLoader, loadedNames, skipped);
+    }
+    return extensions;
+  }
+
+  /**
+   * True when the entry failed because its class is missing rather than present but broken.
+   */
+  private static boolean missingClass(ServiceConfigurationError error) {
+    for (Throwable cause = error.getCause(); cause != null; cause = cause.getCause()) {
+      if (cause instanceof ClassNotFoundException || cause instanceof NoClassDefFoundError) {
+        return true;
+      }
+    }
+    // the JDK reports an unresolvable provider class without a cause
+    return error.getCause() == null && String.valueOf(error.getMessage()).endsWith(" not found");
+  }
+
+  private void warnSkipped(URLClassLoader classLoader, Set<String> loadedNames, List<ServiceConfigurationError> skipped) throws IOException {
+    for (final var declared : declaredExtensions(classLoader).entrySet()) {
+      final String className = declared.getKey();
+      if (loadedNames.contains(className)) {
+        continue;
+      }
+      final String message = "Skipped InjectExtension " + className + " declared in " + declared.getValue()
+        + " - not loadable from the compile-scope classpath";
+      final var error = skipped.stream()
+        .filter(e -> String.valueOf(e.getMessage()).contains(className))
+        .findFirst();
+      final Throwable cause = error.map(Throwable::getCause).orElse(null);
+      if (cause != null && !(cause instanceof ClassNotFoundException)) {
+        getLog().warn(message, error.get());
+      } else {
+        getLog().warn(error.map(e -> message + ": " + e).orElse(message));
+      }
+    }
+  }
+
+  private Map<String, List<URL>> declaredExtensions(URLClassLoader classLoader) throws IOException {
+    final Map<String, List<URL>> declared = new LinkedHashMap<>();
+    final var resources = classLoader.getResources("META-INF/services/" + InjectExtension.class.getName());
+    while (resources.hasMoreElements()) {
+      final URL resource = resources.nextElement();
+      try (var reader = new BufferedReader(new InputStreamReader(resource.openStream(), StandardCharsets.UTF_8))) {
+        String line;
+        while ((line = reader.readLine()) != null) {
+          final int comment = line.indexOf('#');
+          if (comment >= 0) {
+            line = line.substring(0, comment);
+          }
+          line = line.trim();
+          if (!line.isEmpty()) {
+            declared.computeIfAbsent(line, key -> new ArrayList<>()).add(resource);
+          }
+        }
+      }
+    }
+    return declared;
   }
 
   private List<URL> compileDependencies() throws MojoExecutionException {
@@ -94,12 +189,11 @@ public class AutoProvidesMojo extends AbstractMojo {
     return new FileWriter(new File(project.getBuild().getDirectory(), string));
   }
 
-  private void writeProvidedPlugins(URLClassLoader newClassLoader, FileWriter pluginWriter) throws IOException {
+  private void writeProvidedPlugins(List<InjectExtension> extensions, FileWriter pluginWriter) throws IOException {
     final Log log = getLog();
 
     final List<InjectPlugin> plugins = new ArrayList<>();
-    ServiceLoader.load(InjectExtension.class, newClassLoader).stream()
-        .map(Provider::get)
+    extensions.stream()
         .filter(InjectPlugin.class::isInstance)
         .map(InjectPlugin.class::cast)
         .forEach(plugins::add);
@@ -139,11 +233,10 @@ public class AutoProvidesMojo extends AbstractMojo {
     }
   }
 
-  private void writeModuleCSV(ClassLoader newClassLoader, FileWriter moduleWriter) throws IOException {
+  private void writeModuleCSV(List<InjectExtension> extensions, FileWriter moduleWriter) throws IOException {
     final Log log = getLog();
     final List<AvajeModule> avajeModules = new ArrayList<>();
-    ServiceLoader.load(InjectExtension.class, newClassLoader).stream()
-        .map(Provider::get)
+    extensions.stream()
         .filter(AvajeModule.class::isInstance)
         .map(AvajeModule.class::cast)
         .forEach(avajeModules::add);

--- a/inject-maven-plugin/src/test/java/io/avaje/inject/mojo/AutoProvidesMojoTest.java
+++ b/inject-maven-plugin/src/test/java/io/avaje/inject/mojo/AutoProvidesMojoTest.java
@@ -1,0 +1,82 @@
+package io.avaje.inject.mojo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.ServiceConfigurationError;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.avaje.inject.spi.InjectExtension;
+
+class AutoProvidesMojoTest {
+
+  public static class TestExtension implements InjectExtension {}
+
+  public static class OtherTestExtension implements InjectExtension {}
+
+  public static class NotAnExtension {}
+
+  public static class BrokenExtension implements InjectExtension {
+    public BrokenExtension() {
+      throw new IllegalStateException("broken provider");
+    }
+  }
+
+  @Test
+  void loadExtensions_resumesAfterUnresolvableEntry(@TempDir Path dir) throws Exception {
+    try (var classLoader = classLoaderWithServices(dir, getClass().getClassLoader(),
+        "# comment",
+        TestExtension.class.getName(),
+        "does.not.Exist",
+        OtherTestExtension.class.getName())) {
+
+      final var extensions = new AutoProvidesMojo().loadExtensions(classLoader);
+
+      assertEquals(1, extensions.stream().filter(TestExtension.class::isInstance).count());
+      assertEquals(1, extensions.stream().filter(OtherTestExtension.class::isInstance).count());
+    }
+  }
+
+  @Test
+  void loadExtensions_returnsEmptyWhenNoEntryLoads(@TempDir Path dir) throws Exception {
+    try (var classLoader = classLoaderWithServices(dir, ClassLoader.getPlatformClassLoader(),
+        "does.not.Exist",
+        "also.does.not.Exist")) {
+
+      assertTrue(new AutoProvidesMojo().loadExtensions(classLoader).isEmpty());
+    }
+  }
+
+  @Test
+  void loadExtensions_failsWhenProviderIsNotASubtype(@TempDir Path dir) throws Exception {
+    try (var classLoader = classLoaderWithServices(dir, getClass().getClassLoader(),
+        NotAnExtension.class.getName())) {
+
+      assertThrows(ServiceConfigurationError.class, () -> new AutoProvidesMojo().loadExtensions(classLoader));
+    }
+  }
+
+  @Test
+  void loadExtensions_failsWhenProviderConstructorThrows(@TempDir Path dir) throws Exception {
+    try (var classLoader = classLoaderWithServices(dir, getClass().getClassLoader(),
+        BrokenExtension.class.getName())) {
+
+      assertThrows(ServiceConfigurationError.class, () -> new AutoProvidesMojo().loadExtensions(classLoader));
+    }
+  }
+
+  private URLClassLoader classLoaderWithServices(Path dir, ClassLoader parent, String... lines) throws Exception {
+    final Path services = dir.resolve("META-INF/services/" + InjectExtension.class.getName());
+    Files.createDirectories(services.getParent());
+    Files.write(services, List.of(lines));
+    return new URLClassLoader(new URL[]{dir.toUri().toURL()}, parent);
+  }
+}


### PR DESCRIPTION
Since the generated services files also list the modules of upstream dependencies, an entry can name a class that is not resolvable on the compile-scope classpath (an optional, test-scoped, or excluded dependency). The ServiceLoader iteration then threw an uncaught ServiceConfigurationError that named neither the declaring jar nor the reason the class was unresolvable, and failed the build.

Iterate the ServiceLoader stream catching the per-element error, which skips just the unloadable entry; such a module is not a compile-time concern for the project being built. A separate scan of the services resources is used only to name, in the warning, the services file that declares each skipped entry. The extensions are loaded once and shared by the plugin and module CSV writers.