### PR TITLE
blackbox-conditional-provider-order: repro for conditional in-module provider suppressing the requires edge

### DIFF
--- a/blackbox-conditional-provider-order/api/pom.xml
+++ b/blackbox-conditional-provider-order/api/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>blackbox-conditional-provider-order</artifactId>
+    <groupId>io.avaje</groupId>
+    <version>12.7-RC2</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>blackbox-conditional-provider-order-api</artifactId>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-inject</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/blackbox-conditional-provider-order/api/src/main/java/org/example/condorder/api/Greeting.java
+++ b/blackbox-conditional-provider-order/api/src/main/java/org/example/condorder/api/Greeting.java
@@ -1,0 +1,5 @@
+package org.example.condorder.api;
+
+public interface Greeting {
+  String hello();
+}

--- a/blackbox-conditional-provider-order/m1/pom.xml
+++ b/blackbox-conditional-provider-order/m1/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>blackbox-conditional-provider-order</artifactId>
+    <groupId>io.avaje</groupId>
+    <version>12.7-RC2</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>blackbox-conditional-provider-order-m1</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>blackbox-conditional-provider-order-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-inject</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.avaje</groupId>
+              <artifactId>avaje-inject-generator</artifactId>
+              <version>${project.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>io.avaje</groupId>
+        <artifactId>avaje-inject-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <?m2e execute?>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>provides</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/blackbox-conditional-provider-order/m1/src/main/java/org/example/condorder/m1/AppGreeting.java
+++ b/blackbox-conditional-provider-order/m1/src/main/java/org/example/condorder/m1/AppGreeting.java
@@ -1,0 +1,14 @@
+package org.example.condorder.m1;
+
+import io.avaje.inject.RequiresProperty;
+import jakarta.inject.Singleton;
+import org.example.condorder.api.Greeting;
+
+@Singleton
+@RequiresProperty(value = "greet.mode", equalTo = "app")
+public class AppGreeting implements Greeting {
+  @Override
+  public String hello() {
+    return "app";
+  }
+}

--- a/blackbox-conditional-provider-order/m1/src/main/java/org/example/condorder/m1/Reader.java
+++ b/blackbox-conditional-provider-order/m1/src/main/java/org/example/condorder/m1/Reader.java
@@ -1,0 +1,17 @@
+package org.example.condorder.m1;
+
+import jakarta.inject.Singleton;
+import org.example.condorder.api.Greeting;
+
+@Singleton
+public class Reader {
+  public final Greeting greeting;
+
+  Reader(Greeting greeting) {
+    this.greeting = greeting;
+  }
+
+  public String read() {
+    return greeting.hello();
+  }
+}

--- a/blackbox-conditional-provider-order/m2/pom.xml
+++ b/blackbox-conditional-provider-order/m2/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>blackbox-conditional-provider-order</artifactId>
+    <groupId>io.avaje</groupId>
+    <version>12.7-RC2</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>blackbox-conditional-provider-order-m2</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>blackbox-conditional-provider-order-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-inject</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.avaje</groupId>
+              <artifactId>avaje-inject-generator</artifactId>
+              <version>${project.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>io.avaje</groupId>
+        <artifactId>avaje-inject-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <?m2e execute?>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>provides</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/blackbox-conditional-provider-order/m2/src/main/java/org/example/condorder/m2/AltGreeting.java
+++ b/blackbox-conditional-provider-order/m2/src/main/java/org/example/condorder/m2/AltGreeting.java
@@ -1,0 +1,14 @@
+package org.example.condorder.m2;
+
+import io.avaje.inject.RequiresProperty;
+import jakarta.inject.Singleton;
+import org.example.condorder.api.Greeting;
+
+@Singleton
+@RequiresProperty(value = "greet.mode", equalTo = "alt")
+public class AltGreeting implements Greeting {
+  @Override
+  public String hello() {
+    return "alt";
+  }
+}

--- a/blackbox-conditional-provider-order/pom.xml
+++ b/blackbox-conditional-provider-order/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>avaje-inject-parent</artifactId>
+    <groupId>io.avaje</groupId>
+    <version>12.7-RC2</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>blackbox-conditional-provider-order</artifactId>
+  <packaging>pom</packaging>
+
+  <description>
+    Reproduces silent bean loss when a conditional bean is the only in-module provider of a
+    type another bean in the same module consumes. m1's AppGreeting (@RequiresProperty
+    greet.mode=app) provides Greeting, so m1's Reader (which injects Greeting) is satisfied
+    in-module at compile time: M1Module emits no requiresBeans/softRequiresBeans entry for
+    Greeting, while its providesBeans claims Greeting unconditionally. At runtime with
+    greet.mode=alt the claim is false and the real provider is m2's AltGreeting, but no
+    ordering edge exists between m1 and m2, so with m1 first (explicit module list or
+    classpath order) Reader fails with "Injecting null for Greeting". Reversing the order
+    wires correctly. A consumer in a separate module with a declared
+    @InjectModule(requires = Greeting.class) orders correctly past multiple conditional
+    claimants, so the defect is specifically the suppressed requirement, not conditional
+    multi-provider resolution.
+  </description>
+
+  <modules>
+    <module>api</module>
+    <module>m1</module>
+    <module>m2</module>
+    <module>tests</module>
+  </modules>
+</project>

--- a/blackbox-conditional-provider-order/tests/pom.xml
+++ b/blackbox-conditional-provider-order/tests/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>blackbox-conditional-provider-order</artifactId>
+    <groupId>io.avaje</groupId>
+    <version>12.7-RC2</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>blackbox-conditional-provider-order-tests</artifactId>
+
+  <dependencies>
+    <!-- m1 (conditional self-provider + consumer) deliberately precedes m2 (the
+         alternative provider) so classpath discovery order matches the explicit-list
+         failing order -->
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>blackbox-conditional-provider-order-m1</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>blackbox-conditional-provider-order-m2</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-inject</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.8</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/blackbox-conditional-provider-order/tests/src/test/java/org/example/condorder/ConditionalProviderOrderTest.java
+++ b/blackbox-conditional-provider-order/tests/src/test/java/org/example/condorder/ConditionalProviderOrderTest.java
@@ -1,0 +1,53 @@
+package org.example.condorder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.avaje.inject.BeanScope;
+import org.example.condorder.m1.M1Module;
+import org.example.condorder.m1.Reader;
+import org.example.condorder.m2.M2Module;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class ConditionalProviderOrderTest {
+
+  @AfterEach
+  void clear() {
+    System.clearProperty("greet.mode");
+  }
+
+  @Test
+  void conditionFalse_consumerModuleFirst() {
+    System.setProperty("greet.mode", "alt");
+    try (BeanScope scope = BeanScope.builder().modules(new M1Module(), new M2Module()).build()) {
+      assertEquals("alt", scope.get(Reader.class).read());
+    }
+  }
+
+  @Test
+  void conditionFalse_providerModuleFirst() {
+    System.setProperty("greet.mode", "alt");
+    try (BeanScope scope = BeanScope.builder().modules(new M2Module(), new M1Module()).build()) {
+      assertEquals("alt", scope.get(Reader.class).read());
+    }
+  }
+
+  @Test
+  void conditionTrue_eitherOrder() {
+    System.setProperty("greet.mode", "app");
+    try (BeanScope scope = BeanScope.builder().modules(new M1Module(), new M2Module()).build()) {
+      assertEquals("app", scope.get(Reader.class).read());
+    }
+    try (BeanScope scope = BeanScope.builder().modules(new M2Module(), new M1Module()).build()) {
+      assertEquals("app", scope.get(Reader.class).read());
+    }
+  }
+
+  @Test
+  void conditionFalse_classpathDiscovery() {
+    System.setProperty("greet.mode", "alt");
+    try (BeanScope scope = BeanScope.builder().build()) {
+      assertEquals("alt", scope.get(Reader.class).read());
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <module>blackbox-aspect</module>
         <module>blackbox-test-inject</module>
         <module>blackbox-multi-scope</module>
+        <module>blackbox-conditional-provider-order</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
A conditional bean that is the only in-module provider of a type consumed by another bean in the same module satisfies that dependency at compile time: the generated module emits no requiresBeans/softRequiresBeans entry for the type while providesBeans claims it unconditionally. When the condition is false at runtime and the real provider lives in another module, no ordering edge exists and wiring fails ("Injecting null") whenever the consuming module wires first, under explicit module lists and classpath discovery alike. Reproduces on 12.6, 12.7-RC2, and the delay-soft ordering (PR #1061).

A consumer in a separate module with a declared @InjectModule(requires) orders correctly past multiple conditional claimants, so the defect is the suppressed requirement, not conditional multi-provider resolution.