### PR TITLE
Jakarta2Javax: include blackbox-conditional-provider-order child poms

### DIFF
--- a/Jakarta2Javax.java
+++ b/Jakarta2Javax.java
@@ -25,7 +25,11 @@ public class Jakarta2Javax {
         "blackbox-collection-module-order/m1/pom.xml",
         "blackbox-collection-module-order/m2/pom.xml",
         "blackbox-collection-module-order/tests/pom.xml",
-        "blackbox-conditional-provider-order/pom.xml"
+        "blackbox-conditional-provider-order/pom.xml",
+        "blackbox-conditional-provider-order/api/pom.xml",
+        "blackbox-conditional-provider-order/m1/pom.xml",
+        "blackbox-conditional-provider-order/m2/pom.xml",
+        "blackbox-conditional-provider-order/tests/pom.xml"
       };
 
       // Update version in pom files

--- a/Javax2Jakarta.java
+++ b/Javax2Jakarta.java
@@ -26,6 +26,10 @@ public class Javax2Jakarta {
         "blackbox-collection-module-order/m2/pom.xml",
         "blackbox-collection-module-order/tests/pom.xml",
         "blackbox-conditional-provider-order/pom.xml",
+        "blackbox-conditional-provider-order/api/pom.xml",
+        "blackbox-conditional-provider-order/m1/pom.xml",
+        "blackbox-conditional-provider-order/m2/pom.xml",
+        "blackbox-conditional-provider-order/tests/pom.xml",
         "inject-bom/pom.xml"
       };
 


### PR DESCRIPTION
536f8590 added only the aggregator pom to the rewrite lists, so the child poms kept their literal jakarta-flavor parent version through the javax pass and m1 failed to compile against the rewritten javax.inject imports (the build-21 CI leg's 'package javax.inject does not exist'). List all five poms, mirroring blackbox-collection-module-order, in both Jakarta2Javax and Javax2Jakarta. Verified locally: javax-pass reactor build green including the module's four tests, and the reverse pass leaves a clean tree.